### PR TITLE
chore: handle errors for SSHNP Params when it reads config files

### DIFF
--- a/packages/sshnoports/bin/sshnp.dart
+++ b/packages/sshnoports/bin/sshnp.dart
@@ -12,8 +12,14 @@ import 'package:sshnoports/sshnp/sshnp_params.dart';
 void main(List<String> args) async {
   AtSignLogger.root_level = 'SHOUT';
   SSHNP? sshnp;
+  SSHNPParams? params;
 
-  var params = SSHNPParams.fromPartial(SSHNPPartialParams.fromArgs(args));
+  try {
+    params = SSHNPParams.fromPartial(SSHNPPartialParams.fromArgs(args));
+  } catch (error) {
+    stderr.writeln(error.toString());
+    exit(1);
+  }
 
   try {
     sshnp = await SSHNP.fromParams(params);

--- a/packages/sshnoports/lib/sshnp/sshnp_params.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_params.dart
@@ -236,40 +236,50 @@ class SSHNPPartialParams {
     Map<String, dynamic> args = <String, dynamic>{};
 
     File file = File(fileName);
-    List<String> lines = file.readAsLinesSync();
 
-    for (String line in lines) {
-      if (line.startsWith('#')) continue;
-
-      var parts = line.split('=');
-      if (parts.length != 2) continue;
-
-      var key = parts[0].trim();
-      var value = parts[1].trim();
-
-      SSHNPArg arg = SSHNPArg.fromBashName(key);
-      if (arg.name.isEmpty) continue;
-
-      switch (arg.format) {
-        case ArgFormat.flag:
-          if (value.toLowerCase() == 'true') {
-            args[arg.name] = true;
-          }
-          continue;
-        case ArgFormat.multiOption:
-          var values = value.split(';');
-          args.putIfAbsent(arg.name, () => <String>[]);
-          for (String val in values) {
-            if (val.isEmpty) continue;
-            args[arg.name].add(val);
-          }
-          continue;
-        case ArgFormat.option:
-          if (value.isEmpty) continue;
-          args[arg.name] = value;
-          continue;
-      }
+    if (!file.existsSync()) {
+      throw Exception('Config file does not exist: $fileName');
     }
-    return args;
+    try {
+      List<String> lines = file.readAsLinesSync();
+
+      for (String line in lines) {
+        if (line.startsWith('#')) continue;
+
+        var parts = line.split('=');
+        if (parts.length != 2) continue;
+
+        var key = parts[0].trim();
+        var value = parts[1].trim();
+
+        SSHNPArg arg = SSHNPArg.fromBashName(key);
+        if (arg.name.isEmpty) continue;
+
+        switch (arg.format) {
+          case ArgFormat.flag:
+            if (value.toLowerCase() == 'true') {
+              args[arg.name] = true;
+            }
+            continue;
+          case ArgFormat.multiOption:
+            var values = value.split(';');
+            args.putIfAbsent(arg.name, () => <String>[]);
+            for (String val in values) {
+              if (val.isEmpty) continue;
+              args[arg.name].add(val);
+            }
+            continue;
+          case ArgFormat.option:
+            if (value.isEmpty) continue;
+            args[arg.name] = value;
+            continue;
+        }
+      }
+      return args;
+    } on FileSystemException {
+      throw Exception('Error reading config file: $fileName');
+    } catch (e) {
+      throw Exception('Error parsing config file: $fileName');
+    }
   }
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

fixes #268 

**- What I did**

- New try block for param instantiation in the main function
- Throw different exceptions within SSHNPPartialParams based on: file existence, failed to read, failed to parse

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: handle errors for SSHNP Params when it reads config files
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->