### PR TITLE
feat: config files

### DIFF
--- a/packages/sshnoports/lib/config_util.dart
+++ b/packages/sshnoports/lib/config_util.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+
+import 'package:sshnoports/sshnp_args.dart';
+
+List<String> parseConfigFile(String fileName) {
+  List<String> args = <String>[];
+
+  File file = File(fileName);
+  List<String> lines = file.readAsLinesSync();
+
+  for (String line in lines) {
+    if (line.startsWith('#')) continue;
+
+    var parts = line.split('=');
+    if (parts.length != 2) continue;
+
+    var key = parts[0].trim();
+    var value = parts[1].trim();
+
+    SSHNPArg arg = SSHNPArg.fromBashName(key);
+    if (arg.name.isEmpty) continue;
+
+    switch (arg.format) {
+      case ArgFormat.flag:
+        if (value.toLowerCase() == 'true') {
+          args.add('--${arg.name}');
+        }
+        continue;
+      case ArgFormat.multiOption:
+        var values = value.split(';');
+        for (String val in values) {
+          if (val.isEmpty) continue;
+          args.add('--${arg.name}');
+          args.add(val);
+        }
+        continue;
+      case ArgFormat.option:
+        if (value.isEmpty) continue;
+        args.add('--${arg.name}');
+        args.add(value);
+        continue;
+    }
+  }
+  return args;
+}

--- a/packages/sshnoports/lib/sshnp.dart
+++ b/packages/sshnoports/lib/sshnp.dart
@@ -488,10 +488,8 @@ class SSHNP {
       configArgs = parseConfigFile(r['config-file']);
     }
 
-    print(configArgs + args);
-
     // Main Args
-    r = createArgParser(withConfig: true).parse(configArgs + args);
+    r = createArgParser().parse(configArgs + args);
 
     // Do we have a username ?
     p.username = getUserName(throwIfNull: true)!;
@@ -627,7 +625,7 @@ class SSHNP {
     return AtClientManager.getInstance().atClient;
   }
 
