### PR TITLE
chore: Better error messages

### DIFF
--- a/packages/sshnoports/bin/sshnp.dart
+++ b/packages/sshnoports/bin/sshnp.dart
@@ -10,22 +10,30 @@ import 'package:sshnoports/sshnp/cleanup.dart';
 
 void main(List<String> args) async {
   AtSignLogger.root_level = 'SHOUT';
-
-  SSHNP sshnp = await SSHNP.fromCommandLineArgs(args);
-
-  ProcessSignal.sigint.watch().listen((signal) async {
-    await cleanUp(sshnp.sessionId, sshnp.logger);
-    exit(1);
-  });
-
+  SSHNP? sshnp;
   try {
+    sshnp = await SSHNP.fromCommandLineArgs(args);
+
+    ProcessSignal.sigint.watch().listen((signal) async {
+      await cleanUp(sshnp!.sessionId, sshnp.logger);
+      exit(1);
+    });
+
     await sshnp.init();
     await sshnp.run();
     exit(0);
   } catch (error, stackTrace) {
-    stderr.writeln('Error: $error');
-    stderr.writeln('Stack Trace: $stackTrace');
-    await cleanUp(sshnp.sessionId, sshnp.logger);
+    stderr.writeln("\n${error.toString()}");
+
+    if (sshnp?.verbose ?? false) {
+      /// only show stack trace if verbose is true
+      /// or if the program failed before it could be set
+      stderr.writeln('\nStack Trace: $stackTrace');
+    }
+
+    if (sshnp != null) {
+      await cleanUp(sshnp.sessionId, sshnp.logger);
+    }
     exit(1);
   }
 }

--- a/packages/sshnoports/bin/sshnp.dart
+++ b/packages/sshnoports/bin/sshnp.dart
@@ -22,18 +22,17 @@ void main(List<String> args) async {
     await sshnp.init();
     await sshnp.run();
     exit(0);
+  } on ArgumentError catch (_) {
+    exit(1);
   } catch (error, stackTrace) {
-    stderr.writeln("\n${error.toString()}");
-
-    if (sshnp?.verbose ?? false) {
-      /// only show stack trace if verbose is true
-      /// or if the program failed before it could be set
-      stderr.writeln('\nStack Trace: $stackTrace');
-    }
+    stderr.writeln('Error: ${error.toString()}');
+    stderr.writeln('Stack Trace: ${stackTrace.toString()}');
 
     if (sshnp != null) {
       await cleanUp(sshnp.sessionId, sshnp.logger);
     }
+
+    await stderr.flush().timeout(Duration(milliseconds: 100));
     exit(1);
   }
 }

