### PR TITLE
feat: Adding the at_activate application to the sshnoprts repo

### DIFF
--- a/bin/activate_cli.dart
+++ b/bin/activate_cli.dart
@@ -1,0 +1,6 @@
+import 'package:at_onboarding_cli/src/activate_cli/activate_cli.dart'
+    as activate_cli;
+
+Future<void> main(List<String> args) async {
+  await activate_cli.main(args);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies: 
   args: ^2.3.0
   at_lookup: ^3.0.11
-  at_onboarding_cli: ^1.0.0
+  at_onboarding_cli: ^1.2.5
   crypton: ^2.0.3
   dartssh2: ^2.6.0
   ssh_key: ">=0.7.1 <0.9.0"


### PR DESCRIPTION

**- What I did**
Including the at_activate tool into the sshnp repo so it can be used to activate an generate keys for new sshnp installs.

**- How I did it**
Pulled code form the at_libraries repo
**- How to verify it**
tested by hand

<!--
Added the at_activate application to the sshnoprts repo
-->