### PR TITLE
ci: wait time without sync 2 -> 4

### DIFF
--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -16,7 +16,7 @@ env:
   SSHRVD_RV_AM_ATSIGN: "@rv_am"
   DOCKER_COMPOSE_UP_CMD: "docker compose up --exit-code-from=container-sshnp"
   WAITING_TIME_WITH_SYNC: 30
-  WAITING_TIME_WITHOUT_SYNC: 2
+  WAITING_TIME_WITHOUT_SYNC: 4
 
 jobs:
   # e2e-set-up-sshrvd:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- increased "wait time without sync" (which is the time in seconds for sshnp to sleep once the sshnpd container is booted up) from 2 seconds to 4 seconds
- aim is to reduce flaking

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->