### PR TITLE
feat: automate binaries

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -55,4 +55,4 @@ jobs:
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: other_binaries
-          path: tarball
+          path: upload

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -1,9 +1,6 @@
 name: Multibuild
 
 on: 
-  push:
-    branches:
-      - "cpswan-automate-binaries"
   workflow_dispatch:
 
 permissions:  # added using https://github.com/step-security/secure-repo

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -1,0 +1,35 @@
+name: Multibuild
+
+on: [workflow_dispatch]
+
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        include:
+          - os: ubuntu-latest
+            output-name: sshnp-linux-x64
+          - os: macOS-latest
+            output-name: sshnp-macos-x64
+
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f # v1.5.0
+      - run: mkdir sshnp
+      - run: mkdir tarball
+      - run: dart pub get
+      - run: dart compile exe bin/activate_cli.dart -v -o sshnp/at_activate
+      - run: dart compile exe bin/sshnp.dart -v -o sshnp/sshnp
+      - run: dart compile exe bin/sshnpd.dart -v -o sshnp/sshnpd
+      - run: cp scripts/* sshnp
+      - run: tar -cvzf tarball/${{ matrix.output-name }}.tgz sshnp
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: binaries
+          path: tarball

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -1,9 +1,6 @@
 name: Multibuild
 
 on: 
-  push:
-    branches:
-      - "cpswan-automate-binaries"
   workflow_dispatch:
 
 permissions:  # added using https://github.com/step-security/secure-repo
@@ -15,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest]
         include:
           - os: ubuntu-latest
             output-name: sshnp-linux-x64

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -1,6 +1,9 @@
 name: Multibuild
 
 on: 
+  push:
+    branches:
+      - "cpswan-automate-binaries"
   workflow_dispatch:
 
 permissions:  # added using https://github.com/step-security/secure-repo

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -1,6 +1,10 @@
 name: Multibuild
 
-on: [workflow_dispatch]
+on: 
+  push:
+    branches:
+      - "cpswan-automate-binaries"
+  workflow_dispatch:
 
 permissions:  # added using https://github.com/step-security/secure-repo
   contents: read

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -10,7 +10,7 @@ permissions:  # added using https://github.com/step-security/secure-repo
   contents: read
 
 jobs:
-  build:
+  x64_build:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -35,5 +35,24 @@ jobs:
       - run: tar -cvzf tarball/${{ matrix.output-name }}.tgz sshnp
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: binaries
+          name: x64_binaries
+          path: tarball
+  
+  other_build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+      - uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c # v2.5.0
+      - run: |
+          docker buildx build -t atsigncompany/sshnptarball -f Dockerfile.package \
+          --platform linux/arm/v7,linux/arm64,linux/riscv64 -o type=tar,dest=bins.tar .
+      - run: mkdir tarballs
+      - run: tar -xvf bins.tar -C tarballs
+      - run: mkdir upload
+      - run: cp tarballs/*/*.tgz upload/
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: other_binaries
           path: tarball

--- a/Dockerfile.package
+++ b/Dockerfile.package
@@ -1,0 +1,25 @@
+FROM atsigncompany/buildimage:automated AS build
+WORKDIR /sshnoports
+COPY . .
+RUN set -eux; \
+    case "$(dpkg --print-architecture)" in \
+        amd64) \
+            ARCH="x64";; \
+        armhf) \
+            ARCH="arm";; \
+        arm64) \
+            ARCH="arm64";; \
+        riscv64) \
+            ARCH="riscv64";; \
+    esac; \
+    mkdir sshnp; \
+    mkdir tarball; \
+    dart pub get; \
+    dart compile exe bin/activate_cli.dart -v -o sshnp/at_activate; \
+    dart compile exe bin/sshnp.dart -v -o sshnp/sshnp; \
+    dart compile exe bin/sshnpd.dart -v -o sshnp/sshnpd; \
+    cp scripts/* sshnp; \
+    tar -cvzf tarball/sshnp-linux-${ARCH}.tgz sshnp
+    
+FROM scratch
+COPY --from=build /sshnoports/tarball/* /

--- a/Dockerfile.package
+++ b/Dockerfile.package
@@ -1,4 +1,4 @@
-FROM atsigncompany/buildimage:automated AS build
+FROM atsigncompany/buildimage:automated@sha256:9abbc3997700117914848e6c3080c4c6ed3b07adbd9a44514ce42129a203a3c5 AS build
 WORKDIR /sshnoports
 COPY . .
 RUN set -eux; \

--- a/Dockerfile.package
+++ b/Dockerfile.package
@@ -1,4 +1,5 @@
 FROM atsigncompany/buildimage:automated@sha256:9abbc3997700117914848e6c3080c4c6ed3b07adbd9a44514ce42129a203a3c5 AS build
+# Using atsigncompany/buildimage until official dart image has RISC-V support
 WORKDIR /sshnoports
 COPY . .
 RUN set -eux; \


### PR DESCRIPTION
Fixes #133 

**- What I did**

GitHub Actions workflow that combines a matrix build, for x64 binaries, with a Docker Buildx build for Arm and RISC-V binaries.

**- How I did it**

Introduced new Dockerfile.package to create the tarballs, then wrapped that in script to wrangle the tarballs into place.

**- How to verify it**

See the artifacts in [this test run](https://github.com/atsign-foundation/sshnoports/actions/runs/4937812766)

As we don't have automated tests yet this should be compared to binaries created manually

**- Description for the changelog**

feat: automate binaries