### PR TITLE
feat: Add notification to workflow

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -53,3 +53,14 @@ jobs:
         with:
           name: other_binaries
           path: upload
+
+  notify_on_completion:
+    needs: [x64_build, other_build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Google Chat Notification
+        uses: Co-qn/google-chat-notification@3691ccf4763537d6e544bc6cdcccc1965799d056 # v1
+        with:
+          name: SSH no ports binaries were built by GitHub Action ${{ github.run_number }}
+          url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
+          status: ${{ job.status }}


### PR DESCRIPTION
The `other_build` job presently takes around 30m, so nobody should be sat waiting for it. Instead they can get a notification when the job(s) are complete.

**- What I did**

Added a notification job that depends on the existing jobs

**- How I did it**

Copied from at_dockerfiles

**- How to verify it**

[This run](https://github.com/atsign-foundation/sshnoports/actions/runs/4946769866) should generate a notification when it's done in around 30m.

**- Description for the changelog**

feat: Add notification to workflow