### PR TITLE
feat: Ack notification of sshnpd daemon back to sshnp client

### DIFF
--- a/.startup.sh
+++ b/.startup.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 ssh-keygen -A
-# echo "ListenAddress 127.0.0.1" >> /etc/ssh/sshd_config
-# echo "PasswordAuthentication no" >> /etc/ssh/sshd_config
 /usr/sbin/sshd -D -o "ListenAddress 127.0.0.1" -o "PasswordAuthentication no"  &
 while true
 do

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dart:2.18.5@sha256:7744c20385e247d71d421e36ee95a569666afadae1379aebab7e8345cd2c7170 AS buildimage
+FROM dart:2.18.5@sha256:9a6a450b52fabc7c2a9e73fef3cf40de35d6ea1b029b69ff8c192b6efa568025 AS buildimage
 ENV BINARYDIR=/usr/local/at
 WORKDIR /app
 COPY . .
@@ -9,7 +9,7 @@ RUN \
   dart compile exe bin/sshnpd.dart -o $BINARYDIR/sshnpd
 
 # Second stage of build FROM debian-slim
-FROM debian:stable-slim@sha256:110d5f965087ff76eca1f1402818de0c4966dc9baad8bc8c69177cfd50eeadcb
+FROM debian:stable-slim@sha256:cb1452ab51eb89a3a8b7cea58536558c809b2e4e8f687eb61e6ea4bde353f60d
 ENV HOMEDIR=/atsign
 ENV BINARYDIR=/usr/local/at
 ENV USER_ID=1024

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,5 @@ RUN apt-get update && apt-get install -y openssh-server sudo iputils-ping iprout
    chmod 755 /atsign/.startup.sh
 COPY --from=buildimage --chown=atsign:atsign /usr/local/at/sshnpd /usr/local/at/
 WORKDIR /atsign
-# USER atsign
+# USER atsign 
 ENTRYPOINT ["/atsign/.startup.sh"]

--- a/bin/sshnp.dart
+++ b/bin/sshnp.dart
@@ -225,7 +225,7 @@ void main(List<String> args) async {
   try {
     toAtsignUsername = await atClient?.get(atKey);
   } catch (e) {
-    stderr.writeln("Device $device unknown or username not shared");
+    stderr.writeln("Device \"${device.replaceAll('.', '')}\" unknown or username not shared");
     await cleanUp(sessionId, _logger);
     exit(1);
   }

--- a/bin/sshnp.dart
+++ b/bin/sshnp.dart
@@ -133,8 +133,8 @@ void main(List<String> args) async {
       }
     }
   } catch (e) {
-    print(parser.usage);
-    print(e);
+    stdout.writeln(parser.usage);
+    stderr.writeln(e);
     exit(1);
   }
 
@@ -203,7 +203,7 @@ void main(List<String> args) async {
       //   await Future.delayed(Duration(milliseconds: 250));
       ack = true;
     } else {
-      stderr.write('Remote Error: ${notification.value}');
+      stderr.writeln('Remote Error: ${notification.value}');
       ack = true;
     }
   }));
@@ -245,7 +245,7 @@ void main(List<String> args) async {
       _logger.info('ERROR:' + notification.toString());
     });
   } catch (e) {
-    print(e.toString());
+    stderr.writeln(e.toString());
   }
 
   metaData = Metadata()
@@ -274,7 +274,7 @@ void main(List<String> args) async {
         _logger.info('ERROR:' + notification.toString());
       });
     } catch (e) {
-      print("Error openning or validating public key file or sending to remote atSign: " + e.toString());
+      stderr.writeln("Error openning or validating public key file or sending to remote atSign: " + e.toString());
       await cleanUp(sessionId, _logger);
       exit(0);
     }
@@ -305,7 +305,7 @@ void main(List<String> args) async {
       _logger.info('ERROR:' + notification.toString() + ' ' + sshString);
     });
   } catch (e) {
-    print(e.toString());
+    stderr.writeln(e.toString());
   }
 
   // Before we clean up we need to make sure that the reverse ssh made the connection.

--- a/bin/sshnp.dart
+++ b/bin/sshnp.dart
@@ -66,6 +66,7 @@ void main(List<String> args) async {
   List<String> localSshOptions = [];
   int counter = 0;
   bool ack = false;
+  bool ackErrors = false;
   // In the future (perhaps) we can send other commands
   // Perhaps OpenVPN or shell commands
   String sendCommand = 'sshd';
@@ -205,6 +206,7 @@ void main(List<String> args) async {
     } else {
       stderr.writeln('Remote Error: ${notification.value}');
       ack = true;
+      ackErrors = true;
     }
   }));
 
