### PR TITLE
fix: Add a better validator for device name to install_sshnpd

### DIFF
--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -97,6 +97,15 @@ parse_args() {
       read -rp "Device name: " SSHNP_DEVICE_NAME;
     fi
 
+    while [ -z "$SSHNP_DEVICE_NAME" ] ||
+      [ "${#SSHNP_DEVICE_NAME}" -gt 15 ] ||
+      [[ "$SSHNP_DEVICE_NAME" =~ [^a-zA-Z0-9] ]]; do
+        if [ -n "$SSHNP_DEVICE_NAME" ]; then
+          echo "Device name must be between 1 and 15 characters and only contain alphanumeric characters";
+        fi
+        read -rp "Device name: " SSHNP_DEVICE_NAME;
+    done;
+
     norm_atsign CLIENT_ATSIGN
     norm_atsign DEVICE_MANAGER_ATSIGN
     echo;

--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -100,9 +100,7 @@ parse_args() {
     while [ -z "$SSHNP_DEVICE_NAME" ] ||
       [ "${#SSHNP_DEVICE_NAME}" -gt 15 ] ||
       [[ "$SSHNP_DEVICE_NAME" =~ [^a-zA-Z0-9] ]]; do
-        if [ -n "$SSHNP_DEVICE_NAME" ]; then
-          echo "Device name must be between 1 and 15 characters and only contain alphanumeric characters";
-        fi
+        echo "Device name must be between 1 and 15 characters and only contain alphanumeric characters";
         read -rp "Device name: " SSHNP_DEVICE_NAME;
     done;
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added the following checks to a while loop:
- Device name is empty
- Device name longer than 15
- Device name is non-alphanumeric

Will ask for the device name until a valid one is supplied (provides additional hints as to what is valid input).

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: Add a better validator for device name to install_sshnpd
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->