### PR TITLE
fix: pass all options on sshnp@device to sshnp binary

### DIFF
--- a/templates/client/sshnp-full.sh
+++ b/templates/client/sshnp-full.sh
@@ -11,4 +11,14 @@ usage() {
   echo "Note: previously device name was a positional argument, please specify it with -d."
 }
 
+if [ "$#" -eq 0 ]; then
+  usage;
+  exit 1;
+fi
+
+if [ "$1" = "--help" ]; then
+  usage;
+  exit 0;
+fi
+
 "$HOME/.local/bin/$BINARY_NAME" -f "$FROM" -t "$TO" -h "$HOST" -s "$PUBLIC_KEY" "$@";

--- a/templates/client/sshnp-full.sh
+++ b/templates/client/sshnp-full.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#v1.0.0
+#v2.0.0
 BINARY_NAME="sshnp";
 FROM="$CLIENT_ATSIGN";
 TO="$DEVICE_MANAGER_ATSIGN";
@@ -7,37 +7,8 @@ HOST="$DEFAULT_HOST_ATSIGN";
 PUBLIC_KEY="$SSHNP_PUBLIC_KEY";
 
 usage() {
-  echo "Usage: sshnp$DEVICE_MANAGER_ATSIGN [-h <host>] <device name>";
+  "$HOME/.local/bin/$BINARY_NAME" --help | grep -v -e "(mandatory)" -e "FormatException";
+  echo "Note: previously device name was a positional argument, please specify it with -d."
 }
 
-parse_args() {
-  while [ $# -gt 0 ]; do
-    case "$1" in
-      -h|--host)
-        if [ $# -lt 0 ]; then
-          echo "Missing argument for $1";
-          exit 1;
-        fi
-        HOST="$2"
-        shift 2
-        ;;
-      *)
-        SSHNP_DEVICE="$1"
-        shift
-        ;;
-    esac
-    shift
-  done
-  if [ -z "$SSHNP_DEVICE" ]; then
-    echo "No device specified";
-    usage;
-    exit 1;
-  fi
-}
-
-parse_args "$@";
-# -f = client atSign ("from")
-# -t = device atSign ("to")
-# -h = host rendezvous server atSign (SRS)
-# -d = device name
-eval "$HOME/.local/bin/$BINARY_NAME -f $FROM -t $TO -h $HOST -d $SSHNP_DEVICE" -s "$PUBLIC_KEY";
+"$HOME/.local/bin/$BINARY_NAME" -f "$FROM" -t "$TO" -h "$HOST" -s "$PUBLIC_KEY" "$@";

--- a/templates/client/sshnp-simple.sh
+++ b/templates/client/sshnp-simple.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-#v1.0.0
+#v1.1.0
 BINARY_NAME="sshnp";
 # -f = client atSign ("from")
 # -t = device manager atSign ("to")
 # -h = host rendezvous server atSign (SRS)
 # -d = device name
-eval "$HOME/.local/bin/$BINARY_NAME -f $1 -t $2 -h $3 -d $4";
+"$HOME/.local/bin/$BINARY_NAME" -f "$1" -t "$2" -h "$3" -d "$4";


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
closes #186 
**- What I did**

Rather than manually parsing the arguments on this script, just pass them down to sshnp.
Using sshnp's usage as this script's usage, but I've used grep to remove lines with "(mandatory)" since those lines are filled with default values in this script.

**- How I did it**

**- How to verify it**

Make a copy of sshnp-full.sh and replace the values in FROM, TO, HOST, PUBLIC_KEY.

Example:
```sh
#!/bin/bash
#v2.0.0
BINARY_NAME="sshnp";
FROM="@xavierchanth";
TO="@xchan";
HOST=""; #<ommitted intentionally in this example (this is the rendezvous atSign)>
PUBLIC_KEY="sshnp@xchan.pub";

usage() {
  "$HOME/.local/bin/$BINARY_NAME" --help | grep -v -e "(mandatory)" -e "FormatException";
  echo "Note: previously device name was a positional argument, please specify it with -d."
}

if [ "$#" -eq 0 ]; then
  usage;
  exit 1;
fi

if [ "$1" = "--help" ]; then
  usage;
  exit 0;
fi

"$HOME/.local/bin/$BINARY_NAME" -f "$FROM" -t "$TO" -h "$HOST" -s "$PUBLIC_KEY" "$@";
```

Run the above script with -d <devicename>

**- Description for the changelog**
fix: pass all options on sshnp@device to sshnp binary
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->