### PR TITLE
chore: use comma for list delimiter in sshnp config

### DIFF
--- a/packages/sshnoports/lib/sshnp/sshnp_params.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_params.dart
@@ -142,7 +142,6 @@ class SSHNPParams {
       'remote-user-name': remoteUsername,
       'verbose': verbose,
       'root-domain': rootDomain,
-      'list-devices': listDevices,
     };
   }
 
@@ -152,7 +151,7 @@ class SSHNPParams {
       var key = SSHNPArg.fromName(entry.key).bashName;
       var value = entry.value;
       if (value is List) {
-        value = value.join(';');
+        value = value.join(',');
       }
       lines.add('$key=$value');
     }
@@ -365,7 +364,7 @@ class SSHNPPartialParams {
             }
             continue;
           case ArgFormat.multiOption:
-            var values = value.split(';');
+            var values = value.split(',');
             args.putIfAbsent(arg.name, () => <String>[]);
             for (String val in values) {
               if (val.isEmpty) continue;

--- a/packages/sshnoports/templates/config/sshnp-config-template.env
+++ b/packages/sshnoports/templates/config/sshnp-config-template.env
@@ -25,7 +25,7 @@ LOCAL_PORT=
 SSH_PUBLIC_KEY=
 
 # Add these commands to the local ssh command
-# Use ";" to separate your options
+# Use "," to separate your options
 LOCAL_SSH_OPTIONS=
 
 # More logging (true/false)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Changed the delimiter for lists in the config file from ; to , so that the spec is both valid .bash and .env.

Since we haven't done a release including this feature yet, it should still be okay to implement this design change.

I also removed "list-devices" parameter from toArgs and subsequently toConfig and toFile of SSHNPParams, this parameter is not meant to be part of the main args and should not be written to the config files. (A bug curtly and I found today which was appending "=false" to the end of the config files produced using SSHNPParams.toFile()

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: use comma for list delimiter in sshnp config
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->