### PR TITLE
fix: download updater from trunk so we can do less releases

### DIFF
--- a/scripts/install_sshnp
+++ b/scripts/install_sshnp
@@ -190,8 +190,10 @@ download() {
       ;;
   esac
 
-  UPDATE_SCRIPT_URL="https://raw.githubusercontent.com/atsign-foundation/sshnoports/trunk/scripts/update_$BINARY_NAME";
-  curl -sL "$UPDATE_SCRIPT_URL" -o "$HOME_PATH/.atsign/temp/$BINARY_NAME/update_$BINARY_NAME";
+  if [ -z "$SSHNP_LOCAL" ]; then
+    UPDATE_SCRIPT_URL="https://raw.githubusercontent.com/atsign-foundation/sshnoports/trunk/scripts/update_$BINARY_NAME";
+    curl -sL "$UPDATE_SCRIPT_URL" -o "$HOME_PATH/.atsign/temp/$BINARY_NAME/update_$BINARY_NAME";
+  fi
 
   if [ -n "$SSHNP_DEV_MODE" ]; then
     echo "DEV MODE: Installing from local repo: $SSHNP_DEV_MODE";

--- a/scripts/install_sshnp
+++ b/scripts/install_sshnp
@@ -189,6 +189,10 @@ download() {
       tar -zxf "$HOME_PATH/.atsign/temp/$BINARY_NAME.$EXT" -C "$HOME_PATH/.atsign/temp/";
       ;;
   esac
+
+  UPDATE_SCRIPT_URL="https://raw.githubusercontent.com/atsign-foundation/sshnoports/trunk/scripts/update_$BINARY_NAME";
+  curl -sL "$UPDATE_SCRIPT_URL" -o "$HOME_PATH/.atsign/temp/$BINARY_NAME/update_$BINARY_NAME";
+
   if [ -n "$SSHNP_DEV_MODE" ]; then
     echo "DEV MODE: Installing from local repo: $SSHNP_DEV_MODE";
     cp -R "$SSHNP_DEV_MODE/templates/" "$HOME_PATH/.atsign/temp/$BINARY_NAME/templates/";

--- a/scripts/install_sshnpd
+++ b/scripts/install_sshnpd
@@ -174,6 +174,9 @@ download() {
   esac
   mv "$HOME_PATH/.atsign/temp/sshnp" "$HOME_PATH/.atsign/temp/$BINARY_NAME"; # Rename the extracted folder
 
+  UPDATE_SCRIPT_URL="https://raw.githubusercontent.com/atsign-foundation/sshnoports/trunk/scripts/update_$BINARY_NAME";
+  curl -sL "$UPDATE_SCRIPT_URL" -o "$HOME_PATH/.atsign/temp/$BINARY_NAME/update_$BINARY_NAME";
+
   if [ -n "$SSHNP_DEV_MODE" ]; then
     echo "DEV MODE: Installing from local repo: $SSHNP_DEV_MODE";
     cp -R "$SSHNP_DEV_MODE/templates/" "$HOME_PATH/.atsign/temp/$BINARY_NAME/templates/";

--- a/scripts/install_sshnpd
+++ b/scripts/install_sshnpd
@@ -174,8 +174,10 @@ download() {
   esac
   mv "$HOME_PATH/.atsign/temp/sshnp" "$HOME_PATH/.atsign/temp/$BINARY_NAME"; # Rename the extracted folder
 
-  UPDATE_SCRIPT_URL="https://raw.githubusercontent.com/atsign-foundation/sshnoports/trunk/scripts/update_$BINARY_NAME";
-  curl -sL "$UPDATE_SCRIPT_URL" -o "$HOME_PATH/.atsign/temp/$BINARY_NAME/update_$BINARY_NAME";
+  if [ -z "$SSHNP_LOCAL" ]; then
+    UPDATE_SCRIPT_URL="https://raw.githubusercontent.com/atsign-foundation/sshnoports/trunk/scripts/update_$BINARY_NAME";
+    curl -sL "$UPDATE_SCRIPT_URL" -o "$HOME_PATH/.atsign/temp/$BINARY_NAME/update_$BINARY_NAME";
+  fi
 
   if [ -n "$SSHNP_DEV_MODE" ]; then
     echo "DEV MODE: Installing from local repo: $SSHNP_DEV_MODE";

--- a/scripts/update_sshnp
+++ b/scripts/update_sshnp
@@ -127,8 +127,10 @@ download() {
       ;;
   esac
 
-  UPDATE_SCRIPT_URL="https://raw.githubusercontent.com/atsign-foundation/sshnoports/trunk/scripts/update_$BINARY_NAME";
-  curl -sL "$UPDATE_SCRIPT_URL" -o "$HOME_PATH/.atsign/temp/$BINARY_NAME/update_$BINARY_NAME";
+  if [ -z "$SSHNP_LOCAL" ]; then
+    UPDATE_SCRIPT_URL="https://raw.githubusercontent.com/atsign-foundation/sshnoports/trunk/scripts/update_$BINARY_NAME";
+    curl -sL "$UPDATE_SCRIPT_URL" -o "$HOME_PATH/.atsign/temp/$BINARY_NAME/update_$BINARY_NAME";
+  fi
 
   if [ -n "$SSHNP_DEV_MODE" ]; then
     echo "DEV MODE: Installing from local repo: $SSHNP_DEV_MODE";

--- a/scripts/update_sshnp
+++ b/scripts/update_sshnp
@@ -126,6 +126,10 @@ download() {
       tar -zxvf "$HOME_PATH/.atsign/temp/$BINARY_NAME.$EXT" -C "$HOME_PATH/.atsign/temp/";
       ;;
   esac
+
+  UPDATE_SCRIPT_URL="https://raw.githubusercontent.com/atsign-foundation/sshnoports/trunk/scripts/update_$BINARY_NAME";
+  curl -sL "$UPDATE_SCRIPT_URL" -o "$HOME_PATH/.atsign/temp/$BINARY_NAME/update_$BINARY_NAME";
+
   if [ -n "$SSHNP_DEV_MODE" ]; then
     echo "DEV MODE: Installing from local repo: $SSHNP_DEV_MODE";
     cp -R "$SSHNP_DEV_MODE/templates/" "$HOME_PATH/.atsign/temp/$BINARY_NAME/templates/";

--- a/scripts/update_sshnpd
+++ b/scripts/update_sshnpd
@@ -128,8 +128,10 @@ download() {
   esac
   mv "$HOME_PATH/.atsign/temp/sshnp/" "$HOME_PATH/.atsign/temp/$BINARY_NAME"; # Rename the extracted folder
 
-  UPDATE_SCRIPT_URL="https://raw.githubusercontent.com/atsign-foundation/sshnoports/trunk/scripts/update_$BINARY_NAME";
-  curl -sL "$UPDATE_SCRIPT_URL" -o "$HOME_PATH/.atsign/temp/$BINARY_NAME/update_$BINARY_NAME";
+  if [ -z "$SSHNP_LOCAL" ]; then
+    UPDATE_SCRIPT_URL="https://raw.githubusercontent.com/atsign-foundation/sshnoports/trunk/scripts/update_$BINARY_NAME";
+    curl -sL "$UPDATE_SCRIPT_URL" -o "$HOME_PATH/.atsign/temp/$BINARY_NAME/update_$BINARY_NAME";
+  fi
 
   if [ -n "$SSHNP_DEV_MODE" ]; then
     echo "DEV MODE: Installing from local repo: $SSHNP_DEV_MODE";

--- a/scripts/update_sshnpd
+++ b/scripts/update_sshnpd
@@ -127,6 +127,10 @@ download() {
       ;;
   esac
   mv "$HOME_PATH/.atsign/temp/sshnp/" "$HOME_PATH/.atsign/temp/$BINARY_NAME"; # Rename the extracted folder
+
+  UPDATE_SCRIPT_URL="https://raw.githubusercontent.com/atsign-foundation/sshnoports/trunk/scripts/update_$BINARY_NAME";
+  curl -sL "$UPDATE_SCRIPT_URL" -o "$HOME_PATH/.atsign/temp/$BINARY_NAME/update_$BINARY_NAME";
+
   if [ -n "$SSHNP_DEV_MODE" ]; then
     echo "DEV MODE: Installing from local repo: $SSHNP_DEV_MODE";
     cp -R "$SSHNP_DEV_MODE/templates/" "$HOME_PATH/.atsign/temp/$BINARY_NAME/templates/";


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

If --local flag is unset, download updater from trunk instead of using the one from the release.

We should still keep the updater in the zip/tgz in case people do use the --local flag for installation (which accepts a local zip/tgz file)

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: download updater from trunk so we can do less releases
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->