### PR TITLE
fix: fix `Unable to find ssh public key file : false` if -s option is not provided

### DIFF
--- a/lib/sshnp.dart
+++ b/lib/sshnp.dart
@@ -529,8 +529,10 @@ class SSHNP {
         throw ('\n Unable to find .atKeys file : ${p.atKeysFilePath}');
       }
 
-      if (!File(p.sendSshPublicKey).existsSync()) {
-        throw ('\n Unable to find ssh public key file : ${p.sendSshPublicKey}');
+      if (p.sendSshPublicKey != 'false') {
+        if (!File(p.sendSshPublicKey).existsSync()) {
+          throw ('\n Unable to find ssh public key file : ${p.sendSshPublicKey}');
+        }
       }
 
       String sessionId = Uuid().v4();


### PR DESCRIPTION
**- What I did**
fix: fix problem where you get an error message `Unable to find ssh public key file : false` if the -s option is not provided

**- How I did it**
Add guard in init to check if value is 'false' before checking if the file exists

**- How to verify it**
Run sshnp without providing the -s option. Should not fail with this error message.
