### PR TITLE
fix: Correcting typo/bug in sshnp

### DIFF
--- a/packages/sshnoports/lib/sshnp/sshnp_impl.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_impl.dart
@@ -378,7 +378,7 @@ class SSHNPImpl implements SSHNP {
             ' -o IdentitiesOnly=yes'
             ' -i ${sendSshPublicKey.replaceFirst(RegExp(r'.pub$'), '')}');
       } else {
-        stdout.write('ssh -p $localPort $remoteUsername@localhost -o ssh'
+        stdout.write('ssh -p $localPort $remoteUsername@localhost '
             ' -o StrictHostKeyChecking=accept-new');
       }
       // print out optional arguments


### PR DESCRIPTION
**- What I did**
Came across bug when using sshnp with specifying the ssh key to be used (its in my .ssh/config). Found typo that is not caught in end to end tests @JeremyTubongbanua perhaps add one!
**- How I did it**
removed odd `-o ssh` text
**- How to verify it**
compiled and run manually
**- Description for the changelog**
Typo prevents ssh command to run if cut and paste. This only hits if no ssh key is specified with -s
