### PR TITLE
fix: do pub get instead of pub upgrade

### DIFF
--- a/tools/package-macos-arm64.sh
+++ b/tools/package-macos-arm64.sh
@@ -21,7 +21,7 @@ else
   DART=$(which dart)
 fi
 
-eval "$DART pub upgrade -C $SRC_DIR"
+eval "$DART pub get -C $SRC_DIR"
 
 OUTPUT_DIR_PATH="$ROOT_DIRECTORY/build/macos-arm64"
 OUTPUT_DIR="$OUTPUT_DIR_PATH/sshnp"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Changed a line in the package macos arm64 tool from pub upgrade to pub get, since this causes breaking changes if there is a major update in a dependency.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: do pub get instead of pub upgrade
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->