### PR TITLE
docs: unnest `## systemd units`

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ by cron using:
 @reboot /home/<username>/tmux-sshnpd.sh > ~/sshnpd.log 2>&1
 ```
 
-### systemd units
+## systemd units
 
 The systemd directory contains an example unit file with its own
 [README](systemd/README.md).


### PR DESCRIPTION
## What I did

`### systemd units` was nested under `## TWO Ways to run SSH! no ports daemons (root access NOT required)`

now it is not

![image](https://github.com/atsign-foundation/sshnoports/assets/79019866/62fb53e4-b442-4a68-811e-c0c3c643bd8c)
