### PR TITLE
refactor: sshnpd container - move test.txt as a volume

### DIFF
--- a/tests/end2end_tests/contexts/sshnpd/test.txt
+++ b/tests/end2end_tests/contexts/sshnpd/test.txt
@@ -1,0 +1,7 @@
+======
+
+Test Passed
+
+This is a text file in sshnpd to test that sshnp ssh'd correctly.
+
+======

--- a/tests/end2end_tests/templates/sshnpd_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnpd_entrypoint.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-echo "Test Passed" > test.txt
 SSHNPD_COMMAND="~/.local/bin/sshnpd -a @sshnpdatsign -m @sshnpatsign -d deviceName -s -u -v"
 echo "Running: $SSHNPD_COMMAND"
 eval $SSHNPD_COMMAND
-

--- a/tests/end2end_tests/tests/service-container-sshnpd.yaml
+++ b/tests/end2end_tests/tests/service-container-sshnpd.yaml
@@ -4,6 +4,7 @@
       - ../contexts/sshnpd/keys/:/atsign/.atsign/keys/ # mount keys
       - ../contexts/sshnpd/entrypoint.sh:/atsign/entrypoint.sh # mount entrypoint.sh
       - ../contexts/sshnpd/test.sh:/atsign/test.sh # mount test.sh
+      - ../contexts/sshnpd/test.txt/:/atsign/test.txt/ # mount test.txt
     networks:
       - sshnpd
     # auto added:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- instead of using `echo` to create a file in the entrypoint of sshnpd, let's just create the file instead and use it as a volume. 
- this is an alternative way of just creating a file that says "Test Passed"
- hopefully makes it more visible as to how the end to end tests work

**- How I did it**

- see changes

**- How to verify it**

- tests are still passing but with the updated message in .txt

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->