### PR TITLE
ci: extend wait duration for <=3.2.0 npd

### DIFF
--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -74,11 +74,11 @@ jobs:
           ### BACKWARD TESTS WHICH NEED SYNC ###
           - np: local
             npd: v3.1.2
-            wait: 30
+            wait: 60
 
           - np: local
             npd: v3.2.0
-            wait: 30
+            wait: 60
 
           - np: v3.1.2
             npd: local
@@ -94,7 +94,7 @@ jobs:
           echo "np: ${{ matrix.np }}"
           echo "npd: ${{ matrix.npd }}"
           echo "rvd: ${{ matrix.rvd }}"
-          echo "rvd: ${{ matrix.rvd_atsign || env.DEFAULT_RVD_ATSIGN }}"
+          echo "rvd_atsign: ${{ matrix.rvd_atsign || env.DEFAULT_RVD_ATSIGN }}"
           echo "wait: ${{ matrix.wait }}"
 
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Extended the wait duration for the two tests which commonly flake.

If tests still continue to flake, we can run these two separately, or introduce concurrency limits to the workflow.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
ci: extend wait duration for <=3.2.0 npd
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->