### PR TITLE
ci: fix dockerhub_sshnpd

### DIFF
--- a/.github/workflows/dockerhub_sshnpd.yml
+++ b/.github/workflows/dockerhub_sshnpd.yml
@@ -12,9 +12,6 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
   docker:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./packages/sshnoports
     steps:
       -
         name: Checkout
@@ -39,7 +36,7 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
         with:
-          context: .
+          context: ./packages/sshnoports
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           provenance: false


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Same issue as #261 
The dockerhub build for sshnpd was ignoring the working-directory and thus looking for the Dockerfile in the wrong place.

Removed the working-directory and added it directly to the context.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
ci: fix dockerhub_sshnpd
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->