### PR TITLE
fix: Corrected typo in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV HOMEDIR=/atsign
 ENV BINARYDIR=/usr/local/at
 ENV USER_ID=1024
 ENV GROUP_ID=1024
-COPY --from=buildimage  /app/startup.sh /atsign/
+COPY --from=buildimage  /app/.startup.sh /atsign/
 RUN apt-get update && apt-get install -y openssh-server sudo iputils-ping iproute2 ncat telnet net-tools nmap iperf3 tmux traceroute vim;\
    addgroup --gid $GROUP_ID atsign ; \
    sysctl -w net.ipv4.ping_group_range="0 1024" ; \


### PR DESCRIPTION
fix: Docker file was copying the wrong file over


**- What I did**
Corrected typo in the Dockerfile to copy over the correct startup file
**- How I did it**
Edited the Dockerfile
**- How to verify it**
Ran local build 
**- Description for the changelog**
fix: Corrected typo in Dockerfile