### PR TITLE
ci: limit max-parallel to 8

### DIFF
--- a/.github/composite/setup_entrypoints/action.yaml
+++ b/.github/composite/setup_entrypoints/action.yaml
@@ -17,7 +17,7 @@ inputs:
     required: true
   wait_time:
     description: Time to wait for sshnpd to start
-    default: "4"
+    default: "7"
 
 runs:
   using: composite

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 8
       matrix:
         np: [local, trunk]
         npd: [local, trunk]

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -1,5 +1,8 @@
 name: end2end_tests
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:
@@ -36,7 +39,6 @@ jobs:
       matrix:
         np: [local, trunk]
         npd: [local, trunk]
-        wait: [4]
         exclude:
           # Don't run these against themselves, they're irrelevant
           - np: trunk
@@ -47,39 +49,33 @@ jobs:
           #   npd: local
           #   rvd: local
           #   rvd_atsign: "@8485wealthy51"
-          #   wait: 4
 
           - np: latest
             npd: latest
             rvd: local
             rvd_atsign: "@8485wealthy51"
-            wait: 4
 
           ### BACKWARD TESTS WITHOUT SYNC ###
           - np: local
             npd: latest
-            wait: 4
 
           - np: latest
             npd: local
-            wait: 4
 
           - np: local
             npd: v3.3.0
-            wait: 4
 
           - np: v3.3.0
             npd: local
-            wait: 4
 
           ### BACKWARD TESTS WHICH NEED SYNC ###
           - np: local
             npd: v3.1.2
-            wait: 60
+            wait: 120
 
           - np: local
             npd: v3.2.0
-            wait: 60
+            wait: 120
 
           - np: v3.1.2
             npd: local


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

closes #313 

**- What I did**

Limited the number of max-parallel runs for end2end tests to 8.

Why:
end2end tests seem to be flaking more often recently, on average, we need to rerun 2 tests each time. i.e. 10/12 consistently pass first-time, so only running 8/12 should be a good balance between completing tests quickly and consistently.

If this doesn't work, then we can try to increase the 4s wait time back to 7.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
ci: limit max-parallel to 8
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->