### PR TITLE
feat: cease using internet_connection_checker

### DIFF
--- a/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
@@ -164,19 +164,21 @@ class SSHNPDImpl implements SSHNPD {
 
   void startHeartbeat() {
     bool lastHeartbeatOk = true;
-    Timer.periodic(Duration(seconds:15), (timer) async {
-      String? resp = await atClient.getRemoteSecondary()?.atLookUp.executeCommand('noop:0\n');
+    Timer.periodic(Duration(seconds: 15), (timer) async {
+      String? resp = await atClient
+          .getRemoteSecondary()
+          ?.atLookUp
+          .executeCommand('noop:0\n');
       if (resp == null || !resp.startsWith('noop:0')) {
         logger.warning('connection lost');
         lastHeartbeatOk = false;
       } else {
-        if (! lastHeartbeatOk) {
+        if (!lastHeartbeatOk) {
           logger.warning('connection available');
         }
         lastHeartbeatOk = true;
       }
     });
-
   }
 
   void _notificationHandler(AtNotification notification) async {

--- a/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
@@ -148,15 +148,8 @@ class SSHNPDImpl implements SSHNPD {
       }
     }
 
-    logger.info('Starting connectivity listener');
-    // Keep an eye on connectivity and report failures if we see them
-    ConnectivityListener().subscribe().listen((isConnected) {
-      if (isConnected) {
-        logger.warning('connection available');
-      } else {
-        logger.warning('connection lost');
-      }
-    });
+    logger.info('Starting heartbeat');
+    startHeartbeat();
 
     logger.info('Subscribing to $device\\.${SSHNPD.namespace}@');
     notificationService
@@ -167,6 +160,23 @@ class SSHNPDImpl implements SSHNPD {
           onDone: () => logger.info('Notification listener stopped'),
         );
     logger.info('Done');
+  }
+
+  void startHeartbeat() {
+    bool lastHeartbeatOk = true;
+    Timer.periodic(Duration(seconds:30), (timer) async {
+      String? resp = await atClient.getRemoteSecondary()?.atLookUp.executeCommand('noop:0\n');
+      if (resp == null || !resp.startsWith('noop:0')) {
+        logger.warning('connection lost');
+        lastHeartbeatOk = false;
+      } else {
+        if (! lastHeartbeatOk) {
+          logger.warning('connection available');
+        }
+        lastHeartbeatOk = true;
+      }
+    });
+
   }
 
   void _notificationHandler(AtNotification notification) async {

--- a/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
@@ -170,7 +170,9 @@ class SSHNPDImpl implements SSHNPD {
           ?.atLookUp
           .executeCommand('noop:0\n');
       if (resp == null || !resp.startsWith('data:ok')) {
-        logger.warning('connection lost');
+        if (lastHeartbeatOk) {
+          logger.warning('connection lost');
+        }
         lastHeartbeatOk = false;
       } else {
         if (!lastHeartbeatOk) {

--- a/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
@@ -164,7 +164,7 @@ class SSHNPDImpl implements SSHNPD {
 
   void startHeartbeat() {
     bool lastHeartbeatOk = true;
-    Timer.periodic(Duration(seconds:30), (timer) async {
+    Timer.periodic(Duration(seconds:15), (timer) async {
       String? resp = await atClient.getRemoteSecondary()?.atLookUp.executeCommand('noop:0\n');
       if (resp == null || !resp.startsWith('noop:0')) {
         logger.warning('connection lost');

--- a/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
@@ -165,18 +165,21 @@ class SSHNPDImpl implements SSHNPD {
   void startHeartbeat() {
     bool lastHeartbeatOk = true;
     Timer.periodic(Duration(seconds: 15), (timer) async {
-      String? resp = await atClient
-          .getRemoteSecondary()
-          ?.atLookUp
-          .executeCommand('noop:0\n');
+      String? resp;
+      try {
+        resp = await atClient
+            .getRemoteSecondary()
+            ?.atLookUp
+            .executeCommand('noop:0\n');
+      } catch (_) {}
       if (resp == null || !resp.startsWith('data:ok')) {
         if (lastHeartbeatOk) {
-          logger.warning('connection lost');
+          logger.shout('connection lost');
         }
         lastHeartbeatOk = false;
       } else {
         if (!lastHeartbeatOk) {
-          logger.warning('connection available');
+          logger.shout('connection available');
         }
         lastHeartbeatOk = true;
       }

--- a/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
@@ -169,7 +169,7 @@ class SSHNPDImpl implements SSHNPD {
           .getRemoteSecondary()
           ?.atLookUp
           .executeCommand('noop:0\n');
-      if (resp == null || !resp.startsWith('noop:0')) {
+      if (resp == null || !resp.startsWith('data:ok')) {
         logger.warning('connection lost');
         lastHeartbeatOk = false;
       } else {

--- a/packages/sshnoports/pubspec.lock
+++ b/packages/sshnoports/pubspec.lock
@@ -68,11 +68,10 @@ packages:
   at_client:
     dependency: "direct main"
     description:
-      path: "packages/at_client"
-      ref: trunk
-      resolved-ref: "65fb64b39d4eae484c342f23f4614df04d9cd397"
-      url: "https://github.com/atsign-foundation/at_client_sdk.git"
-    source: git
+      name: at_client
+      sha256: c7f8316fe97faf010e0698d7e0bd81e35cc39644bf2dcd69a22cf25ba914b8c5
+      url: "https://pub.dev"
+    source: hosted
     version: "3.0.64"
   at_commons:
     dependency: transitive

--- a/packages/sshnoports/pubspec.lock
+++ b/packages/sshnoports/pubspec.lock
@@ -68,11 +68,12 @@ packages:
   at_client:
     dependency: "direct main"
     description:
-      name: at_client
-      sha256: "63652edf7f856b875b59002bd48c2df3a5848aab0ac34fea12f07b02d2036db3"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.63"
+      path: "packages/at_client"
+      ref: trunk
+      resolved-ref: "65fb64b39d4eae484c342f23f4614df04d9cd397"
+      url: "https://github.com/atsign-foundation/at_client_sdk.git"
+    source: git
+    version: "3.0.64"
   at_commons:
     dependency: transitive
     description:
@@ -173,10 +174,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -221,10 +222,10 @@ packages:
     dependency: transitive
     description:
       name: dart_internal
-      sha256: dae3976f383beddcfcd07ad5291a422df2c8c0a8a03c52cda63ac7b4f26e0f4e
+      sha256: "689dccc3d5f62affd339534cca548dce12b3a6b32f0f10861569d3025efc0567"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.8"
+    version: "0.2.9"
   dartssh2:
     dependency: "direct main"
     description:
@@ -589,10 +590,10 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "67ec5684c7a19b2aba91d2831f3d305a6fd8e1504629c5818f8d64478abf4f38"
+      sha256: b9a384c4b9c4966dbf7215e7c033a78db1da7e5dcaf8da9232c5f24735f65652
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.4"
+    version: "1.24.5"
   test_api:
     dependency: transitive
     description:
@@ -605,10 +606,10 @@ packages:
     dependency: transitive
     description:
       name: test_core
-      sha256: "6b753899253c38ca0523bb0eccff3934ec83d011705dae717c61ecf209e333c9"
+      sha256: c6a536288535efef8526eea8adfa4e25fdd2849fa7f457ecb2a52099998ce8f7
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.4"
+    version: "0.5.5"
   tuple:
     dependency: transitive
     description:
@@ -698,4 +699,4 @@ packages:
     source: hosted
     version: "0.2.0"
 sdks:
-  dart: ">=3.0.0 <3.2.0"
+  dart: ">=3.0.0 <3.3.0"

--- a/packages/sshnoports/pubspec.yaml
+++ b/packages/sshnoports/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   args: 2.4.2
-  at_client: 3.0.63
+  at_client: 3.0.64
   at_lookup: 3.0.38
   at_onboarding_cli: 1.3.0
   at_utils: 3.0.15
@@ -24,13 +24,6 @@ dependencies:
   version: 3.0.2
   socket_connector: 1.0.10
   meta: ^1.9.1
-
-dependency_overrides:
-  at_client:
-    git:
-      url: https://github.com/atsign-foundation/at_client_sdk.git
-      ref: trunk
-      path: packages/at_client
 
 dev_dependencies:
   lints: ^2.1.1

--- a/packages/sshnoports/pubspec.yaml
+++ b/packages/sshnoports/pubspec.yaml
@@ -25,7 +25,14 @@ dependencies:
   socket_connector: 1.0.10
   meta: ^1.9.1
 
+dependency_overrides:
+  at_client:
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk.git
+      ref: trunk
+      path: packages/at_client
+
 dev_dependencies:
   lints: ^2.1.1
-  test: ^1.24.3
+  test: ^1.24.4
   mocktail: ^0.3.0


### PR DESCRIPTION
Closes #292 . This PR will complete one of the tasks identified in #292 ; the other two tasks are completed by the changes in [this at_client PR](https://github.com/atsign-foundation/at_client_sdk/pull/1100) which have now been released in [version 3.0.64](https://pub.dev/packages/at_client/changelog) of the `at_client` package

**- What I did**
feat: cease using internet_connection_checker

**- How I did it**
- use latest version of at_client, v3.0.64, which eliminates all usage within the at_client package itself of the internet_connection_checker package
- removed usage of internet_connection_checker package by removing usage of at_client's now-deprecated ConnectivityListener
- replaced with a simple periodic heartbeat check

**- How to verify it**
- automated tests pass
- run sshnpd; take down your connection to internet; should see a message `connection lost` within at most 25 seconds; bring the internet connection back up; should see a message `connection available` within 15-20 seconds

**- Description for the changelog**
feat: cease using internet_connection_checker
