### PR TITLE
fix: dependency upgrades + cleanup error messages in sshnp

### DIFF
--- a/packages/sshnoports/bin/sshnp.dart
+++ b/packages/sshnoports/bin/sshnp.dart
@@ -7,12 +7,16 @@ import 'package:at_utils/at_logger.dart';
 // local packages
 import 'package:sshnoports/sshnp/sshnp.dart';
 import 'package:sshnoports/sshnp/cleanup.dart';
+import 'package:sshnoports/sshnp/sshnp_params.dart';
 
 void main(List<String> args) async {
   AtSignLogger.root_level = 'SHOUT';
   SSHNP? sshnp;
+
+  var params = SSHNPParams.fromPartial(SSHNPPartialParams.fromArgs(args));
+
   try {
-    sshnp = await SSHNP.fromCommandLineArgs(args);
+    sshnp = await SSHNP.fromParams(params);
 
     ProcessSignal.sigint.watch().listen((signal) async {
       await cleanUp(sshnp!.sessionId, sshnp.logger);
@@ -25,8 +29,11 @@ void main(List<String> args) async {
   } on ArgumentError catch (_) {
     exit(1);
   } catch (error, stackTrace) {
-    stderr.writeln('Error: ${error.toString()}');
-    stderr.writeln('Stack Trace: ${stackTrace.toString()}');
+    stderr.writeln(error.toString());
+
+    if (params.verbose) {
+      stderr.writeln('\nStack Trace: ${stackTrace.toString()}');
+    }
 
     if (sshnp != null) {
       await cleanUp(sshnp.sessionId, sshnp.logger);

--- a/packages/sshnoports/lib/sshnp/sshnp.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp.dart
@@ -4,6 +4,7 @@ import 'package:at_client/at_client.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:meta/meta.dart';
 import 'package:sshnoports/sshnp/sshnp_impl.dart';
+import 'package:sshnoports/sshnp/sshnp_params.dart';
 
 abstract class SSHNP {
   abstract final AtSignLogger logger;
@@ -113,8 +114,6 @@ abstract class SSHNP {
   @visibleForTesting
   bool initialized = false;
 
-
-
   factory SSHNP({
     // final fields
     required AtClient atClient,
@@ -153,6 +152,10 @@ abstract class SSHNP {
 
   static Future<SSHNP> fromCommandLineArgs(List<String> args) async {
     return SSHNPImpl.fromCommandLineArgs(args);
+  }
+
+  static Future<SSHNP> fromParams(SSHNPParams p) {
+    return SSHNPImpl.fromParams(p);
   }
 
   /// Must be run after construction, to complete initialization

--- a/packages/sshnoports/lib/sshnp/sshnp_impl.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_impl.dart
@@ -188,12 +188,13 @@ class SSHNPImpl implements SSHNP {
     }
   }
 
-  static Future<SSHNP> fromCommandLineArgs(List<String> args) async {
-    try {
-      var p = SSHNPParams.fromPartial(
-        SSHNPPartialParams.fromArgs(args),
-      );
+  static Future<SSHNP> fromCommandLineArgs(List<String> args) {
+    var params = SSHNPParams.fromPartial(SSHNPPartialParams.fromArgs(args));
+    return fromParams(params);
+  }
 
+  static Future<SSHNP> fromParams(SSHNPParams p) async {
+    try {
       if (p.clientAtSign == null) {
         throw ArgumentError('Option from is mandatory.');
       }

--- a/packages/sshnoports/pubspec.yaml
+++ b/packages/sshnoports/pubspec.yaml
@@ -8,15 +8,14 @@ version: 3.4.0
 homepage: https://docs.atsign.com/
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ">=3.0.0 <4.0.0"
 
-
-dependencies: 
+dependencies:
   args: 2.4.2
-  at_client: 3.0.61
-  at_lookup: 3.0.37
+  at_client: 3.0.63
+  at_lookup: 3.0.38
   at_onboarding_cli: 1.3.0
-  at_utils: 3.0.13
+  at_utils: 3.0.15
   crypton: 2.1.0
   dartssh2: 2.8.2
   ssh_key: ">=0.7.1 <0.9.0"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

closes #264 

I get the params object in the main function now so I can check if the verbose flag is set.
Then only print stack trace if verbose is true.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: cleanup error messages in sshnp
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->