### PR TITLE
ci: fixed "without sync" tests

### DIFF
--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -47,11 +47,11 @@ jobs:
             rvd_atsign: "@8485wealthy51"
             wait: 4
 
-          - np: latest
-            npd: latest
-            rvd: local
-            rvd_atsign: "@8485wealthy51"
-            wait: 4
+          # - np: latest
+          #   npd: latest
+          #   rvd: local
+          #   rvd_atsign: "@8485wealthy51"
+          #   wait: 4
 
           ### BACKWARD TESTS WITHOUT SYNC ###
           - np: local

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -41,17 +41,17 @@ jobs:
             npd: trunk
         include:
           ### RVD TESTS ###
-          - np: local
-            npd: local
-            rvd: local
-            rvd_atsign: "@8485wealthy51"
-            wait: 4
-
-          # - np: latest
-          #   npd: latest
+          # - np: local
+          #   npd: local
           #   rvd: local
           #   rvd_atsign: "@8485wealthy51"
           #   wait: 4
+
+          - np: latest
+            npd: latest
+            rvd: local
+            rvd_atsign: "@8485wealthy51"
+            wait: 4
 
           ### BACKWARD TESTS WITHOUT SYNC ###
           - np: local

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -52,19 +52,24 @@ jobs:
             npd: latest
             rvd: local
             rvd_atsign: "@8485wealthy51"
+            wait: 4
 
           ### BACKWARD TESTS WITHOUT SYNC ###
           - np: local
             npd: latest
+            wait: 4
 
           - np: latest
             npd: local
+            wait: 4
 
           - np: local
             npd: v3.3.0
+            wait: 4
 
           - np: v3.3.0
             npd: local
+            wait: 4
 
           ### BACKWARD TESTS WHICH NEED SYNC ###
           - np: local

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -45,24 +45,30 @@ jobs:
             npd: local
             rvd: local
             rvd_atsign: "@8485wealthy51"
+            wait: 4
 
           - np: latest
             npd: latest
             rvd: local
             rvd_atsign: "@8485wealthy51"
+            wait: 4
 
           ### BACKWARD TESTS WITHOUT SYNC ###
           - np: local
             npd: latest
+            wait: 4
 
           - np: latest
             npd: local
+            wait: 4
 
           - np: local
             npd: v3.3.0
+            wait: 4
 
           - np: v3.3.0
             npd: local
+            wait: 4
 
           ### BACKWARD TESTS WHICH NEED SYNC ###
           - np: local

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -35,6 +35,7 @@ jobs:
       matrix:
         np: [local, trunk]
         npd: [local, trunk]
+        wait: [4]
         exclude:
           # Don't run these against themselves, they're irrelevant
           - np: trunk
@@ -51,24 +52,19 @@ jobs:
             npd: latest
             rvd: local
             rvd_atsign: "@8485wealthy51"
-            wait: 4
 
           ### BACKWARD TESTS WITHOUT SYNC ###
           - np: local
             npd: latest
-            wait: 4
 
           - np: latest
             npd: local
-            wait: 4
 
           - np: local
             npd: v3.3.0
-            wait: 4
 
           - np: v3.3.0
             npd: local
-            wait: 4
 
           ### BACKWARD TESTS WHICH NEED SYNC ###
           - np: local
@@ -89,12 +85,12 @@ jobs:
     steps:
       - name: Show Matrix Values
         run: |
-          echo ${{ strategy.job-index }}
-          echo ${{ matrix.np }}
-          echo ${{ matrix.npd }}
-          echo ${{ matrix.rvd }}
-          echo ${{ matrix.rvd_atsign || env.DEFAULT_RVD_ATSIGN }}
-          echo ${{ matrix.wait }}
+          echo "job index: ${{ strategy.job-index }}"
+          echo "np: ${{ matrix.np }}"
+          echo "npd: ${{ matrix.npd }}"
+          echo "rvd: ${{ matrix.rvd }}"
+          echo "rvd: ${{ matrix.rvd_atsign || env.DEFAULT_RVD_ATSIGN }}"
+          echo "wait: ${{ matrix.wait }}"
 
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 

--- a/tests/end2end_tests/templates/sshnp_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnp_entrypoint.sh
@@ -21,7 +21,7 @@ then
         exit 1
     fi
 fi
-
 echo " -o StrictHostKeyChecking=no " >> sshcommand.txt ;
+echo "ssh -p command: $(cat sshcommand.txt)"
 echo "sh test.sh " | $(cat sshcommand.txt)
 sleep 2 # time for ssh connection to properly exit

--- a/tests/end2end_tests/tests/docker-compose.yaml
+++ b/tests/end2end_tests/tests/docker-compose.yaml
@@ -9,7 +9,7 @@ networks:
 services:
   image-runtime-local:
     build:
-      context: ../../../
+      context: ../
       dockerfile: ./tests/end2end_tests/image/Dockerfile
       target: runtime-local
     image: atsigncompany/sshnp-e2e-runtime:local

--- a/tests/end2end_tests/tests/docker-compose.yaml
+++ b/tests/end2end_tests/tests/docker-compose.yaml
@@ -9,7 +9,7 @@ networks:
 services:
   image-runtime-local:
     build:
-      context: ../
+      context: ../../../
       dockerfile: ./tests/end2end_tests/image/Dockerfile
       target: runtime-local
     image: atsigncompany/sshnp-e2e-runtime:local

--- a/tests/end2end_tests/tests/service-image-runtime-release.yaml
+++ b/tests/end2end_tests/tests/service-image-runtime-release.yaml
@@ -8,6 +8,6 @@
       target: runtime-release
       args:
         # auto added:
-        # - branch
+        # - release
     # auto added:
     # - image


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- added `wait: 4` because `default: 4` in the composite action was not working
- commented out local-local-local (it wasn't running anyways), and we cannot run multiple RVD instances under the same atSign simultaneously 
- now echos what the `ssh -p` that the sshnp container is running

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->