### PR TITLE
fix: fixed typo which reintroduced a bug in SSHNP.getSshrvCommand

### DIFF
--- a/lib/sshnp.dart
+++ b/lib/sshnp.dart
@@ -661,11 +661,11 @@ class SSHNP {
   /// this case) replaced with `sshrv`
   static String getSshrvCommand() {
     late String sshnpDir;
-    if (Platform.executable.endsWith('${Platform.pathSeparator}sshnp')) {
-      List<String> pathList =
-          Platform.resolvedExecutable.split(Platform.pathSeparator);
+    List<String> pathList =
+        Platform.resolvedExecutable.split(Platform.pathSeparator);
+    if (pathList.last == 'sshnp' || pathList.last == 'sshnp.exe') {
       pathList.removeLast();
-      sshnpDir = pathList.join(Platform.pathSeparator) + Platform.pathSeparator;
+      sshnpDir = pathList.join(Platform.pathSeparator);
 
       return '$sshnpDir${Platform.pathSeparator}sshrv';
     } else {


### PR DESCRIPTION
**- What I did**
fix: re-fixed [this bug](https://github.com/atsign-foundation/sshnoports/issues/148)

**- How I did it**
- Replace a usage of `Platform.executable` to use `Platform.resolvedExecutable` instead

**- How to verify it**
- Run sshnp via PATH e.g. `sshnp`
- Run sshnp with full path provided e.g. `/Users/gary/dev/atsign/repos/sshnoports/bin/sshnp`
- Run sshnp with relative path provided e.g. while in the bin directory, `./sshnp`

