### PR TITLE
fix: LateInitializationError sshrvdPort

### DIFF
--- a/packages/sshnoports/lib/sshnp/sshnp.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp.dart
@@ -87,7 +87,7 @@ abstract class SSHNP {
   abstract final String namespace;
 
   /// When using sshrvd, this is fetched from sshrvd during [init]
-  abstract final String sshrvdPort;
+  String get sshrvdPort;
 
   /// Set to '$localPort $port $username $host $sessionId' during [init]
   abstract final String sshString;

--- a/packages/sshnoports/lib/sshnp/sshnp_impl.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_impl.dart
@@ -115,7 +115,7 @@ class SSHNPImpl implements SSHNP {
 
   /// When using sshrvd, this is fetched from sshrvd during [init]
   @override
-  late final String sshrvdPort;
+  late String sshrvdPort;
 
   /// Set to '$localPort $port $username $host $sessionId' during [init]
   @override

--- a/packages/sshnoports/lib/sshnp/sshnp_impl.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_impl.dart
@@ -114,8 +114,12 @@ class SSHNPImpl implements SSHNP {
   late final String namespace;
 
   /// When using sshrvd, this is fetched from sshrvd during [init]
+  /// This is only set when using sshrvd
+  /// (i.e. after [getHostAndPortFromSshrvd] has been called)
   @override
-  late String sshrvdPort;
+  String get sshrvdPort => _sshrvdPort;
+
+  late String _sshrvdPort;
 
   /// Set to '$localPort $port $username $host $sessionId' during [init]
   @override
@@ -484,7 +488,7 @@ class SSHNPImpl implements SSHNP {
       List results = ipPorts.split(',');
       host = results[0];
       port = results[1];
-      sshrvdPort = results[2];
+      _sshrvdPort = results[2];
       sshrvdAck = true;
     });
 
@@ -525,7 +529,7 @@ class SSHNPImpl implements SSHNP {
 
     // Connect to rendezvous point using background process.
     // sshnp (this program) can then exit without issue.
-    unawaited(Process.run(getSshrvCommand(), [host, sshrvdPort]));
+    unawaited(Process.run(getSshrvCommand(), [host, _sshrvdPort]));
   }
 
   Future<void> generateSshKeys() async {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

sshrvdPort was a late final variable, which meant it was causing a LateInitializationError.
Removed the final modifier, and cleaned up how we expose it to the public interface.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: LateInitializationError sshrvdPort
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->