### PR TITLE
fix: Set provenance to false for Docker builds

### DIFF
--- a/.github/workflows/dockerhub_sshnpd.yml
+++ b/.github/workflows/dockerhub_sshnpd.yml
@@ -1,6 +1,7 @@
 name: dockerhub_sshnpd
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*.*.*'
@@ -38,6 +39,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
+          provenance: false
           tags: |
             atsigncompany/sshnpd:latest
             atsigncompany/sshnpd:release-${{ env.VERSION }}


### PR DESCRIPTION
Docker image files with OCI manifests have been causing problems with routers, so we need to build older style images.

**- What I did**

* Set `provenance: false` so that OCI images aren't used
* Allow the builds to be triggered by `workflow_despatch` so that a new release doesn't have to be cut to rebuild images.

**- How to verify it**

Run the workflow manually and check that routers can use the new images.

**- Description for the changelog**

fix: Set provenance to false for Docker builds