-  static ArgParser createArgParser({bool withConfig = false}) {
+  static ArgParser createArgParser({bool withConfig = true}) {
     var parser = ArgParser();
     // Basic arguments
     for (SSHNPArg arg in sshnpArgs) {

--- a/packages/sshnoports/lib/sshnp.dart
+++ b/packages/sshnoports/lib/sshnp.dart
@@ -479,17 +479,18 @@ class SSHNP {
 
   static SSHNPParams parseSSHNPParams(List<String> args) {
     var p = SSHNPParams();
+    ArgParser parser = createArgParser();
     late ArgResults r;
     List<String> configArgs = [];
 
     // Config file
-    r = createConfigParser().parse(args);
+    r = parser.parse(args);
     if (r.wasParsed('config-file')) {
       configArgs = parseConfigFile(r['config-file']);
     }
 
     // Main Args
-    r = createArgParser().parse(configArgs + args);
+    r = parser.parse(configArgs + args);
 
     // Do we have a username ?
     p.username = getUserName(throwIfNull: true)!;
@@ -590,7 +591,7 @@ class SSHNP {
       return sshnp;
     } catch (e) {
       version();
-      stdout.writeln(createConfigParser(createArgParser()).usage);
+      stdout.writeln(createArgParser().usage);
       stderr.writeln(e);
       exit(1);
     }
@@ -658,18 +659,12 @@ class SSHNP {
       }
     }
     if (withConfig) {
-      parser = createConfigParser(parser);
+      parser.addOption(
+        'config-file',
+        help:
+            'Read args from a config file\nMandatory args are not required if already supplied in the config file',
+      );
     }
-    return parser;
-  }
-
-  static ArgParser createConfigParser([ArgParser? parser]) {
-    parser ??= ArgParser();
-    parser.addOption(
-      'config-file',
-      help:
-          'Read args from a config file\nMandatory args are not required if already supplied in the config file',
-    );
     return parser;
   }
 

--- a/packages/sshnoports/lib/sshnp_args.dart
+++ b/packages/sshnoports/lib/sshnp_args.dart
@@ -1,0 +1,122 @@
+enum ArgFormat {
+  option,
+  multiOption,
+  flag,
+}
+
+class SSHNPArg {
+  final ArgFormat format;
+
+  final String name;
+  final String? abbr;
+  final String? help;
+  final bool mandatory;
+  final dynamic defaultsTo;
+
+  const SSHNPArg({
+    required this.name,
+    this.abbr,
+    this.help,
+    this.mandatory = false,
+    this.format = ArgFormat.option,
+    this.defaultsTo,
+  });
+
+  String get bashName => name.replaceAll('-', '_').toUpperCase();
+
+  factory SSHNPArg.noArg() {
+    return SSHNPArg(name: '');
+  }
+
+  factory SSHNPArg.fromName(String name) {
+    return sshnpArgs.firstWhere(
+      (arg) => arg.name == name,
+      orElse: () => SSHNPArg.noArg(),
+    );
+  }
+
+  factory SSHNPArg.fromBashName(String bashName) {
+    return sshnpArgs.firstWhere(
+      (arg) => arg.bashName == bashName,
+      orElse: () => SSHNPArg.noArg(),
+    );
+  }
+}
+
+List<SSHNPArg> sshnpArgs = [
+  SSHNPArg(
+    name: 'key-file',
+    abbr: 'k',
+    help: 'Sending atSign\'s atKeys file if not in ~/.atsign/keys/',
+  ),
+  SSHNPArg(
+    name: 'from',
+    abbr: 'f',
+    help: 'Sending (a.k.a. client) atSign',
+    mandatory: true,
+  ),
+  SSHNPArg(
+    name: 'to',
+    abbr: 't',
+    help: 'Receiving device atSign',
+    mandatory: true,
+  ),
+  SSHNPArg(
+    name: 'device',
+    abbr: 'd',
+    help: 'Receiving device name',
+    defaultsTo: "default",
+  ),
+  SSHNPArg(
+    name: 'host',
+    abbr: 'h',
+    help: 'atSign of sshrvd daemon or FQDN/IP address to connect back to',
+    mandatory: true,
+  ),
+  SSHNPArg(
+    name: 'port',
+    abbr: 'p',
+    help:
+        'TCP port to connect back to (only required if --host specified a FQDN/IP)',
+    defaultsTo: '22',
+  ),
+  SSHNPArg(
+    name: 'local-port',
+    abbr: 'l',
+    help:
+        'Reverse ssh port to listen on, on your local machine, by sshnp default finds a spare port',
+    defaultsTo: '0',
+  ),
+  SSHNPArg(
+    name: 'ssh-public-key',
+    abbr: 's',
+    help:
+        'Public key file from ~/.ssh to be appended to authorized_hosts on the remote device',
+    defaultsTo: 'false',
+  ),
+  SSHNPArg(
+    name: 'local-ssh-options',
+    abbr: 'o',
+    help: 'Add these commands to the local ssh command',
+    format: ArgFormat.multiOption,
+  ),
+  SSHNPArg(
+    name: 'verbose',
+    abbr: 'v',
+    defaultsTo: false,
+    help: 'More logging',
+    format: ArgFormat.flag,
+  ),
+  SSHNPArg(
+    name: 'rsa',
+    abbr: 'r',
+    defaultsTo: false,
+    help: 'Use RSA 4096 keys rather than the default ED25519 keys',
+    format: ArgFormat.flag,
+  ),
+  SSHNPArg(
+    name: 'remote-user-name',
+    abbr: 'u',
+    help: 'username to use in the ssh session on the remote host',
+  ),
+];

--- a/packages/sshnoports/templates/config/sshnp-config-template.env
+++ b/packages/sshnoports/templates/config/sshnp-config-template.env
@@ -1,0 +1,38 @@
+### Template Config File for SSH No Ports ###
+
+# Sending atSign's atKeys file if not in ~/.atsign/keys/
+KEY_FILE=
+
+# Sending (a.k.a. client) atSign
+FROM=
+
+# Receiving (a.k.a. remote) device atSign
+TO=
+
+# Receiving (a.k.a. remote) device name
+DEVICE=
+
+# atSign of sshrvd daemon or FQDN/IP address to connect back to
+HOST=
+
+# TCP port to connect back to (only required if --host specified a FQDN/IP)
+PORT=
+
+# Reverse ssh port to listen on, on your local machine, by sshnp default finds a spare port
+LOCAL_PORT=
+
+# Public key file from ~/.ssh to be appended to authorized_hosts on the remote device
+SSH_PUBLIC_KEY=
+
+# Add these commands to the local ssh command
+# Use ";" to separate your options
+LOCAL_SSH_OPTIONS=
+
+# More logging (true/false)
+VERBOSE=
+
+# Use RSA 4096 keys rather than the default ED25519 keys (true/false)
+RSA=
+
+# username to use in the ssh session on the remote host
+REMOTE_USER_NAME=


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added config file support which follows the [dotenv spec](https://hexdocs.pm/dotenvy/dotenv-file-format.html):
- Option: `--config-file`
- Expected value: `path to file` (relative or absolute)

Notes:

If a config file is supplied, it is read and parsed first, then the rest of the args are read.
So command line args will always override any duplicate args in the file.


**- How I did it**

**- How to verify it**

Demo:

Note: the second attempt to sshnp, the error is expected since I don't own the atSign that I passed into the config file. Third attempt shows that command line args override the value in the file contents.

https://github.com/atsign-foundation/sshnoports/assets/33691921/60dadb6b-b629-4ea9-acd5-081c9260fc4d

**- Description for the changelog**
feat: config files
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->