@@ -323,18 +325,20 @@ void main(List<String> args) async {
   // Clean Up the files we created
   await cleanUp(sessionId, _logger);
 
-  // print out base ssh command
+  // print out base ssh command if we hit no Ack Errors
   // If we had a Public key include the private key in the command line
   // By removing the .pub extn
-  if (sendSshPublicKey != 'false') {
-    stdout.write(
-        "ssh -p $localPort $remoteUsername@localhost -i ${sendSshPublicKey.replaceFirst(RegExp(r'.pub$'), '')} ");
-  } else {
-    stdout.write("ssh -p $localPort $remoteUsername@localhost ");
-  }
-  // print out optional arguments
-  for (var argument in localSshOptions) {
-    stdout.write(argument + " ");
+  if (!ackErrors) {
+    if (sendSshPublicKey != 'false') {
+      stdout.write(
+          "ssh -p $localPort $remoteUsername@localhost -i ${sendSshPublicKey.replaceFirst(RegExp(r'.pub$'), '')} ");
+    } else {
+      stdout.write("ssh -p $localPort $remoteUsername@localhost ");
+    }
+    // print out optional arguments
+    for (var argument in localSshOptions) {
+      stdout.write(argument + " ");
+    }
   }
   // Print the  return
   stdout.write('\n');

--- a/bin/sshnp.dart
+++ b/bin/sshnp.dart
@@ -302,7 +302,7 @@ void main(List<String> args) async {
 
   if (sendCommand == 'sshd') {
     // Local port, port of sshd , username , hostname
-    sshString = '$localPort $port $username $host ';
+    sshString = '$localPort $port $username $host $sessionId';
   }
 
   try {
@@ -317,7 +317,15 @@ void main(List<String> args) async {
     print(e.toString());
   }
 
+  // Before we clean up we need to make sure that the reverse ssh made the connection.
+  // Or that if it had a problem what the problem was, or timeout and explain why.
+
+///TODO Sleep is not the right solution
+    sleep(Duration(seconds: 2));
+
+  // Clean Up the files we created
   await cleanUp(sessionId, _logger);
+
   // print out base ssh command
   // If we had a Public key include the private key in the command line
   // By removing the .pub extn

--- a/bin/sshnp.dart
+++ b/bin/sshnp.dart
@@ -192,6 +192,17 @@ void main(List<String> args) async {
     await Future.delayed(Duration(milliseconds: 100));
   }
 
+    notificationService.subscribe(regex: '$device.$nameSpace@', shouldDecrypt: true).listen(((notification) async {
+    String keyAtsign = notification.key;
+    keyAtsign = keyAtsign.replaceAll(notification.to + ':', '');
+    keyAtsign = keyAtsign.replaceAll('.' + device + '.' + nameSpace + notification.from, '');
+
+    if (keyAtsign == sessionId) {
+      _logger.info('Session $sessionId connected succesfully');
+      ack = true;
+    }
+  }));
+
   var metaData = Metadata()
     ..isPublic = false
     ..isEncrypted = true
@@ -294,16 +305,7 @@ void main(List<String> args) async {
 
   // Before we clean up we need to make sure that the reverse ssh made the connection.
   // Or that if it had a problem what the problem was, or timeout and explain why.
-  notificationService.subscribe(regex: '$device.$nameSpace@', shouldDecrypt: true).listen(((notification) async {
-    String keyAtsign = notification.key;
-    keyAtsign = keyAtsign.replaceAll(notification.to + ':', '');
-    keyAtsign = keyAtsign.replaceAll('.' + device + '.' + nameSpace + notification.from, '');
 
-    if (keyAtsign == sessionId) {
-      _logger.info('Session $sessionId connected succesfully');
-      ack = true;
-    }
-  }));
 
   // Timer to timeout after 10 Secs or after the Ack of connected/Errors
   while (!ack) {

--- a/bin/sshnp.dart
+++ b/bin/sshnp.dart
@@ -192,11 +192,11 @@ void main(List<String> args) async {
     await Future.delayed(Duration(milliseconds: 100));
   }
 
-    notificationService.subscribe(regex: '$device.$nameSpace@', shouldDecrypt: true).listen(((notification) async {
+  notificationService.subscribe(regex: '$device.$nameSpace@', shouldDecrypt: true).listen(((notification) async {
     String keyAtsign = notification.key;
     keyAtsign = keyAtsign.replaceAll(notification.to + ':', '');
     keyAtsign = keyAtsign.replaceAll('.' + device + '.' + nameSpace + notification.from, '');
-
+    _logger.info('Received $keyAtsign notification');
     if (keyAtsign == sessionId) {
       _logger.info('Session $sessionId connected succesfully');
       ack = true;
@@ -305,7 +305,6 @@ void main(List<String> args) async {
 
   // Before we clean up we need to make sure that the reverse ssh made the connection.
   // Or that if it had a problem what the problem was, or timeout and explain why.
-
 
   // Timer to timeout after 10 Secs or after the Ack of connected/Errors
   while (!ack) {

--- a/bin/sshnp.dart
+++ b/bin/sshnp.dart
@@ -200,7 +200,7 @@ void main(List<String> args) async {
     if (notification.value == 'connected') {
       _logger.info('Session $sessionId connected succesfully');
   // Give ssh/sshd a little time to get everything in place
-     await Future.delayed(Duration(milliseconds: 250));
+  //   await Future.delayed(Duration(milliseconds: 250));
       ack = true;
     }
   }));

--- a/bin/sshnp.dart
+++ b/bin/sshnp.dart
@@ -199,8 +199,11 @@ void main(List<String> args) async {
     _logger.info('Received $keyAtsign notification');
     if (notification.value == 'connected') {
       _logger.info('Session $sessionId connected succesfully');
-  // Give ssh/sshd a little time to get everything in place
-  //   await Future.delayed(Duration(milliseconds: 250));
+      // Give ssh/sshd a little time to get everything in place
+      //   await Future.delayed(Duration(milliseconds: 250));
+      ack = true;
+    } else {
+      stderr.write('Remote Error: ${notification.value}');
       ack = true;
     }
   }));

--- a/bin/sshnp.dart
+++ b/bin/sshnp.dart
@@ -192,7 +192,7 @@ void main(List<String> args) async {
     await Future.delayed(Duration(milliseconds: 100));
   }
 
-  notificationService.subscribe(regex: '$device.$nameSpace@', shouldDecrypt: true).listen(((notification) async {
+  notificationService.subscribe(regex: '$sessionId.$nameSpace@', shouldDecrypt: true).listen(((notification) async {
     String keyAtsign = notification.key;
     keyAtsign = keyAtsign.replaceAll(notification.to + ':', '');
     keyAtsign = keyAtsign.replaceAll('.' + device + '.' + nameSpace + notification.from, '');

--- a/bin/sshnp.dart
+++ b/bin/sshnp.dart
@@ -195,9 +195,9 @@ void main(List<String> args) async {
   notificationService.subscribe(regex: '$sessionId.$nameSpace@', shouldDecrypt: true).listen(((notification) async {
     String keyAtsign = notification.key;
     keyAtsign = keyAtsign.replaceAll(notification.to + ':', '');
-    keyAtsign = keyAtsign.replaceAll('.' + device + '.' + nameSpace + notification.from, '');
+    keyAtsign = keyAtsign.replaceAll('.' + device + '.' + 'sshnp' + notification.from, '');
     _logger.info('Received $keyAtsign notification');
-    if (keyAtsign == sessionId) {
+    if (notification.value == 'connected') {
       _logger.info('Session $sessionId connected succesfully');
       ack = true;
     }

--- a/bin/sshnp.dart
+++ b/bin/sshnp.dart
@@ -204,7 +204,7 @@ void main(List<String> args) async {
       //   await Future.delayed(Duration(milliseconds: 250));
       ack = true;
     } else {
-      stderr.writeln('Remote Error: ${notification.value}');
+      stderr.writeln('Remote sshnpd error: ${notification.value}');
       ack = true;
       ackErrors = true;
     }

--- a/bin/sshnp.dart
+++ b/bin/sshnp.dart
@@ -199,6 +199,8 @@ void main(List<String> args) async {
     _logger.info('Received $keyAtsign notification');
     if (notification.value == 'connected') {
       _logger.info('Session $sessionId connected succesfully');
+  // Give ssh/sshd a little time to get everything in place
+     await Future.delayed(Duration(milliseconds: 250));
       ack = true;
     }
   }));

--- a/bin/sshnp.dart
+++ b/bin/sshnp.dart
@@ -9,6 +9,7 @@ import 'package:at_onboarding_cli/at_onboarding_cli.dart';
 import 'package:args/args.dart';
 import 'package:uuid/uuid.dart';
 // local packages
+import 'package:sshnoports/version.dart';
 import 'package:sshnoports/home_directory.dart';
 import 'package:sshnoports/check_non_ascii.dart';
 import 'package:sshnoports/cleanup_sshnp.dart';
@@ -134,6 +135,7 @@ void main(List<String> args) async {
       }
     }
   } catch (e) {
+    version();
     stdout.writeln(parser.usage);
     stderr.writeln(e);
     exit(1);

--- a/bin/sshnp.dart
+++ b/bin/sshnp.dart
@@ -165,6 +165,7 @@ void main(List<String> args) async {
     ..downloadPath = '$homeDirectory/.sshnp/files'
     ..isLocalStoreRequired = true
     ..commitLogPath = '$homeDirectory/.sshnp/$fromAtsign/storage/commitLog'
+    ..fetchOfflineNotifications = false
     //..cramSecret = '<your cram secret>';
     ..atKeysFilePath = atsignFile;
 

--- a/bin/sshnp.dart
+++ b/bin/sshnp.dart
@@ -221,8 +221,14 @@ void main(List<String> args) async {
     ..sharedWith = fromAtsign
     ..namespace = nameSpace
     ..metadata = metaData;
-  var toAtsignUsername = await atClient?.get(atKey);
-
+  AtValue? toAtsignUsername;
+  try {
+    toAtsignUsername = await atClient?.get(atKey);
+  } catch (e) {
+    stderr.writeln("Device $device unknown or username not shared");
+    await cleanUp(sessionId, _logger);
+    exit(1);
+  }
   var remoteUsername = toAtsignUsername?.value;
 
   metaData = Metadata()

--- a/bin/sshnp.dart
+++ b/bin/sshnp.dart
@@ -24,7 +24,7 @@ void main(List<String> args) async {
 
   ProcessSignal.sigint.watch().listen((signal) async {
     await cleanUp(sessionId, _logger);
-    exit(0);
+    exit(1);
   });
 
   var parser = ArgParser();
@@ -278,7 +278,7 @@ void main(List<String> args) async {
     } catch (e) {
       stderr.writeln("Error openning or validating public key file or sending to remote atSign: " + e.toString());
       await cleanUp(sessionId, _logger);
-      exit(0);
+      exit(1);
     }
   }
 
@@ -317,8 +317,11 @@ void main(List<String> args) async {
   while (!ack) {
     await Future.delayed(Duration(milliseconds: 100));
     counter++;
-    if (counter == 100) {
+    if (counter == 300) {
       ack = true;
+      await cleanUp(sessionId, _logger);
+      stderr.writeln('sshnp: connection timeout');
+      exit(1);
     }
   }
 

--- a/bin/sshnpd.dart
+++ b/bin/sshnpd.dart
@@ -83,8 +83,8 @@ void main(List<String> args) async {
       throw ('\n Unable to find .atKeys file : $atsignFile');
     }
   } catch (e) {
-    print(e);
-    print(parser.usage);
+    (e);
+    stdout.writeln(parser.usage);
     exit(0);
   }
 
@@ -288,7 +288,7 @@ void sshCallback(AtNotification notification, String privateKey, AtSignLogger _l
             _logger.info('ERROR:' + notification.toString());
           });
         } catch (e) {
-          print(e.toString());
+          stderr.writeln(e.toString());
         }
         return;
       }
@@ -298,7 +298,7 @@ void sshCallback(AtNotification notification, String privateKey, AtSignLogger _l
 
       try {
         // Say this session is connected to client
-        print(atKey.toString());
+        _logger.info(' sshnpd connected notification sent to:from "' + atKey.toString());
         await notificationService.notify(NotificationParams.forUpdate(atKey, value: "connected"),
             onSuccess: (notification) {
           _logger.info('SUCCESS:' + notification.toString() + ' for: ' + sessionId);
@@ -306,7 +306,7 @@ void sshCallback(AtNotification notification, String privateKey, AtSignLogger _l
           _logger.info('ERROR:' + notification.toString());
         });
       } catch (e) {
-        print(e.toString());
+        stderr.writeln(e.toString());
       }
 
       ///
@@ -346,7 +346,7 @@ void sshCallback(AtNotification notification, String privateKey, AtSignLogger _l
           _logger.info('ERROR:' + notification.toString());
         });
       } catch (e) {
-        print(e.toString());
+        stderr.writeln(e.toString());
       }
     }
   }

--- a/bin/sshnpd.dart
+++ b/bin/sshnpd.dart
@@ -14,6 +14,7 @@ import 'package:dartssh2/dartssh2.dart';
 // local packages
 import 'package:sshnoports/check_non_ascii.dart';
 import 'package:sshnoports/home_directory.dart';
+import 'package:sshnoports/version.dart';
 //
 
 void main(List<String> args) async {
@@ -84,6 +85,7 @@ void main(List<String> args) async {
     }
   } catch (e) {
     (e);
+    version();
     stdout.writeln(parser.usage);
     exit(0);
   }
@@ -249,11 +251,11 @@ void sshCallback(AtNotification notification, String privateKey, AtSignLogger _l
     if (sshList.length == 5) {
       sessionId = sshList[4];
       atKey = AtKey()
-    ..key = '$sessionId.$device'
-    ..sharedBy = deviceAtsign
-    ..sharedWith = managerAtsign
-    ..namespace = nameSpace
-    ..metadata = metaData;
+        ..key = '$sessionId.$device'
+        ..sharedBy = deviceAtsign
+        ..sharedWith = managerAtsign
+        ..namespace = nameSpace
+        ..metadata = metaData;
     }
     _logger
         .info('ssh session started for $username to $hostname on port $port using localhost:$localPort on $hostname ');
@@ -281,9 +283,10 @@ void sshCallback(AtNotification notification, String privateKey, AtSignLogger _l
         _logger.warning('Failed to forward remote port $localPort');
         try {
           // Say this session is connected to client
-          await notificationService
-              .notify(NotificationParams.forUpdate(atKey, value: 'Failed to forward remote port $localPort, (use --local-port to specify unused port)'),
-                  onSuccess: (notification) {
+          await notificationService.notify(
+              NotificationParams.forUpdate(atKey,
+                  value: 'Failed to forward remote port $localPort, (use --local-port to specify unused port)'),
+              onSuccess: (notification) {
             _logger.info('SUCCESS:' + notification.toString() + ' for: ' + sessionId);
           }, onError: (notification) {
             _logger.info('ERROR:' + notification.toString());

--- a/bin/sshnpd.dart
+++ b/bin/sshnpd.dart
@@ -107,6 +107,7 @@ void main(List<String> args) async {
     ..isLocalStoreRequired = true
     ..commitLogPath = '$homeDirectory/.sshnp/$deviceAtsign/storage/commitLog'
     //..cramSecret = '<your cram secret>';
+    ..fetchOfflineNotifications = false
     ..atKeysFilePath = atsignFile;
   nameSpace = atOnboardingConfig.namespace!;
 

--- a/bin/sshnpd.dart
+++ b/bin/sshnpd.dart
@@ -281,7 +281,7 @@ void sshCallback(AtNotification notification, String privateKey, AtSignLogger _l
         try {
           // Say this session is connected to client
           await notificationService
-              .notify(NotificationParams.forUpdate(atKey, value: 'Failed to forward remote port $localPort'),
+              .notify(NotificationParams.forUpdate(atKey, value: 'Failed to forward remote port $localPort, (use --local-port to specify unused port)'),
                   onSuccess: (notification) {
             _logger.info('SUCCESS:' + notification.toString() + ' for: ' + sessionId);
           }, onError: (notification) {

--- a/bin/sshnpd.dart
+++ b/bin/sshnpd.dart
@@ -206,15 +206,15 @@ void main(List<String> args) async {
 
     if (keyAtsign == 'sshd') {
       _logger.info('ssh callback request recieved from ' + notification.from + ' notification id : ' + notification.id);
-      sshCallback(notification, privateKey, _logger, managerAtsign, deviceAtsign, nameSpace, device);
+      sshCallback(atClient, notification, privateKey, _logger, managerAtsign, deviceAtsign, nameSpace, device);
     }
   }),
       onError: (e) => _logger.severe('Notification Failed:' + e.toString()),
       onDone: () => _logger.info('Notification listener stopped'));
 }
 
-void sshCallback(
-    AtNotification notification, String privateKey, AtSignLogger _logger, String managerAtsign, String deviceAtsign,String nameSpace, String device) async {
+void sshCallback(AtClient? atClient, AtNotification notification, String privateKey, AtSignLogger _logger, String managerAtsign,
+    String deviceAtsign, String nameSpace, String device) async {
   var uuid = Uuid();
   String sessionId = uuid.v4();
 
@@ -229,7 +229,7 @@ void sshCallback(
     var hostname = sshList[3];
     // Assure backward compatibility with 1.x clients
     if (sshList.length == 5) {
-       sessionId = sshList[4];
+      sessionId = sshList[4];
     }
     _logger
         .info('ssh session started for $username to $hostname on port $port using localhost:$localPort on $hostname ');
@@ -250,38 +250,40 @@ void sshCallback(
       );
 
       await client.authenticated;
+
       ///
       ///
-      AtClientManager atClientManager = AtClientManager.getInstance();
-      NotificationService notificationService = atClientManager.notificationService;
+      //AtClientManager atClientManager = AtClientManager.getInstance();
+      
+      //NotificationService notificationService = atClientManager.notificationService;
 
-      var  metaData = Metadata()
-       ..isPublic = false
-      ..isEncrypted = true
-      ..namespaceAware = true
-      ..ttr = -1
-      ..ttl = 10000;
+      var metaData = Metadata()
+        ..isPublic = false
+        ..isEncrypted = true
+        ..namespaceAware = true
+        ..ttr = -1
+        ..ttl = 10000;
 
-  var key = AtKey()
-    ..key = sessionId
-    ..sharedBy = deviceAtsign
-    ..sharedWith = managerAtsign
-    ..namespace = device + '.' + nameSpace
-    ..metadata = metaData;
-    
-  try {
-    // Say this session is connected to client
-    await notificationService
-        .notify(NotificationParams.forUpdate(key, value: "connected"),
-            onSuccess: (notification) {
-      _logger.info('SUCCESS:' + notification.toString() + 'for: ' + sessionId);
-    }, onError: (notification) {
-      _logger.info('ERROR:' + notification.toString());
-    });
-  } catch (e) {
-    print(e.toString());
-  }
+      var atKey = AtKey()
+        ..key = sessionId
+        ..sharedBy = deviceAtsign
+        ..sharedWith = managerAtsign
+        ..namespace = device + '.' + nameSpace
+        ..metadata = metaData;
 
+      try {
+        // Say this session is connected to client
+        atClient?.put(atKey, username);
+      //   await notificationService.notify(NotificationParams.forUpdate(key, value: "connected"),
+      //       onSuccess: (notification) {
+      //     print(key.toString());
+      //     _logger.info('SUCCESS:' + notification.toString() + ' for: ' + sessionId);
+      //   }, onError: (notification) {
+      //     _logger.info('ERROR:' + notification.toString());
+      //   });
+      } catch (e) {
+        print(e.toString());
+      }
 
       ///
 

--- a/bin/sshnpd.dart
+++ b/bin/sshnpd.dart
@@ -247,7 +247,12 @@ void sshCallback(AtNotification notification, String privateKey, AtSignLogger _l
     // Assure backward compatibility with 1.x clients
     if (sshList.length == 5) {
       sessionId = sshList[4];
-       atKey = AtKey()..key = '$sessionId.$device';
+      atKey = AtKey()
+    ..key = '$sessionId.$device'
+    ..sharedBy = deviceAtsign
+    ..sharedWith = managerAtsign
+    ..namespace = nameSpace
+    ..metadata = metaData;
     }
     _logger
         .info('ssh session started for $username to $hostname on port $port using localhost:$localPort on $hostname ');

--- a/bin/sshnpd.dart
+++ b/bin/sshnpd.dart
@@ -274,7 +274,7 @@ void sshCallback(
     await notificationService
         .notify(NotificationParams.forUpdate(key, value: "connected"),
             onSuccess: (notification) {
-      _logger.info('SUCCESS:' + notification.toString());
+      _logger.info('SUCCESS:' + notification.toString() + 'for: ' + sessionId);
     }, onError: (notification) {
       _logger.info('ERROR:' + notification.toString());
     });

--- a/bin/sshnpd.dart
+++ b/bin/sshnpd.dart
@@ -248,9 +248,16 @@ void sshCallback(
           ...SSHKeyPair.fromPem(privateKey)
         ],
       );
-
+      // connect back to ssh server/port
       await client.authenticated;
-      ///
+      // Do the port forwarding
+      final forward = await client.forwardRemote(port: int.parse(localPort));
+
+      if (forward == null) {
+        _logger.warning('Failed to forward remote port');
+        return;
+      }
+      /// Send a notification to tell sshnp connection is made
       ///
       AtClientManager atClientManager = AtClientManager.getInstance();
       NotificationService notificationService = atClientManager.notificationService;
@@ -285,12 +292,6 @@ void sshCallback(
 
       ///
 
-      final forward = await client.forwardRemote(port: int.parse(localPort));
-
-      if (forward == null) {
-        _logger.warning('Failed to forward remote port');
-        return;
-      }
 
       int counter = 0;
       bool stop = false;

--- a/bin/sshnpd.dart
+++ b/bin/sshnpd.dart
@@ -219,6 +219,22 @@ void sshCallback(
   String sessionId = uuid.v4();
 
   var sshString = notification.value!;
+// Get atPlatform notifications ready
+  var  metaData = Metadata()
+       ..isPublic = false
+      ..isEncrypted = true
+      ..namespaceAware = true
+      ..ttr = -1
+      ..ttl = 10000;
+
+  var atKey = AtKey()
+    ..key = '$sessionId.$device'
+    ..sharedBy = deviceAtsign
+    ..sharedWith = managerAtsign
+    ..namespace =  nameSpace
+    ..metadata = metaData;
+    AtClientManager atClientManager = AtClientManager.getInstance();
+    NotificationService notificationService = atClientManager.notificationService;
 
   if (notification.from == managerAtsign) {
     // Local port, port of sshd , username , hostname
@@ -254,27 +270,24 @@ void sshCallback(
       final forward = await client.forwardRemote(port: int.parse(localPort));
 
       if (forward == null) {
-        _logger.warning('Failed to forward remote port');
+        _logger.warning('Failed to forward remote port $localPort');
+          try {
+    // Say this session is connected to client
+    await notificationService
+        .notify(NotificationParams.forUpdate(atKey, value: 'Failed to forward remote port $localPort'),
+            onSuccess: (notification) {
+      _logger.info('SUCCESS:' + notification.toString() + ' for: ' + sessionId);
+    }, onError: (notification) {
+      _logger.info('ERROR:' + notification.toString());
+    });
+  } catch (e) {
+    print(e.toString());
+  }
         return;
       }
       /// Send a notification to tell sshnp connection is made
       ///
-      AtClientManager atClientManager = AtClientManager.getInstance();
-      NotificationService notificationService = atClientManager.notificationService;
 
-      var  metaData = Metadata()
-       ..isPublic = false
-      ..isEncrypted = true
-      ..namespaceAware = true
-      ..ttr = -1
-      ..ttl = 10000;
-
-  var atKey = AtKey()
-    ..key = '$sessionId.$device'
-    ..sharedBy = deviceAtsign
-    ..sharedWith = managerAtsign
-    ..namespace =  nameSpace
-    ..metadata = metaData;
     
   try {
     // Say this session is connected to client
@@ -318,6 +331,18 @@ void sshCallback(
     } catch (e) {
       // need to make sure things close
       _logger.severe('SSH Client failure : ' + e.toString());
+               try {
+    // Say this session is connected to client
+    await notificationService
+        .notify(NotificationParams.forUpdate(atKey, value: 'Remote SSH Client failure : ' + e.toString()),
+            onSuccess: (notification) {
+      _logger.info('SUCCESS:' + notification.toString() + ' for: ' + sessionId);
+    }, onError: (notification) {
+      _logger.info('ERROR:' + notification.toString());
+    });
+  } catch (e) {
+    print(e.toString());
+  }
     }
   }
 }

--- a/bin/sshnpd.dart
+++ b/bin/sshnpd.dart
@@ -264,8 +264,8 @@ void sshCallback(
 
   var key = AtKey()
     ..key = sessionId
-    ..sharedBy = managerAtsign
-    ..sharedWith = deviceAtsign
+    ..sharedBy = deviceAtsign
+    ..sharedWith = managerAtsign
     ..namespace = nameSpace
     ..metadata = metaData;
     

--- a/bin/sshnpd.dart
+++ b/bin/sshnpd.dart
@@ -213,8 +213,6 @@ void main(List<String> args) async {
       onDone: () => _logger.info('Notification listener stopped'));
 }
 
-
-
 void sshCallback(
     AtNotification notification, String privateKey, AtSignLogger _logger, String managerAtsign, String device) async {
   var uuid = Uuid();
@@ -229,6 +227,10 @@ void sshCallback(
     var port = sshList[1];
     var username = sshList[2];
     var hostname = sshList[3];
+    // Assure backward compatibility with 1.x clients
+    if (sshList.length == 5) {
+       sessionId = sshList[4];
+    }
     _logger
         .info('ssh session started for $username to $hostname on port $port using localhost:$localPort on $hostname ');
     _logger.shout('ssh session started from: ' + notification.from.toString() + " session: $sessionId");

--- a/bin/sshnpd.dart
+++ b/bin/sshnpd.dart
@@ -206,15 +206,15 @@ void main(List<String> args) async {
 
     if (keyAtsign == 'sshd') {
       _logger.info('ssh callback request recieved from ' + notification.from + ' notification id : ' + notification.id);
-      sshCallback(atClient, notification, privateKey, _logger, managerAtsign, deviceAtsign, nameSpace, device);
+      sshCallback(notification, privateKey, _logger, managerAtsign, deviceAtsign, nameSpace, device);
     }
   }),
       onError: (e) => _logger.severe('Notification Failed:' + e.toString()),
       onDone: () => _logger.info('Notification listener stopped'));
 }
 
-void sshCallback(AtClient? atClient, AtNotification notification, String privateKey, AtSignLogger _logger, String managerAtsign,
-    String deviceAtsign, String nameSpace, String device) async {
+void sshCallback(
+    AtNotification notification, String privateKey, AtSignLogger _logger, String managerAtsign, String deviceAtsign,String nameSpace, String device) async {
   var uuid = Uuid();
   String sessionId = uuid.v4();
 
@@ -229,7 +229,7 @@ void sshCallback(AtClient? atClient, AtNotification notification, String private
     var hostname = sshList[3];
     // Assure backward compatibility with 1.x clients
     if (sshList.length == 5) {
-      sessionId = sshList[4];
+       sessionId = sshList[4];
     }
     _logger
         .info('ssh session started for $username to $hostname on port $port using localhost:$localPort on $hostname ');
@@ -250,40 +250,38 @@ void sshCallback(AtClient? atClient, AtNotification notification, String private
       );
 
       await client.authenticated;
-
       ///
       ///
-      //AtClientManager atClientManager = AtClientManager.getInstance();
-      
-      //NotificationService notificationService = atClientManager.notificationService;
+      AtClientManager atClientManager = AtClientManager.getInstance();
+      NotificationService notificationService = atClientManager.notificationService;
 
-      var metaData = Metadata()
-        ..isPublic = false
-        ..isEncrypted = true
-        ..namespaceAware = true
-        ..ttr = -1
-        ..ttl = 10000;
+      var  metaData = Metadata()
+       ..isPublic = false
+      ..isEncrypted = true
+      ..namespaceAware = true
+      ..ttr = -1
+      ..ttl = 10000;
 
-      var atKey = AtKey()
-        ..key = sessionId
-        ..sharedBy = deviceAtsign
-        ..sharedWith = managerAtsign
-        ..namespace = device + '.' + nameSpace
-        ..metadata = metaData;
+  var atKey = AtKey()
+    ..key = '$sessionId.$device'
+    ..sharedBy = deviceAtsign
+    ..sharedWith = managerAtsign
+    ..namespace =  nameSpace
+    ..metadata = metaData;
+    
+  try {
+    // Say this session is connected to client
+    await notificationService
+        .notify(NotificationParams.forUpdate(atKey, value: "connected"),
+            onSuccess: (notification) {
+      _logger.info('SUCCESS:' + notification.toString() + ' for: ' + sessionId);
+    }, onError: (notification) {
+      _logger.info('ERROR:' + notification.toString());
+    });
+  } catch (e) {
+    print(e.toString());
+  }
 
-      try {
-        // Say this session is connected to client
-        atClient?.put(atKey, username);
-      //   await notificationService.notify(NotificationParams.forUpdate(key, value: "connected"),
-      //       onSuccess: (notification) {
-      //     print(key.toString());
-      //     _logger.info('SUCCESS:' + notification.toString() + ' for: ' + sessionId);
-      //   }, onError: (notification) {
-      //     _logger.info('ERROR:' + notification.toString());
-      //   });
-      } catch (e) {
-        print(e.toString());
-      }
 
       ///
 

--- a/bin/sshnpd.dart
+++ b/bin/sshnpd.dart
@@ -266,7 +266,7 @@ void sshCallback(
     ..key = sessionId
     ..sharedBy = deviceAtsign
     ..sharedWith = managerAtsign
-    ..namespace = nameSpace
+    ..namespace = device + '.' + nameSpace
     ..metadata = metaData;
     
   try {

--- a/lib/cleanup_sshnp.dart
+++ b/lib/cleanup_sshnp.dart
@@ -14,13 +14,7 @@ Future<void> cleanUp(String sessionId, AtSignLogger _logger) async {
   if (Platform.isWindows) {
     sshHomeDirectory = homeDirectory + '\\.ssh\\';
   }
-// Wait a few seconds for the remote ssh session to connect back here
-// do we need to wait ? Yes as it takes time for the reverse ssh to connect
-// 2 seconds seems like a reasonable time...
-// could make it an option if folks have trouble.
   _logger.info('Tidying up files');
-
-  sleep(Duration(seconds: 2));
 // Delete the generated RSA keys and remove the entry from ~/.ssh/authorized_keys
   await deleteFile('$sshHomeDirectory${sessionId}_rsa', _logger);
   await deleteFile('$sshHomeDirectory${sessionId}_rsa.pub', _logger);

--- a/lib/version.dart
+++ b/lib/version.dart
@@ -1,0 +1,7 @@
+import 'dart:io';
+
+// Get the home directory or null if unknown.
+void version() {
+  final String version = "2.0.0";
+  stdout.writeln('Version : $version');
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sshnoports
 description: A simple command-line application.
-version: 1.0.0
+version: 2.0.0
 homepage: https://docs.atsign.com/
 
 environment:


### PR DESCRIPTION
**- What I did**
Enabled sshnpd to send acknowledgements and errors back to the sshnp client application. This removes the need for "blind" sending of commands and makes everything event driven, so speeds up the client experience. The only timeout now is if sshnpd fails to respond. This work has side benefit of allowing a 30 second timeout without penalizing working connections. This enables sshnp to work on very low bandwidth and high latency connections without issues.
Enabled erroring and ensured any errors are placed on stderr not stdout.
This work closes https://github.com/atsign-foundation/sshnoports/issues/24

ssshnp/sshnpd v2.0.0 are backward compatible to 1.\*.\* ssshnp/sshnpd 

**- How I did it**
Created a UUID for the sshnp request and shared that with the sshnpd as part of the initial request
An acknowledgement is sent to the sshnp once the ssh connection and tunnel is established with a "connected" messaged
Any errors in setting up the connection or the ssh tunnels are sent back to the sshnp client using the UUID as the identifier
Migrated away from print to stdout and stderr to ensure sshnp can be used safely in $(sshnp <options>) format
Added a version note in the command help
Edited error messages are now clearer and provide useful help if that is knowable

**- How to verify it**
Ran extensive tests locally and with built docker files

**- Description for the changelog**
feat: Ack notification of sshnpd daemon back to sshnp client