### PR TITLE
ci: copy license into releases

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -34,6 +34,7 @@ jobs:
       - run: dart compile exe bin/sshrvd.dart -v -o sshnp/sshrvd
       - run: cp -r templates sshnp/templates
       - run: cp scripts/* sshnp
+      - run: cp LICENSE sshnp
       - run: tar -cvzf tarball/${{ matrix.output-name }}.tgz sshnp
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/packages/sshnoports/Dockerfile.package
+++ b/packages/sshnoports/Dockerfile.package
@@ -19,6 +19,7 @@ RUN set -eux; \
     dart compile exe bin/sshrvd.dart -v -o sshnp/sshrvd; \
     cp -r templates sshnp/templates; \
     cp scripts/* sshnp/; \
+    cp LICENSE sshnp/; \
     tar -cvzf tarball/sshnp-linux-${ARCH}.tgz sshnp
 
 FROM scratch

--- a/tools/package-macos-arm64.sh
+++ b/tools/package-macos-arm64.sh
@@ -37,3 +37,4 @@ eval "$DART compile exe -o $OUTPUT_DIR/at_activate $SRC_DIR/bin/activate_cli.dar
 
 cp -r "$SRC_DIR/templates" "$OUTPUT_DIR/templates";
 cp "$SRC_DIR"/scripts/* "$OUTPUT_DIR/";
+cp "$SRC_DIR"/LICENSE "$OUTPUT_DIR/";


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added the step to copy the LICENSE in 3 places:
- Workflow for x64 based releases
- bash tool for Apple Silicon packager
- Dockerfile.package for all others (armv7/arm64/riscv)

**- How I did it**

**- How to verify it**

[Multibuild run against the branch](https://github.com/atsign-foundation/sshnoports/actions/runs/5804502160)

Apple Silicon verified manually:

<img width="156" alt="CleanShot 2023-08-09 at 11 24 09@2x" src="https://github.com/atsign-foundation/sshnoports/assets/33691921/b9d17ab9-7e2e-4d7e-83fa-260fe16dc7d4">


**- Description for the changelog**
ci: copy license into releases
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->