### PR TITLE
fix: sshnpd updater patches

### DIFF
--- a/scripts/install_sshnpd
+++ b/scripts/install_sshnpd
@@ -259,12 +259,7 @@ setup_service() {
 
 # used to restart the service after an update
 restart_service() {
-  SERVICE_LIST_FILE="$HOME_PATH/.$BINARY_NAME/.service_list";
-  while read -r SERVICE;
-  do
-    SERVICE=$(echo "$SERVICE" | cut -f 1 -d ' ');
-    killall -qu "$SSHNP_USER" "$SERVICE";
-  done < "$SERVICE_LIST_FILE";
+  killall -qu "$SSHNP_USER" -r "$BINARY_NAME$"
 }
 
 post_install() {

--- a/scripts/install_sshnpd
+++ b/scripts/install_sshnpd
@@ -259,7 +259,7 @@ setup_service() {
 
 # used to restart the service after an update
 restart_service() {
-  killall -qu "$SSHNP_USER" -r "$BINARY_NAME$"
+  killall -q -u "$SSHNP_USER" -r "$BINARY_NAME$"
 }
 
 post_install() {

--- a/scripts/install_sshnpd
+++ b/scripts/install_sshnpd
@@ -280,20 +280,15 @@ main () {
 
   setup_main_binaries
 
-  case "$SSHNP_OP" in
-    install)
-      setup_service
-      ;;
-    update)
-      restart_service
-      ;;
-    *)
-      echo "Invalid operation: $SSHNP_OP";
-      exit 0;
-      ;;
-  esac
+  if [ "$SSHNP_OP" = 'install' ]; then
+    setup_service
+  fi
 
   post_install
+
+  if [ "$SSHNP_OP" = 'update' ]; then
+    restart_service
+  fi
 }
 
 parse_args "$@";


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- moved post_install function to run before restarting sshnpd
- service restarter now restarts like so:
  `killall -qu "$SSHNP_USER" -r "$BINARY_NAME$"`
  which ensures that the restarter loop keeps running in the background

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: sshnpd updater patches
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->