### PR TITLE
fix: removed need to edit the crontab entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ and <devicename>.
 You might also want to add a crontab entry to run the script on reboot:
 
 ```
-@reboot /home/<username>/sshnpd.sh > ~/sshnpd.log 2>&1
+@reboot ~/sshnpd.sh > ~/sshnpd.log 2>&1
 ```
 
 ### `tmux-sshnpd.sh` and `tmux-sshrvd.sh` - the power of tmux, highly recommended if tmux is installed `sudo apt install tmux`
@@ -157,7 +157,7 @@ Once again, ensure that the placeholders are replaced, and this can be run
 by cron using:
 
 ```
-@reboot /home/<username>/tmux-sshnpd.sh > ~/sshnpd.log 2>&1
+@reboot ~/tmux-sshnpd.sh > ~/sshnpd.log 2>&1
 ```
 
 ## systemd units


### PR DESCRIPTION
Using ~/ rather than specific username


**- What I did**
Edited README.md to have pure cut and past instructions for the crontab enteries
**- How I did it**
removed /home/<username> for ~/
**- How to verify it**
performed on linux machine and rebooted to confirmed things worked 
**- Description for the changelog**
removed need to edit the crontab entries, 