--- a/packages/sshnoports/bin/sshnpd.dart
+++ b/packages/sshnoports/bin/sshnpd.dart
@@ -2,14 +2,18 @@ import 'dart:io';
 import 'package:sshnoports/sshnpd/sshnpd.dart';
 
 void main(List<String> args) async {
-  SSHNPD sshnpd = await SSHNPD.fromCommandLineArgs(args);
+  SSHNPD? sshnpd;
 
   try {
+    sshnpd = await SSHNPD.fromCommandLineArgs(args);
+
     await sshnpd.init();
     await sshnpd.run();
+  } on ArgumentError catch (_) {
+    exit(1);
   } catch (error, stackTrace) {
-    stderr.writeln('sshnpd: ${error.toString()}');
-    stderr.writeln('stack trace: ${stackTrace.toString()}');
+    stderr.writeln('Error: ${error.toString()}');
+    stderr.writeln('Stack Trace: ${stackTrace.toString()}');
     await stderr.flush().timeout(Duration(milliseconds: 100));
     exit(1);
   }

--- a/packages/sshnoports/bin/sshrvd.dart
+++ b/packages/sshnoports/bin/sshrvd.dart
@@ -11,8 +11,8 @@ void main(List<String> args) async {
   } on ArgumentError catch (_) {
     exit(1);
   } catch (error, stackTrace) {
-    stderr.writeln('sshrvd: ${error.toString()}');
-    stderr.writeln('stack trace: ${stackTrace.toString()}');
+    stderr.writeln('Error: ${error.toString()}');
+    stderr.writeln('Stack Trace: ${stackTrace.toString()}');
     await stderr.flush().timeout(Duration(milliseconds: 100));
     exit(1);
   }

--- a/packages/sshnoports/bin/sshrvd.dart
+++ b/packages/sshnoports/bin/sshrvd.dart
@@ -2,11 +2,14 @@ import 'dart:io';
 import 'package:sshnoports/sshrvd/sshrvd.dart';
 
 void main(List<String> args) async {
-  SSHRVD sshrvd = await SSHRVD.fromCommandLineArgs(args);
+  SSHRVD? sshrvd;
 
   try {
+    sshrvd = await SSHRVD.fromCommandLineArgs(args);
     await sshrvd.init();
     await sshrvd.run();
+  } on ArgumentError catch (_) {
+    exit(1);
   } catch (error, stackTrace) {
     stderr.writeln('sshrvd: ${error.toString()}');
     stderr.writeln('stack trace: ${stackTrace.toString()}');

--- a/packages/sshnoports/lib/common/utils.dart
+++ b/packages/sshnoports/lib/common/utils.dart
@@ -54,7 +54,8 @@ bool checkNonAscii(String test) {
   }
 }
 
-String getDefaultAtKeysFilePath(String homeDirectory, String atSign) {
+String getDefaultAtKeysFilePath(String homeDirectory, String? atSign) {
+  if (atSign == null) return '';
   return '$homeDirectory/.atsign/keys/${atSign}_key.atKeys'
       .replaceAll('/', Platform.pathSeparator);
 }

--- a/packages/sshnoports/lib/sshnp/sshnp.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp.dart
@@ -107,9 +107,13 @@ abstract class SSHNP {
   @visibleForTesting
   abstract bool sshrvdAck;
 
+  bool verbose = false;
+
   /// true once [init] has completed
   @visibleForTesting
   bool initialized = false;
+
+
 
   factory SSHNP({
     // final fields
@@ -127,6 +131,7 @@ abstract class SSHNP {
     required String port,
     required String localPort,
     String? remoteUsername,
+    bool verbose = false,
   }) {
     return SSHNPImpl(
       atClient: atClient,
@@ -142,6 +147,7 @@ abstract class SSHNP {
       port: port,
       localPort: localPort,
       remoteUsername: remoteUsername,
+      verbose: verbose,
     );
   }
 

--- a/packages/sshnoports/lib/sshnp/sshnp_impl.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_impl.dart
@@ -150,6 +150,9 @@ class SSHNPImpl implements SSHNP {
   @visibleForTesting
   bool initialized = false;
 
+  @override
+  bool verbose = false;
+
   SSHNPImpl({
     // final fields
     required this.atClient,
@@ -166,6 +169,7 @@ class SSHNPImpl implements SSHNP {
     required this.port,
     required this.localPort,
     this.remoteUsername,
+    this.verbose = false,
   }) {
     namespace = '$device.sshnp';
     clientAtSign = atClient.getCurrentAtSign()!;
@@ -190,9 +194,22 @@ class SSHNPImpl implements SSHNP {
         SSHNPPartialParams.fromArgs(args),
       );
 
+      if (p.clientAtSign == null) {
+        throw FormatException('"--from" is required');
+      }
+
+      if (p.sshnpdAtSign == null) {
+        throw FormatException('"--to" is required');
+        
+      }
+
+      if (p.host == null) {
+        throw FormatException('"--host" is required');
+      }
+
       // Check atKeyFile selected exists
       if (!await fileExists(p.atKeysFilePath)) {
-        throw ('\n Unable to find .atKeys file : ${p.atKeysFilePath}');
+        throw ('\nUnable to find .atKeys file : ${p.atKeysFilePath}');
       }
 
       String sessionId = Uuid().v4();
@@ -204,25 +221,26 @@ class SSHNPImpl implements SSHNP {
 
       AtClient atClient = await createAtClientCli(
           homeDirectory: p.homeDirectory,
-          atsign: p.clientAtSign,
+          atsign: p.clientAtSign!,
           namespace: '${p.device}.sshnp',
           pathExtension: sessionId,
           atKeysFilePath: p.atKeysFilePath);
 
       var sshnp = SSHNP(
         atClient: atClient,
-        sshnpdAtSign: p.sshnpdAtSign,
+        sshnpdAtSign: p.sshnpdAtSign!,
         username: p.username,
         homeDirectory: p.homeDirectory,
         sessionId: sessionId,
         device: p.device,
-        host: p.host,
+        host: p.host!,
         port: p.port,
         localPort: p.localPort,
         localSshOptions: p.localSshOptions,
         rsa: p.rsa,
         sendSshPublicKey: p.sendSshPublicKey,
         remoteUsername: p.remoteUsername,
+        verbose: p.verbose,
       );
       if (p.verbose) {
         sshnp.logger.logger.level = Level.INFO;
@@ -232,7 +250,6 @@ class SSHNPImpl implements SSHNP {
     } catch (e) {
       printVersion();
       stdout.writeln(SSHNPPartialParams.parser.usage);
-      stderr.writeln(e);
       rethrow;
     }
   }

--- a/packages/sshnoports/lib/sshnp/sshnp_impl.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_impl.dart
@@ -195,16 +195,15 @@ class SSHNPImpl implements SSHNP {
       );
 
       if (p.clientAtSign == null) {
-        throw FormatException('"--from" is required');
+        throw ArgumentError('Option from is mandatory.');
       }
 
       if (p.sshnpdAtSign == null) {
-        throw FormatException('"--to" is required');
-        
+        throw ArgumentError('Option to is mandatory.');
       }
 
       if (p.host == null) {
-        throw FormatException('"--host" is required');
+        throw ArgumentError('Option host is mandatory.');
       }
 
       // Check atKeyFile selected exists
@@ -250,6 +249,7 @@ class SSHNPImpl implements SSHNP {
     } catch (e) {
       printVersion();
       stdout.writeln(SSHNPPartialParams.parser.usage);
+      stderr.writeln('\n$e');
       rethrow;
     }
   }

--- a/packages/sshnoports/lib/sshnp/sshnp_params.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_params.dart
@@ -1,16 +1,21 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:at_utils/at_utils.dart';
 import 'package:sshnoports/common/utils.dart';
 import 'package:sshnoports/sshnp/sshnp_arg.dart';
 
 class SSHNPParams {
-  /// from atSign
-  late final String clientAtSign;
+  /// Required Arguments
+  /// These arguments do not have fallback values and must be provided.
+  /// Since there are multiple sources for these values, we cannot validate
+  /// that they will be provided. If any are null, then the caller must
+  /// handle the error.
+  late final String? clientAtSign;
+  late final String? sshnpdAtSign;
+  late final String? host;
 
-  /// to atSign
-  late final String sshnpdAtSign;
-  late final String host;
+  /// Optional Arguments
   late final String device;
   late final String port;
   late final String localPort;
@@ -44,15 +49,24 @@ class SSHNPParams {
     homeDirectory = getHomeDirectory(throwIfNull: true)!;
 
     // Use default atKeysFilePath if not provided
+
     this.atKeysFilePath =
         atKeysFilePath ?? getDefaultAtKeysFilePath(homeDirectory, clientAtSign);
   }
 
   factory SSHNPParams.fromPartial(SSHNPPartialParams partial) {
+    AtSignLogger logger = AtSignLogger(' SSHNPParams ');
+
+    /// If any required params are null log severe, but do not throw
+    /// The caller must handle the error if any required params are null
+    partial.clientAtSign ?? (logger.severe('clientAtSign is null'));
+    partial.sshnpdAtSign ?? (logger.severe('sshnpdAtSign is null'));
+    partial.host ?? (logger.severe('host is null'));
+
     return SSHNPParams(
-      clientAtSign: partial.clientAtSign!,
-      sshnpdAtSign: partial.sshnpdAtSign!,
-      host: partial.host!,
+      clientAtSign: partial.clientAtSign,
+      sshnpdAtSign: partial.sshnpdAtSign,
+      host: partial.host,
       device: partial.device ?? 'default',
       port: partial.port ?? '22',
       localPort: partial.localPort ?? '0',

--- a/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
@@ -94,7 +94,7 @@ class SSHNPDImpl implements SSHNPD {
     } catch (e) {
       printVersion();
       stdout.writeln(SSHNPDParams.parser.usage);
-      stderr.writeln(e);
+      stderr.writeln('\n$e');
       rethrow;
     }
   }

--- a/packages/sshnoports/lib/sshrvd/sshrvd_impl.dart
+++ b/packages/sshnoports/lib/sshrvd/sshrvd_impl.dart
@@ -86,7 +86,7 @@ class SSHRVDImpl implements SSHRVD {
     } catch (e) {
       printVersion();
       stdout.writeln(SSHRVDParams.parser.usage);
-      stderr.writeln(e);
+      stderr.writeln('\n$e');
       rethrow;
     }
   }

--- a/packages/sshnoports/test/sshnp_test.dart
+++ b/packages/sshnoports/test/sshnp_test.dart
@@ -46,7 +46,7 @@ void main() {
       expect(p.username, getUserName(throwIfNull: true));
       expect(p.homeDirectory, getHomeDirectory(throwIfNull: true));
       expect(p.atKeysFilePath,
-          getDefaultAtKeysFilePath(p.homeDirectory, p.clientAtSign));
+          getDefaultAtKeysFilePath(p.homeDirectory, p.clientAtSign ?? ''));
       expect(p.sendSshPublicKey, 'false');
       expect(p.localSshOptions, []);
       expect(p.rsa, false);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Due to some changes in the way arg parsing is done, the error messages for a bad parse is unpleasant, especially if you just want to see usage (this is what you get if you type `sshnp`, yuck):

```
Version : 3.4.0
-k, --key-file             Sending atSign's atKeys file if not in ~/.atsign/keys/
-f, --from (mandatory)     Sending (a.k.a. client) atSign
-t, --to (mandatory)       Receiving device atSign
-d, --device               Receiving device name
                           (defaults to "default")
-h, --host (mandatory)     atSign of sshrvd daemon or FQDN/IP address to connect back to
-p, --port                 TCP port to connect back to (only required if --host specified a FQDN/IP)
                           (defaults to "22")
-l, --local-port           Reverse ssh port to listen on, on your local machine, by sshnp default finds a spare port
                           (defaults to "0")
-s, --ssh-public-key       Public key file from ~/.ssh to be appended to authorized_hosts on the remote device
                           (defaults to "false")
-o, --local-ssh-options    Add these commands to the local ssh command
-v, --[no-]verbose         More logging
-r, --[no-]rsa             Use RSA 4096 keys rather than the default ED25519 keys
-u, --remote-user-name     username to use in the ssh session on the remote host
    --config-file          Read args from a config file
                           Mandatory args are not required if already supplied in the config file
Null check operator used on a null value
Unhandled exception:
Null check operator used on a null value
#0      new SSHNPParams.fromPartial (package:sshnoports/sshnp/sshnp_params.dart:53)
#1      SSHNPImpl.fromCommandLineArgs (package:sshnoports/sshnp/sshnp_impl.dart:189)
#2      SSHNP.fromCommandLineArgs (package:sshnoports/sshnp/sshnp.dart:149)
#3      main (file:///Users/chant/src/af/sshnoports/packages/sshnoports/bin/sshnp.dart:14)
#4      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:294)
#5      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:189)
```

Change: Moved creation of SSHNP / SSHNPD/ SSHRVD class into the try block, and added a separate on catch:
```
} on ArgumentError catch (_) {
    exit(1);
  }
```
  
Net change is cleaner, easier to read ArgumentError messages when printing usage:
```
Version : 3.4.0
-k, --key-file             Sending atSign's atKeys file if not in ~/.atsign/keys/
-f, --from (mandatory)     Sending (a.k.a. client) atSign
-t, --to (mandatory)       Receiving device atSign
-d, --device               Receiving device name
                           (defaults to "default")
-h, --host (mandatory)     atSign of sshrvd daemon or FQDN/IP address to connect back to
-p, --port                 TCP port to connect back to (only required if --host specified a FQDN/IP)
                           (defaults to "22")
-l, --local-port           Reverse ssh port to listen on, on your local machine, by sshnp default finds a spare port
                           (defaults to "0")
-s, --ssh-public-key       Public key file from ~/.ssh to be appended to authorized_hosts on the remote device
                           (defaults to "false")
-o, --local-ssh-options    Add these commands to the local ssh command
-v, --[no-]verbose         More logging
-r, --[no-]rsa             Use RSA 4096 keys rather than the default ED25519 keys
-u, --remote-user-name     username to use in the ssh session on the remote host
    --config-file          Read args from a config file
                           Mandatory args are not required if already supplied in the config file

Invalid argument(s): Option from is mandatory.
```

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: Better error messages
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->