### PR TITLE
feat: make sshnpd execute ssh command via Process.start

### DIFF
--- a/packages/sshnoports/bin/sshnp.dart
+++ b/packages/sshnoports/bin/sshnp.dart
@@ -11,6 +11,7 @@ import 'package:sshnoports/sshnp/sshnp_params.dart';
 
 void main(List<String> args) async {
   AtSignLogger.root_level = 'SHOUT';
+  AtSignLogger.defaultLoggingHandler = AtSignLogger.stdErrLoggingHandler;
   SSHNP? sshnp;
 
   var params = SSHNPParams.fromPartial(SSHNPPartialParams.fromArgs(args));

--- a/packages/sshnoports/bin/sshnpd.dart
+++ b/packages/sshnoports/bin/sshnpd.dart
@@ -1,7 +1,10 @@
 import 'dart:io';
+import 'package:at_utils/at_logger.dart';
 import 'package:sshnoports/sshnpd/sshnpd.dart';
 
 void main(List<String> args) async {
+  AtSignLogger.root_level = 'SHOUT';
+  AtSignLogger.defaultLoggingHandler = AtSignLogger.stdErrLoggingHandler;
   SSHNPD? sshnpd;
 
   try {

--- a/packages/sshnoports/bin/sshrvd.dart
+++ b/packages/sshnoports/bin/sshrvd.dart
@@ -1,7 +1,10 @@
 import 'dart:io';
+import 'package:at_utils/at_logger.dart';
 import 'package:sshnoports/sshrvd/sshrvd.dart';
 
 void main(List<String> args) async {
+  AtSignLogger.root_level = 'SHOUT';
+  AtSignLogger.defaultLoggingHandler = AtSignLogger.stdErrLoggingHandler;
   SSHRVD? sshrvd;
 
   try {

--- a/packages/sshnoports/lib/common/supported_ssh_clients.dart
+++ b/packages/sshnoports/lib/common/supported_ssh_clients.dart
@@ -1,0 +1,7 @@
+enum SupportedSshClient {
+  hostSsh(cliArg: '/usr/bin/ssh'),
+  pureDart(cliArg: 'pure-dart');
+
+  final String cliArg;
+  const SupportedSshClient({required this.cliArg});
+}

--- a/packages/sshnoports/lib/sshnp/sshnp_impl.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_impl.dart
@@ -373,11 +373,10 @@ class SSHNPImpl implements SSHNP {
     // By removing the .pub extn
     if (!sshnpdAckErrors) {
       if (sendSshPublicKey != 'false') {
-        stdout.write(
-            'ssh -p $localPort $remoteUsername@localhost'
-                ' -o StrictHostKeyChecking=accept-new'
-                ' -o IdentitiesOnly=yes'
-                ' -i ${sendSshPublicKey.replaceFirst(RegExp(r'.pub$'), '')}');
+        stdout.write('ssh -p $localPort $remoteUsername@localhost'
+            ' -o StrictHostKeyChecking=accept-new'
+            ' -o IdentitiesOnly=yes'
+            ' -i ${sendSshPublicKey.replaceFirst(RegExp(r'.pub$'), '')}');
       } else {
         stdout.write('ssh -p $localPort $remoteUsername@localhost -o ssh'
             ' -o StrictHostKeyChecking=accept-new');

--- a/packages/sshnoports/lib/sshnp/sshnp_impl.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_impl.dart
@@ -376,6 +376,7 @@ class SSHNPImpl implements SSHNP {
         stdout.write(
             'ssh -p $localPort $remoteUsername@localhost'
                 ' -o StrictHostKeyChecking=accept-new'
+                ' -o IdentitiesOnly=yes'
                 ' -i ${sendSshPublicKey.replaceFirst(RegExp(r'.pub$'), '')}');
       } else {
         stdout.write('ssh -p $localPort $remoteUsername@localhost -o ssh'

--- a/packages/sshnoports/lib/sshnp/sshnp_impl.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_impl.dart
@@ -374,9 +374,12 @@ class SSHNPImpl implements SSHNP {
     if (!sshnpdAckErrors) {
       if (sendSshPublicKey != 'false') {
         stdout.write(
-            "ssh -p $localPort $remoteUsername@localhost -i ${sendSshPublicKey.replaceFirst(RegExp(r'.pub$'), '')} ");
+            'ssh -p $localPort $remoteUsername@localhost'
+                ' -o StrictHostKeyChecking=accept-new'
+                ' -i ${sendSshPublicKey.replaceFirst(RegExp(r'.pub$'), '')}');
       } else {
-        stdout.write("ssh -p $localPort $remoteUsername@localhost ");
+        stdout.write('ssh -p $localPort $remoteUsername@localhost -o ssh'
+            ' -o StrictHostKeyChecking=accept-new');
       }
       // print out optional arguments
       for (var argument in localSshOptions) {

--- a/packages/sshnoports/lib/sshnpd/sshnpd.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:at_client/at_client.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:meta/meta.dart';
+import 'package:sshnoports/common/supported_ssh_clients.dart';
 import 'package:sshnoports/sshnpd/sshnpd_impl.dart';
 
 abstract class SSHNPD {
@@ -28,6 +29,9 @@ abstract class SSHNPD {
   String get deviceAtsign;
   abstract final String managerAtsign;
 
+  /// The ssh client to use when doing reverse ssh
+  abstract final SupportedSshClient sshClient;
+
   /// true once [init] has completed
   @visibleForTesting
   bool initialized = false;
@@ -38,15 +42,16 @@ abstract class SSHNPD {
       required AtClient atClient,
       required String username,
       required String homeDirectory,
-      // volatile fields
       required String device,
-      required String managerAtsign}) {
+      required String managerAtsign,
+      required SupportedSshClient sshClient}) {
     return SSHNPDImpl(
         atClient: atClient,
         username: username,
         homeDirectory: homeDirectory,
         device: device,
-        managerAtsign: managerAtsign);
+        managerAtsign: managerAtsign,
+        sshClient: sshClient);
   }
 
   static Future<SSHNPD> fromCommandLineArgs(List<String> args) async {

--- a/packages/sshnoports/lib/sshnpd/sshnpd.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd.dart
@@ -32,8 +32,6 @@ abstract class SSHNPD {
   @visibleForTesting
   bool initialized = false;
 
-  static const String commandToSend = 'sshd';
-
   factory SSHNPD(
       {
       // final fields

--- a/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
@@ -404,8 +404,6 @@ class SSHNPDImpl implements SSHNPD {
         logger.shout(
             '$sessionId | Exit code $sshExitCode from'
                 ' /usr/bin/ssh ${args.join(' ')}');
-        logger.shout('$sessionId | stdout   : ${result?.stdout}');
-        logger.shout('$sessionId | stderr   : ${result?.stderr}');
         errorMessage = 'Failed to establish connection - exit code $sshExitCode';
       }
     }

--- a/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
@@ -341,8 +341,9 @@ class SSHNPDImpl implements SSHNPD {
     // The incantation for that is -R clientHostPort:localhost:22
     //
     // We will disable strict host checking since we don't know what hosts we're going to be
-    // connecting to. We add these options:
-    // -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+    // connecting to. Instead, we'll accept new hostnames but the checks will still be executed
+    // if the host identity has changed.
+    // -o StrictHostKeyChecking=accept-new
     //
     // We don't want keyboard interactive: we add -o BatchMode=yes
     //
@@ -351,8 +352,8 @@ class SSHNPDImpl implements SSHNPD {
     // So we will add options 'ForkAfterAuthentication=yes' and also
     // 'ExitOnForwardFailure=yes' so that it won't fork until after
     // all of the forwarding has been successfully set up.
-    // This allows us to do a simple Process.run() knowing we will get an exit
-    // code 0 promptly if the ssh connection has succeeded, and the ssh
+    // This allows us to do a simple Process.start() knowing we will get an exit
+    // code 0 promptly if the ssh connection has succeeded, and the actual ssh
     // connection can run happily in the background.
     //
     // Lastly, we want to ensure that if the connection isn't used then it closes after 15 seconds
@@ -369,11 +370,10 @@ class SSHNPDImpl implements SSHNPD {
       '-p', port,
       '-i', pemFile.absolute.path,
       '-R', '$localPort:localhost:22',
-      '-v',
+      '-o LogLevel=VERBOSE',
       '-t', '-t',
-      '-o', 'StrictHostKeyChecking=no',
+      '-o', 'StrictHostKeyChecking=accept-new',
       '-o', 'IdentitiesOnly=yes',
-      '-o', 'UserKnownHostsFile=/dev/null',
       '-o', 'BatchMode=yes',
       '-o', 'ExitOnForwardFailure=yes',
       '-o', 'ForkAfterAuthentication=yes',

--- a/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
@@ -83,13 +83,12 @@ class SSHNPDImpl implements SSHNPD {
       );
 
       var sshnpd = SSHNPD(
-        atClient: atClient,
-        username: p.username,
-        homeDirectory: p.homeDirectory,
-        device: p.device,
-        managerAtsign: p.managerAtsign,
-        sshClient: p.sshClient
-      );
+          atClient: atClient,
+          username: p.username,
+          homeDirectory: p.homeDirectory,
+          device: p.device,
+          managerAtsign: p.managerAtsign,
+          sshClient: p.sshClient);
 
       if (p.verbose) {
         sshnpd.logger.logger.level = Level.INFO;
@@ -286,12 +285,12 @@ class SSHNPDImpl implements SSHNPD {
 
       switch (sshClient) {
         case SupportedSshClient.hostSsh:
-          (success, errorMessage) = await reverseSshViaExec(
-              privateKey, username, hostname, port, localPort, logger, sessionId);
+          (success, errorMessage) = await reverseSshViaExec(privateKey,
+              username, hostname, port, localPort, logger, sessionId);
           break;
         case SupportedSshClient.pureDart:
-          (success, errorMessage) = await reverseSshViaSSHClient(
-              privateKey, username, hostname, port, localPort, logger, sessionId);
+          (success, errorMessage) = await reverseSshViaSSHClient(privateKey,
+              username, hostname, port, localPort, logger, sessionId);
           break;
       }
 
@@ -307,7 +306,6 @@ class SSHNPDImpl implements SSHNPD {
       } else {
         /// Notify sshnp that the connection has been made
         logger.info(' sshnpd connected notification sent to:from "$atKey');
-        await Future.delayed(Duration(seconds:1));
         await _notify(atKey, "connected", sessionId: sessionId);
       }
     } catch (e) {
@@ -332,7 +330,6 @@ class SSHNPDImpl implements SSHNPD {
       String localPort,
       AtSignLogger logger,
       String sessionId) async {
-
     late final SSHSocket socket;
     try {
       socket = await SSHSocket.connect(hostname, int.parse(port));
@@ -351,13 +348,19 @@ class SSHNPDImpl implements SSHNPD {
         ],
       );
     } catch (e) {
-      return (false, 'Failed to create SSHClient for $username@$hostname:$port : $e');
+      return (
+        false,
+        'Failed to create SSHClient for $username@$hostname:$port : $e'
+      );
     }
 
     try {
       await client.authenticated;
     } catch (e) {
-      return (false, 'Failed to authenticate as $username@$hostname:$port : $e');
+      return (
+        false,
+        'Failed to authenticate as $username@$hostname:$port : $e'
+      );
     }
 
     /// Do the port forwarding
@@ -382,8 +385,7 @@ class SSHNPDImpl implements SSHNPD {
         await client.done;
         shouldStop = true;
         timer.cancel();
-        logger.shout(
-            '$sessionId | ssh session complete');
+        logger.shout('$sessionId | ssh session complete');
       }
     });
 
@@ -395,7 +397,7 @@ class SSHNPDImpl implements SSHNPD {
 
         unawaited(
           connection.stream.cast<List<int>>().pipe(socket).whenComplete(
-                () async {
+            () async {
               counter--;
             },
           ),
@@ -404,7 +406,8 @@ class SSHNPDImpl implements SSHNPD {
         if (shouldStop) break;
       }
     }).catchError((e) {
-      logger.shout('$sessionId | reverseSshViaSSHClient | error from forward connections handler $e');
+      logger.shout(
+          '$sessionId | reverseSshViaSSHClient | error from forward connections handler $e');
     }));
 
     return (true, null);
@@ -422,7 +425,7 @@ class SSHNPDImpl implements SSHNPD {
       AtSignLogger logger,
       String sessionId) async {
     final pemFile = File('/tmp/.${Uuid().v4()}');
-    if (! privateKey.endsWith('\n')) {
+    if (!privateKey.endsWith('\n')) {
       privateKey += '\n';
     }
     pemFile.writeAsStringSync(privateKey);
@@ -466,20 +469,19 @@ class SSHNPDImpl implements SSHNPD {
     // ssh username@targetHostName -p targetHostPort -i $pemFile -R clientForwardPort:localhost:22 \
     //     -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
     //     sleep 15
-    List<String> args = [
-      '$username@$hostname',
-      '-p', port,
-      '-i', pemFile.absolute.path,
-      '-R', '$localPort:localhost:22',
-      '-o LogLevel=VERBOSE',
-      '-t', '-t',
-      '-o', 'StrictHostKeyChecking=accept-new',
-      '-o', 'IdentitiesOnly=yes',
-      '-o', 'BatchMode=yes',
-      '-o', 'ExitOnForwardFailure=yes',
-      '-o', 'ForkAfterAuthentication=yes',
-      'sleep', '15'
-    ];
+    List<String> args = '$username@$hostname'
+            ' -p $port'
+            ' -i ${pemFile.absolute.path}'
+            ' -R $localPort:localhost:22'
+            ' -o LogLevel=VERBOSE'
+            ' -t -t'
+            ' -o StrictHostKeyChecking=accept-new'
+            ' -o IdentitiesOnly=yes'
+            ' -o BatchMode=yes'
+            ' -o ExitOnForwardFailure=yes'
+            ' -o ForkAfterAuthentication=yes'
+            ' sleep 15'
+        .split(' ');
     logger.info('$sessionId | Executing /usr/bin/ssh ${args.join(' ')}');
 
     // Because of the options we are using, we can wait for this process
@@ -501,7 +503,7 @@ class SSHNPDImpl implements SSHNPD {
         logger.info('$sessionId | sshStdErr | $s');
       }, onError: (e) {});
       sshExitCode = await process.exitCode.timeout(Duration(seconds: 10));
-    // ignore: unused_catch_clause
+      // ignore: unused_catch_clause
     } on TimeoutException catch (e) {
       sshExitCode = 6464;
     }
@@ -514,10 +516,10 @@ class SSHNPDImpl implements SSHNPD {
             '$sessionId | Command timed out: /usr/bin/ssh ${args.join(' ')}');
         errorMessage = 'Failed to establish connection - timed out';
       } else {
-        logger.shout(
-            '$sessionId | Exit code $sshExitCode from'
-                ' /usr/bin/ssh ${args.join(' ')}');
-        errorMessage = 'Failed to establish connection - exit code $sshExitCode';
+        logger.shout('$sessionId | Exit code $sshExitCode from'
+            ' /usr/bin/ssh ${args.join(' ')}');
+        errorMessage =
+            'Failed to establish connection - exit code $sshExitCode';
       }
     }
 

--- a/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
@@ -383,7 +383,6 @@ class SSHNPDImpl implements SSHNPD {
     // Because of the options we are using, we can wait for this process
     // to complete, because it will exit with exitCode 0 once it has connected
     // successfully
-    ProcessResult? result;
     late int sshExitCode;
     try {
       Process process = await Process.start('/usr/bin/ssh', args);

--- a/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
@@ -371,7 +371,7 @@ class SSHNPDImpl implements SSHNPD {
       '-v',
       '-t', '-t',
       '-o', 'StrictHostKeyChecking=no',
-      // '-o', 'IdentitiesOnly=yes',
+      '-o', 'IdentitiesOnly=yes',
       '-o', 'UserKnownHostsFile=/dev/null',
       '-o', 'BatchMode=yes',
       '-o', 'ExitOnForwardFailure=yes',

--- a/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
@@ -274,90 +274,30 @@ class SSHNPDImpl implements SSHNPD {
         'ssh session started from: ${notification.from} session: $sessionId');
 
     try {
-      final pemFile = File('/tmp/.pem-${Uuid().v4()}');
-      pemFile.writeAsStringSync(privateKey);
-      await Process.run('chmod', ['go-rwx', pemFile.absolute.path]);
+      bool success = false;
+      String? errorMessage;
 
-      bool running = true;
-      // When we receive notification 'sshd', WE are going to ssh to the host and port provided by sshnp
-      // which could be the host and port of a client machine, or the host and port of an sshrvd which is
-      // joined via socket connector to the client machine. Let's call it targetHostName/Port
-      //
-      // so: ssh username@targetHostName -p targetHostPort
-      //
-      // We're not providing a stdin so we use '-t -t' to get ssh to create a pseudo-terminal anyway
-      //
-      // We need to use the private key which the client sent to us (and we just stored in a tmp file)
-      // This is done by adding '-i <pemFile>' to the ssh command
-      //
-      // When we make the connection (remember we are the client) we want to tell the client
-      // to listen on some port and forward all connections to that port to port 22 on sshnpd's host.
-      // The incantation for that is -R clientHostPort:localhost:22
-      //
-      // We will disable strict host checking since we don't know what hosts we're going to be
-      // connecting to. We add these options:
-      // -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
-      //
-      // Lastly, we want to ensure that if the connection isn't used then it closes after 15 seconds
-      // or once the last connection via the remote port has ended. For that we append 'sleep 15' to
-      // the ssh command.
-      //
-      // Final command will look like this:
-      //
-      // ssh username@targetHostName -p targetHostPort -i $pemFile -R clientForwardPort:localhost:22 \
-      //     -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-      //     sleep 15
-      List<String> args = [
-        '$username@$hostname',
-        '-p', port,
-        '-t', '-t',
-        '-i', pemFile.absolute.path,
-        '-R', '$localPort:localhost:22',
-        '-o', 'StrictHostKeyChecking=no',
-        '-o', 'UserKnownHostsFile=/dev/null',
-        'sleep', '15'];
-      logger.info('$sessionId | Executing /usr/bin/ssh ${args.join(' ')}');
-      unawaited(Process.run('/usr/bin/ssh', args)
-        .then((ProcessResult result) {
-          running = false;
-          if (result.exitCode != 0) {
-            logger.shout('$sessionId | Non-zero exit code from /usr/bin/ssh ${args.join(' ')}');
-            logger.shout('$sessionId | stdout   : ${result.stdout}');
-            logger.shout('$sessionId | stderr   : ${result.stderr}');
-          } else {
-            logger.shout('$sessionId | ssh session ended');
-          }
-          if (pemFile.existsSync()) {
-            pemFile.deleteSync();
-          }
-        })
-          .onError((error, stackTrace) {
-            running = false;
-            if (pemFile.existsSync()) {
-              pemFile.deleteSync();
-            }
-            logger.shout('$sessionId | Error $error from running /usr/bin/ssh ${args.join(' ')}');
-      }));
-      await Future.delayed(Duration(milliseconds: 500));
-      if (pemFile.existsSync()) {
-        pemFile.deleteSync();
-      }
+      // TODO Add command line param which determines how to do the ssh
+      // 1) by executing the ssh command on the host
+      // 2) by using SSHClient
+      (success, errorMessage) = await reverseSshViaExec(
+          privateKey, username, hostname, port, localPort, logger, sessionId);
 
-      if (! running) {
-        logger.warning('Failed to forward remote port $localPort');
+      if (!success) {
+        errorMessage ??= 'Failed to forward remote port $localPort';
+        logger.warning(errorMessage);
         // Notify sshnp that this session is NOT connected
         await _notify(
           atKey,
-          'Failed to forward remote port $localPort, (use --local-port to specify unused port)',
+          '$errorMessage (use --local-port to specify unused port)',
           sessionId: sessionId,
         );
-        return;
+      } else {
+        /// Notify sshnp that the connection has been made
+        logger.info(' sshnpd connected notification sent to:from "$atKey');
+        await Future.delayed(Duration(seconds:1));
+        await _notify(atKey, "connected", sessionId: sessionId);
       }
-
-      /// Notify sshnp that the connection has been made
-      logger.info(' sshnpd connected notification sent to:from "$atKey');
-      await _notify(atKey, "connected", sessionId: sessionId);
-
     } catch (e) {
       logger.severe('SSH Client failure : $e');
       // Notify sshnp that this session is NOT connected
@@ -366,6 +306,122 @@ class SSHNPDImpl implements SSHNPD {
         'Remote SSH Client failure : $e',
         sessionId: sessionId,
       );
+    }
+  }
+
+  /// Set up a reverse ssh session. We will ssh outwards, with a remote port
+  /// forwarding to allow a client on the other side to ssh to port 22 here.
+  Future<(bool, String?)> reverseSshViaExec(
+      String privateKey,
+      String username,
+      String hostname,
+      String port,
+      String localPort,
+      AtSignLogger logger,
+      String sessionId) async {
+    final pemFile = File('/tmp/.${Uuid().v4()}');
+    if (! privateKey.endsWith('\n')) {
+      privateKey += '\n';
+    }
+    pemFile.writeAsStringSync(privateKey);
+    await Process.run('chmod', ['go-rwx', pemFile.absolute.path]);
+
+    // When we receive notification 'sshd', WE are going to ssh to the host and port provided by sshnp
+    // which could be the host and port of a client machine, or the host and port of an sshrvd which is
+    // joined via socket connector to the client machine. Let's call it targetHostName/Port
+    //
+    // so: ssh username@targetHostName -p targetHostPort
+    //
+    // We need to use the private key which the client sent to us (and we just stored in a tmp file)
+    // This is done by adding '-i <pemFile>' to the ssh command
+    //
+    // When we make the connection (remember we are the client) we want to tell the client
+    // to listen on some port and forward all connections to that port to port 22 on sshnpd's host.
+    // The incantation for that is -R clientHostPort:localhost:22
+    //
+    // We will disable strict host checking since we don't know what hosts we're going to be
+    // connecting to. We add these options:
+    // -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+    //
+    // We don't want keyboard interactive: we add -o BatchMode=yes
+    //
+    // For convenience of this SSHNPD, we would like to know as quickly
+    // as possible if the ssh connection has succeeded or not.
+    // So we will add options 'ForkAfterAuthentication=yes' and also
+    // 'ExitOnForwardFailure=yes' so that it won't fork until after
+    // all of the forwarding has been successfully set up.
+    // This allows us to do a simple Process.run() knowing we will get an exit
+    // code 0 promptly if the ssh connection has succeeded, and the ssh
+    // connection can run happily in the background.
+    //
+    // Lastly, we want to ensure that if the connection isn't used then it closes after 15 seconds
+    // or once the last connection via the remote port has ended. For that we append 'sleep 15' to
+    // the ssh command.
+    //
+    // Final command will look like this:
+    //
+    // ssh username@targetHostName -p targetHostPort -i $pemFile -R clientForwardPort:localhost:22 \
+    //     -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+    //     sleep 15
+    List<String> args = [
+      '$username@$hostname',
+      '-p', port,
+      '-i', pemFile.absolute.path,
+      '-R', '$localPort:localhost:22',
+      '-v',
+      '-t', '-t',
+      '-o', 'StrictHostKeyChecking=no',
+      '-o', 'IdentitiesOnly=yes',
+      '-o', 'UserKnownHostsFile=/dev/null',
+      '-o', 'BatchMode=yes',
+      '-o', 'ExitOnForwardFailure=yes',
+      '-o', 'ForkAfterAuthentication=yes',
+      'sleep', '15'
+    ];
+    logger.info('$sessionId | Executing /usr/bin/ssh ${args.join(' ')}');
+
+    // Because of the options we are using, we can wait for this process
+    // to complete, because it will exit with exitCode 0 once it has connected
+    // successfully
+    ProcessResult? result;
+    late int sshExitCode;
+    try {
+      result =
+      await Process.run('/usr/bin/ssh', args).timeout(Duration(seconds: 10));
+      sshExitCode = result.exitCode;
+    // ignore: unused_catch_clause
+    } on TimeoutException catch (e) {
+      sshExitCode = 6464;
+    }
+    cleanupPemFile(pemFile);
+
+    String? errorMessage;
+    if (sshExitCode != 0) {
+      if (sshExitCode == 6464) {
+        logger.shout(
+            '$sessionId | Command timed out: /usr/bin/ssh ${args.join(' ')}');
+        errorMessage = 'Failed to establish connection - timed out';
+      } else {
+        logger.shout(
+            '$sessionId | Exit code $sshExitCode from'
+                ' /usr/bin/ssh ${args.join(' ')}');
+        logger.shout('$sessionId | stdout   : ${result?.stdout}');
+        logger.shout('$sessionId | stderr   : ${result?.stderr}');
+        errorMessage = 'Failed to establish connection - exit code $sshExitCode';
+      }
+    }
+
+    return (sshExitCode == 0, errorMessage);
+  }
+
+  void cleanupPemFile(File pemFile) {
+    /// Clean up tmp file
+    if (pemFile.existsSync()) {
+      try {
+        pemFile.deleteSync();
+      } catch (e) {
+        logger.shout('Failed to clean up a pem : $e');
+      }
     }
   }
 

--- a/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
@@ -371,7 +371,7 @@ class SSHNPDImpl implements SSHNPD {
       '-v',
       '-t', '-t',
       '-o', 'StrictHostKeyChecking=no',
-      '-o', 'IdentitiesOnly=yes',
+      // '-o', 'IdentitiesOnly=yes',
       '-o', 'UserKnownHostsFile=/dev/null',
       '-o', 'BatchMode=yes',
       '-o', 'ExitOnForwardFailure=yes',
@@ -386,9 +386,8 @@ class SSHNPDImpl implements SSHNPD {
     ProcessResult? result;
     late int sshExitCode;
     try {
-      result =
-      await Process.run('/usr/bin/ssh', args).timeout(Duration(seconds: 10));
-      sshExitCode = result.exitCode;
+      Process process = await Process.start('/usr/bin/ssh', args);
+      sshExitCode = await process.exitCode.timeout(Duration(seconds: 10));
     // ignore: unused_catch_clause
     } on TimeoutException catch (e) {
       sshExitCode = 6464;

--- a/packages/sshnoports/lib/sshnpd/sshnpd_params.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_params.dart
@@ -1,4 +1,5 @@
 import 'package:args/args.dart';
+import 'package:sshnoports/common/supported_ssh_clients.dart';
 import 'package:sshnoports/common/utils.dart';
 
 class SSHNPDParams {
@@ -10,6 +11,7 @@ class SSHNPDParams {
   late final String sendSshPublicKey;
   late final String deviceAtsign;
   late final bool verbose;
+  late final SupportedSshClient sshClient;
 
   // Non param variables
   static final ArgParser parser = _createArgParser();
@@ -38,6 +40,9 @@ class SSHNPDParams {
         r['key-file'] ?? getDefaultAtKeysFilePath(homeDirectory, deviceAtsign);
 
     verbose = r['verbose'];
+
+    sshClient = SupportedSshClient.values
+        .firstWhere((c) => c.cliArg == r['ssh-client']);
   }
 
   static ArgParser _createArgParser() {
@@ -88,6 +93,12 @@ class SSHNPDParams {
       abbr: 'v',
       help: 'More logging',
     );
+
+    parser.addOption('ssh-client',
+        mandatory: false,
+        defaultsTo: SupportedSshClient.hostSsh.cliArg,
+        allowed: SupportedSshClient.values.map((c) => c.cliArg).toList(),
+        help: 'What to use for outbound ssh connections.');
 
     return parser;
   }

--- a/packages/sshnoports/pubspec.lock
+++ b/packages/sshnoports/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: at_commons
-      sha256: a621036d44e9b59e14655b4723703dc0b711a1ad9f41f36ad75f29cf52658fbb
+      sha256: "1e8c6b981f9797ee8b902efc1dc17c85245d61a272d4f2f735070b98a2d55871"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.51"
+    version: "3.0.52"
   at_lookup:
     dependency: "direct main"
     description:
@@ -225,14 +225,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.8"
-  dartssh2:
-    dependency: "direct main"
-    description:
-      name: dartssh2
-      sha256: "53a230c7dd6f487b704ceef1b29323ad64d19be89e786ccbc81e157a70417a56"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.8.2"
   ecdsa:
     dependency: transitive
     description:
@@ -449,14 +441,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.0"
-  pinenacl:
-    dependency: transitive
-    description:
-      name: pinenacl
-      sha256: "3a5503637587d635647c93ea9a8fecf48a420cc7deebe6f1fc85c2a5637ab327"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.1"
   pointycastle:
     dependency: transitive
     description:
@@ -545,14 +529,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
-  ssh_key:
-    dependency: "direct main"
-    description:
-      name: ssh_key
-      sha256: ded1af84f2c34748c000101940e7b9a63a077c9a136aaab85dbf54a6e9d19ec8
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.8.0"
   stack_trace:
     dependency: transitive
     description:
@@ -609,14 +585,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.4"
-  tuple:
-    dependency: transitive
-    description:
-      name: tuple
-      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.2"
   typed_data:
     dependency: transitive
     description:

--- a/packages/sshnoports/pubspec.lock
+++ b/packages/sshnoports/pubspec.lock
@@ -225,6 +225,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.8"
+  dartssh2:
+    dependency: "direct main"
+    description:
+      name: dartssh2
+      sha256: "53a230c7dd6f487b704ceef1b29323ad64d19be89e786ccbc81e157a70417a56"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.8.2"
   ecdsa:
     dependency: transitive
     description:
@@ -441,6 +449,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.0"
+  pinenacl:
+    dependency: transitive
+    description:
+      name: pinenacl
+      sha256: "3a5503637587d635647c93ea9a8fecf48a420cc7deebe6f1fc85c2a5637ab327"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
   pointycastle:
     dependency: transitive
     description:
@@ -529,6 +545,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  ssh_key:
+    dependency: "direct main"
+    description:
+      name: ssh_key
+      sha256: ded1af84f2c34748c000101940e7b9a63a077c9a136aaab85dbf54a6e9d19ec8
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.0"
   stack_trace:
     dependency: transitive
     description:
@@ -585,6 +609,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.4"
+  tuple:
+    dependency: transitive
+    description:
+      name: tuple
+      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   typed_data:
     dependency: transitive
     description:

--- a/packages/sshnoports/pubspec.lock
+++ b/packages/sshnoports/pubspec.lock
@@ -225,14 +225,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.8"
-  dartssh2:
-    dependency: "direct main"
-    description:
-      name: dartssh2
-      sha256: "53a230c7dd6f487b704ceef1b29323ad64d19be89e786ccbc81e157a70417a56"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.8.2"
   ecdsa:
     dependency: transitive
     description:
@@ -449,14 +441,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.0"
-  pinenacl:
-    dependency: transitive
-    description:
-      name: pinenacl
-      sha256: "3a5503637587d635647c93ea9a8fecf48a420cc7deebe6f1fc85c2a5637ab327"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.1"
   pointycastle:
     dependency: transitive
     description:
@@ -545,14 +529,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
-  ssh_key:
-    dependency: "direct main"
-    description:
-      name: ssh_key
-      sha256: ded1af84f2c34748c000101940e7b9a63a077c9a136aaab85dbf54a6e9d19ec8
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.8.0"
   stack_trace:
     dependency: transitive
     description:
@@ -609,14 +585,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.4"
-  tuple:
-    dependency: transitive
-    description:
-      name: tuple
-      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.2"
   typed_data:
     dependency: transitive
     description:

--- a/packages/sshnoports/pubspec.yaml
+++ b/packages/sshnoports/pubspec.yaml
@@ -17,8 +17,6 @@ dependencies:
   at_onboarding_cli: 1.3.0
   at_utils: 3.0.15
   crypton: 2.1.0
-  dartssh2: 2.8.2
-  ssh_key: ">=0.7.1 <0.9.0"
   uuid: 3.0.7
   logging: 1.2.0
   version: 3.0.2

--- a/packages/sshnoports/pubspec.yaml
+++ b/packages/sshnoports/pubspec.yaml
@@ -17,6 +17,8 @@ dependencies:
   at_onboarding_cli: 1.3.0
   at_utils: 3.0.15
   crypton: 2.1.0
+  dartssh2: 2.8.2
+  ssh_key: ">=0.7.1 <0.9.0"
   uuid: 3.0.7
   logging: 1.2.0
   version: 3.0.2

--- a/packages/sshnoports/test/sshnpd_test.dart
+++ b/packages/sshnoports/test/sshnpd_test.dart
@@ -1,3 +1,4 @@
+import 'package:sshnoports/common/supported_ssh_clients.dart';
 import 'package:sshnoports/sshnpd/sshnpd_params.dart';
 import 'package:test/test.dart';
 import 'package:args/args.dart';
@@ -22,10 +23,7 @@ void main() {
     });
 
     test('test parsed args with only mandatory provided', () {
-      List<String> args = [];
-
-      args.addAll(['-a', '@bob']);
-      args.addAll(['-m', '@alice']);
+      List<String> args = '-a @bob -m @alice'.split(' ');
 
       var p = SSHNPDParams.fromArgs(args);
 
@@ -40,20 +38,31 @@ void main() {
           getDefaultAtKeysFilePath(p.homeDirectory, p.deviceAtsign));
     });
 
+    test('test --ssh-client arg', () {
+      expect(SSHNPDParams.fromArgs('-a @bob -m @alice'.split(' ')).sshClient,
+          SupportedSshClient.hostSsh);
+
+      expect(
+          SSHNPDParams.fromArgs(
+                  '-a @bob -m @alice --ssh-client pure-dart'.split(' '))
+              .sshClient,
+          SupportedSshClient.pureDart);
+
+      expect(
+          SSHNPDParams.fromArgs(
+                  '-a @bob -m @alice --ssh-client /usr/bin/ssh'.split(' '))
+              .sshClient,
+          SupportedSshClient.hostSsh);
+
+      expect(
+          () => SSHNPDParams.fromArgs(
+              '-a @bob -m @alice --ssh-client something-we-do-not-support'
+                  .split(' ')),
+          throwsA(isA<ArgParserException>()));
+    });
+
     test('test parsed args with non-mandatory args provided', () {
-      List<String> args = [];
-
-      args.addAll(['-a', '@bob']);
-      args.addAll(['-m', '@alice']);
-
-      args.addAll([
-        '-d',
-        'device',
-        '-u',
-        '-v',
-        '-s',
-        '-u',
-      ]);
+      List<String> args = '-a @bob -m @alice -d device -u -v -s -u'.split(' ');
 
       var p = SSHNPDParams.fromArgs(args);
 


### PR DESCRIPTION
**- What I did**
- feat: For perf reasons, by default we will have SSHNPDImpl directly execute the ssh command on the host rather than using SSHClient
  - writes privatekey which it received earlier from sshnp into a tmp file which is later deleted
  - added a bunch of comments explaining how the command is constructed and why
- refactor: remove _sshPublicKey instance variable from SSHNPDImpl and make it a local variable in the `case 'sshpublickey'` in the notification handler
- feat: Direct AtSignLogger log messages to stdErr for sshnpd, sshnp and sshrvd via `AtSignLogger.defaultLoggingHandler = AtSignLogger.stdErrLoggingHandler;`
- feat: Added command-line option `--ssh-client` which can currently have values '/usr/bin/ssh' (the default) or 'pure-dart'. If set to `pure-dart` then we'll do it using SSHClient as we used to.
- feat: added more command-line options to the ssh command which sshnp generates and prints to stdout
  - `-o StrictHostKeyChecking=accept-new` to silently accept new, but still check existing
  - `-o IdentitiesOnly=yes` to use only the identity in the specified identity file