### PR TITLE
test: at_client's Monitor's call to socket.listen() wrapped in runZonedGuarded

### DIFF
--- a/packages/sshnoports/pubspec.lock
+++ b/packages/sshnoports/pubspec.lock
@@ -68,10 +68,11 @@ packages:
   at_client:
     dependency: "direct main"
     description:
-      name: at_client
-      sha256: "63652edf7f856b875b59002bd48c2df3a5848aab0ac34fea12f07b02d2036db3"
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/at_client"
+      ref: gkc-runZonedGuarded-monitor-socket-listen
+      resolved-ref: "14ffe9718047250e05d5a0397b9f611993f38e19"
+      url: "https://github.com/atsign-foundation/at_client_sdk.git"
+    source: git
     version: "3.0.63"
   at_commons:
     dependency: transitive

--- a/packages/sshnoports/pubspec.yaml
+++ b/packages/sshnoports/pubspec.yaml
@@ -25,6 +25,12 @@ dependencies:
   socket_connector: 1.0.10
   meta: ^1.9.1
 
+dependency_overrides:
+  at_client:
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk.git
+      path: packages/at_client
+      ref: gkc-runZonedGuarded-monitor-socket-listen
 dev_dependencies:
   lints: ^2.1.1
   test: ^1.24.3


### PR DESCRIPTION
**- What I did**
test: added dependency override to use a branch of at_client package which wraps the Monitor's call to `socket.listen()` in a `runZonedGuarded` block

**- How I did it**

**- How to verify it**
Tests pass

