### PR TITLE
fix: multibuild (+ reduced build duration)

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -67,13 +67,10 @@ jobs:
       - run: mkdir tarballs
       - run: tar -xvf bins.tar -C tarballs
       - run: ls -l tarballs
-      - run: mkdir upload
-      - run: cp tarballs/*/*.tgz upload/
-      - run: ls -l upload
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: other_binaries
-          path: ./packages/sshnoports/upload/${{ matrix.output-name }}.tgz
+          path: ./packages/sshnoports/tarballs/${{ matrix.output-name }}.tgz
 
   notify_on_completion:
     needs: [x64_build, other_build]

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: x64_binaries
-          path: tarball/${{ matrix.output-name }}.tgz
+          path: ./packages/sshnoports/tarball/${{ matrix.output-name }}.tgz
 
   other_build:
     runs-on: ubuntu-latest
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: other_binaries
-          path: upload/${{ matrix.output-name }}.tgz
+          path: ./packages/sshnoports/upload/${{ matrix.output-name }}.tgz
 
   notify_on_completion:
     needs: [x64_build, other_build]
@@ -83,5 +83,17 @@ jobs:
         uses: Co-qn/google-chat-notification@3691ccf4763537d6e544bc6cdcccc1965799d056 # v1
         with:
           name: SSH no ports binaries were built by GitHub Action ${{ github.run_number }}
+          url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
+          status: ${{ job.status }}
+
+  notify_on_failure:
+    if: failure()
+    needs: [x64_build, other_build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Google Chat Notification
+        uses: Co-qn/google-chat-notification@3691ccf4763537d6e544bc6cdcccc1965799d056 # v1
+        with:
+          name: SSH no ports binaries build FAILED by GitHub Action ${{ github.run_number }}
           url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
           status: ${{ job.status }}

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -34,9 +34,7 @@ jobs:
       - run: dart compile exe bin/sshrvd.dart -v -o sshnp/sshrvd
       - run: cp -r templates sshnp/templates
       - run: cp scripts/* sshnp
-      - run: ls -l sshnp
       - run: tar -cvzf tarball/${{ matrix.output-name }}.tgz sshnp
-      - run: ls -l tarball
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: x64_binaries
@@ -66,7 +64,6 @@ jobs:
           --platform ${{ matrix.platform }} -o type=tar,dest=bins.tar .
       - run: mkdir tarballs
       - run: tar -xvf bins.tar -C tarballs
-      - run: ls -l tarballs
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: other_binaries

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -39,6 +39,7 @@ jobs:
         with:
           name: x64_binaries
           path: ./packages/sshnoports/tarball/${{ matrix.output-name }}.tgz
+          if-no-files-found: error
 
   other_build:
     runs-on: ubuntu-latest
@@ -68,6 +69,7 @@ jobs:
         with:
           name: other_binaries
           path: ./packages/sshnoports/tarballs/${{ matrix.output-name }}.tgz
+          if-no-files-found: error
 
   notify_on_completion:
     needs: [x64_build, other_build]

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -34,7 +34,9 @@ jobs:
       - run: dart compile exe bin/sshrvd.dart -v -o sshnp/sshrvd
       - run: cp -r templates sshnp/templates
       - run: cp scripts/* sshnp
+      - run: ls -l sshnp
       - run: tar -cvzf tarball/${{ matrix.output-name }}.tgz sshnp
+      - run: ls -l tarball
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: x64_binaries
@@ -61,8 +63,10 @@ jobs:
           --platform ${{ matrix.platform }} -o type=tar,dest=bins.tar .
       - run: mkdir tarballs
       - run: tar -xvf bins.tar -C tarballs
+      - run: ls -l tarballs
       - run: mkdir upload
       - run: cp tarballs/*/*.tgz upload/
+      - run: ls -l upload
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: other_binaries

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: x64_binaries
-          path: tarball
+          path: tarball/${{ matrix.output-name }}.tgz
 
   other_build:
     runs-on: ubuntu-latest
@@ -52,8 +52,11 @@ jobs:
         platform: [linux/arm/v7, linux/arm64, linux/riscv64]
         include:
           - platform: linux/arm/v7
+            output-name: sshnp-linux-arm
           - platform: linux/arm64
+            output-name: sshnp-linux-arm64
           - platform: linux/riscv64
+            output-name: sshnp-linux-riscv64
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.2.0
@@ -70,7 +73,7 @@ jobs:
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: other_binaries
-          path: upload
+          path: upload/${{ matrix.output-name }}.tgz
 
   notify_on_completion:
     needs: [x64_build, other_build]

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -1,9 +1,9 @@
 name: Multibuild
 
-on: 
+on:
   workflow_dispatch:
 
-permissions:  # added using https://github.com/step-security/secure-repo
+permissions: # added using https://github.com/step-security/secure-repo
   contents: read
 
 jobs:
@@ -39,19 +39,26 @@ jobs:
         with:
           name: x64_binaries
           path: tarball
-  
+
   other_build:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./packages/sshnoports
+    strategy:
+      matrix:
+        platform: [linux/arm/v7, linux/arm64, linux/riscv64]
+        include:
+          - platform: linux/arm/v7
+          - platform: linux/arm64
+          - platform: linux/riscv64
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.2.0
       - uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1 # v2.9.1
       - run: |
           docker buildx build -t atsigncompany/sshnptarball -f Dockerfile.package \
-          --platform linux/arm/v7,linux/arm64,linux/riscv64 -o type=tar,dest=bins.tar .
+          --platform ${{ matrix.platform }} -o type=tar,dest=bins.tar .
       - run: mkdir tarballs
       - run: tar -xvf bins.tar -C tarballs
       - run: mkdir upload


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Converted to absolute path for multibuild upload artifacts, because actions/upload-artifact doesn't respect the working-directory.
  - See https://github.com/actions/upload-artifact/issues/294
- Added a job to alert in google chat if ssh no ports builds fail
- Doing other_build in parallel to reduce wait time of build

**- How I did it**

**- How to verify it**

See https://github.com/atsign-foundation/sshnoports/actions/runs/5606212030

**- Description for the changelog**
fix: multibuild (+ reduced build duration)
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->