### PR TITLE
feat: make sshnpd ping/heartbeat an opt-in feature

### DIFF
--- a/packages/sshnoports/lib/sshnpd/sshnpd.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd.dart
@@ -33,7 +33,7 @@ abstract class SSHNPD {
   abstract final SupportedSshClient sshClient;
 
   /// Whether this device should be hidden from sshnpd or not
-  abstract final bool shouldBroadcastInfo;
+  abstract final bool isPingable;
 
   /// true once [init] has completed
   @visibleForTesting
@@ -47,7 +47,7 @@ abstract class SSHNPD {
     required String device,
     required String managerAtsign,
     required SupportedSshClient sshClient,
-    bool shouldBroadcastInfo = false,
+    bool isPingable = false,
   }) {
     return SSHNPDImpl(
       atClient: atClient,
@@ -56,7 +56,7 @@ abstract class SSHNPD {
       device: device,
       managerAtsign: managerAtsign,
       sshClient: sshClient,
-      shouldBroadcastInfo: shouldBroadcastInfo,
+      isPingable: isPingable,
     );
   }
 

--- a/packages/sshnoports/lib/sshnpd/sshnpd.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd.dart
@@ -32,26 +32,32 @@ abstract class SSHNPD {
   /// The ssh client to use when doing reverse ssh
   abstract final SupportedSshClient sshClient;
 
+  /// Whether this device should be hidden from sshnpd or not
+  abstract final bool isHidden;
+
   /// true once [init] has completed
   @visibleForTesting
   bool initialized = false;
 
-  factory SSHNPD(
-      {
-      // final fields
-      required AtClient atClient,
-      required String username,
-      required String homeDirectory,
-      required String device,
-      required String managerAtsign,
-      required SupportedSshClient sshClient}) {
+  factory SSHNPD({
+    // final fields
+    required AtClient atClient,
+    required String username,
+    required String homeDirectory,
+    required String device,
+    required String managerAtsign,
+    required SupportedSshClient sshClient,
+    bool isHidden = true,
+  }) {
     return SSHNPDImpl(
-        atClient: atClient,
-        username: username,
-        homeDirectory: homeDirectory,
-        device: device,
-        managerAtsign: managerAtsign,
-        sshClient: sshClient);
+      atClient: atClient,
+      username: username,
+      homeDirectory: homeDirectory,
+      device: device,
+      managerAtsign: managerAtsign,
+      sshClient: sshClient,
+      isHidden: isHidden,
+    );
   }
 
   static Future<SSHNPD> fromCommandLineArgs(List<String> args) async {

--- a/packages/sshnoports/lib/sshnpd/sshnpd.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd.dart
@@ -33,7 +33,7 @@ abstract class SSHNPD {
   abstract final SupportedSshClient sshClient;
 
   /// Whether this device should be hidden from sshnpd or not
-  abstract final bool isHidden;
+  abstract final bool shouldBroadcastInfo;
 
   /// true once [init] has completed
   @visibleForTesting
@@ -47,7 +47,7 @@ abstract class SSHNPD {
     required String device,
     required String managerAtsign,
     required SupportedSshClient sshClient,
-    bool isHidden = true,
+    bool shouldBroadcastInfo = false,
   }) {
     return SSHNPDImpl(
       atClient: atClient,
@@ -56,7 +56,7 @@ abstract class SSHNPD {
       device: device,
       managerAtsign: managerAtsign,
       sshClient: sshClient,
-      isHidden: isHidden,
+      shouldBroadcastInfo: shouldBroadcastInfo,
     );
   }
 

--- a/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
@@ -42,7 +42,7 @@ class SSHNPDImpl implements SSHNPD {
   final SupportedSshClient sshClient;
 
   @override
-  final bool shouldBroadcastInfo;
+  final bool isPingable;
 
   @override
   @visibleForTesting
@@ -59,7 +59,7 @@ class SSHNPDImpl implements SSHNPD {
     required this.device,
     required this.managerAtsign,
     required this.sshClient,
-    this.shouldBroadcastInfo = false,
+    this.isPingable = false,
   }) {
     logger.hierarchicalLoggingEnabled = true;
     logger.logger.level = Level.SHOUT;
@@ -93,7 +93,7 @@ class SSHNPDImpl implements SSHNPD {
         device: p.device,
         managerAtsign: p.managerAtsign,
         sshClient: p.sshClient,
-        shouldBroadcastInfo: p.shouldBroadcastInfo,
+        isPingable: p.isPingable,
       );
 
       if (p.verbose) {

--- a/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
@@ -42,7 +42,7 @@ class SSHNPDImpl implements SSHNPD {
   final SupportedSshClient sshClient;
 
   @override
-  final bool isHidden;
+  final bool shouldBroadcastInfo;
 
   @override
   @visibleForTesting
@@ -59,7 +59,7 @@ class SSHNPDImpl implements SSHNPD {
     required this.device,
     required this.managerAtsign,
     required this.sshClient,
-    this.isHidden = true,
+    this.shouldBroadcastInfo = false,
   }) {
     logger.hierarchicalLoggingEnabled = true;
     logger.logger.level = Level.SHOUT;
@@ -93,7 +93,7 @@ class SSHNPDImpl implements SSHNPD {
         device: p.device,
         managerAtsign: p.managerAtsign,
         sshClient: p.sshClient,
-        isHidden: p.hidden,
+        shouldBroadcastInfo: p.shouldBroadcastInfo,
       );
 
       if (p.verbose) {
@@ -253,8 +253,8 @@ class SSHNPDImpl implements SSHNPD {
             deviceAtsign, device);
         break;
       case 'ping':
-        // If the device is set to hidden, ignore the ping
-        if (isHidden) break;
+        // Break if we shouldn't broadcast info
+        if (!shouldBroadcastInfo) break;
         logger.info(
             'ping received from ${notification.from} notification id : ${notification.id}');
         var metaData = Metadata()
@@ -613,8 +613,8 @@ class SSHNPDImpl implements SSHNPD {
 
   /// This function creates an atKey which shares the device name with the client
   Future<void> _refreshDeviceEntry() async {
-    // If the device is set to hidden, don't update the device info
-    if (isHidden) return;
+    // Return if we shouldn't broadcast info
+    if (!shouldBroadcastInfo) return;
     const ttl = 1000 * 60 * 60 * 24 * 30; // 30 days
     var metaData = Metadata()
       ..isPublic = false

--- a/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
@@ -254,7 +254,7 @@ class SSHNPDImpl implements SSHNPD {
         break;
       case 'ping':
         // Break if we shouldn't broadcast info
-        if (!shouldBroadcastInfo) break;
+        if (!isPingable) break;
         logger.info(
             'ping received from ${notification.from} notification id : ${notification.id}');
         var metaData = Metadata()
@@ -614,7 +614,7 @@ class SSHNPDImpl implements SSHNPD {
   /// This function creates an atKey which shares the device name with the client
   Future<void> _refreshDeviceEntry() async {
     // Return if we shouldn't broadcast info
-    if (!shouldBroadcastInfo) return;
+    if (!isPingable) return;
     const ttl = 1000 * 60 * 60 * 24 * 30; // 30 days
     var metaData = Metadata()
       ..isPublic = false

--- a/packages/sshnoports/lib/sshnpd/sshnpd_params.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_params.dart
@@ -13,7 +13,7 @@ class SSHNPDParams {
   late final bool verbose;
   late final SupportedSshClient sshClient;
   late final String rootDomain;
-  late final bool hidden;
+  late final bool shouldBroadcastInfo;
   // Non param variables
   static final ArgParser parser = _createArgParser();
 
@@ -46,7 +46,7 @@ class SSHNPDParams {
         .firstWhere((c) => c.cliArg == r['ssh-client']);
 
     rootDomain = r['root-domain'];
-    hidden = r['hidden'];
+    shouldBroadcastInfo = r['broadcast'];
   }
 
   static ArgParser _createArgParser() {
@@ -99,11 +99,10 @@ class SSHNPDParams {
       help: 'More logging',
     );
     parser.addFlag(
-      'hidden',
-      defaultsTo: true,
-      negatable: true,
-      help: 'Hide this device from "sshnp --list-devices" (default)'
-          'Use --no-hidden to show this device in "sshnp --list-devices"',
+      'broadcast',
+      abbr: 'b',
+      help: 'Broadcast device info to the client and respond to pings'
+          '(i.e. make it discoverable to sshnpd --list-devices)',
     );
     parser.addOption(
       'ssh-client',

--- a/packages/sshnoports/lib/sshnpd/sshnpd_params.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_params.dart
@@ -13,7 +13,7 @@ class SSHNPDParams {
   late final bool verbose;
   late final SupportedSshClient sshClient;
   late final String rootDomain;
-  late final bool shouldBroadcastInfo;
+  late final bool isPingable;
   // Non param variables
   static final ArgParser parser = _createArgParser();
 
@@ -46,7 +46,7 @@ class SSHNPDParams {
         .firstWhere((c) => c.cliArg == r['ssh-client']);
 
     rootDomain = r['root-domain'];
-    shouldBroadcastInfo = r['broadcast'];
+    isPingable = r['pingable'];
   }
 
   static ArgParser _createArgParser() {
@@ -99,9 +99,9 @@ class SSHNPDParams {
       help: 'More logging',
     );
     parser.addFlag(
-      'broadcast',
-      abbr: 'b',
-      help: 'Broadcast device info to the client and respond to pings'
+      'pingable',
+      abbr: 'p',
+      help: 'Whether to share device info to the client and respond to pings'
           '(i.e. make it discoverable to sshnpd --list-devices)',
     );
     parser.addOption(

--- a/packages/sshnoports/lib/sshnpd/sshnpd_params.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_params.dart
@@ -13,7 +13,7 @@ class SSHNPDParams {
   late final bool verbose;
   late final SupportedSshClient sshClient;
   late final String rootDomain;
-
+  late final bool hidden;
   // Non param variables
   static final ArgParser parser = _createArgParser();
 
@@ -46,6 +46,7 @@ class SSHNPDParams {
         .firstWhere((c) => c.cliArg == r['ssh-client']);
 
     rootDomain = r['root-domain'];
+    hidden = r['hidden'];
   }
 
   static ArgParser _createArgParser() {
@@ -80,6 +81,7 @@ class SSHNPDParams {
           'Send a trigger to this device, allows multiple devices share an atSign',
     );
 
+    // Customization Arguments
     parser.addFlag(
       'sshpublickey',
       abbr: 's',
@@ -96,17 +98,25 @@ class SSHNPDParams {
       abbr: 'v',
       help: 'More logging',
     );
-
-    parser.addOption('ssh-client',
-        mandatory: false,
-        defaultsTo: SupportedSshClient.hostSsh.cliArg,
-        allowed: SupportedSshClient.values.map((c) => c.cliArg).toList(),
-        help: 'What to use for outbound ssh connections.');
-
-    parser.addOption('root-domain',
-        mandatory: false,
-        defaultsTo: 'root.atsign.org',
-        help: 'atDirectory domain',
+    parser.addFlag(
+      'hidden',
+      defaultsTo: true,
+      negatable: true,
+      help: 'Hide this device from "sshnp --list-devices" (default)'
+          'Use --no-hidden to show this device in "sshnp --list-devices"',
+    );
+    parser.addOption(
+      'ssh-client',
+      mandatory: false,
+      defaultsTo: SupportedSshClient.hostSsh.cliArg,
+      allowed: SupportedSshClient.values.map((c) => c.cliArg).toList(),
+      help: 'What to use for outbound ssh connections.',
+    );
+    parser.addOption(
+      'root-domain',
+      mandatory: false,
+      defaultsTo: 'root.atsign.org',
+      help: 'atDirectory domain',
     );
 
     return parser;

--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -35,7 +35,7 @@ usage() {
   echo "  -d, --device <address>      Device address (e.g. @alice_device)"
   echo "  -n, --name <device name>    Name of the device"
   echo "  -v, --version <version>     Version to install (default: latest)"
-  echo "      --no-hidden             Make the device discoverable by the client"
+  echo "      --broadcast             Make the device discoverable by the client"
   echo ""
   echo "Rename options:"
   echo "  -c, --client <address>      Client address (e.g. @alice_client)"
@@ -106,8 +106,8 @@ parse_args() {
         SSHNP_VERSION="$2"
         shift 2
       ;;
-      --no-hidden)
-        SSHNP_SERVICE_ARGS="$SSHNP_SERVICE_ARGS --no-hidden"
+      --broadcast)
+        SSHNP_SERVICE_ARGS="$SSHNP_SERVICE_ARGS --broadcast"
         shift 1
       ;;
       *)

--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -35,6 +35,7 @@ usage() {
   echo "  -d, --device <address>      Device address (e.g. @alice_device)"
   echo "  -n, --name <device name>    Name of the device"
   echo "  -v, --version <version>     Version to install (default: latest)"
+  echo "      --no-hidden             Make the device discoverable by the client"
   echo ""
   echo "Rename options:"
   echo "  -c, --client <address>      Client address (e.g. @alice_client)"
@@ -104,6 +105,10 @@ parse_args() {
         fi
         SSHNP_VERSION="$2"
         shift 2
+      ;;
+      --no-hidden)
+        SSHNP_SERVICE_ARGS="$SSHNP_SERVICE_ARGS --no-hidden"
+        shift 1
       ;;
       *)
         echo "Unknown argument: $1"
@@ -301,6 +306,7 @@ setup_service() {
       -e "s/\$1/$DEVICE_MANAGER_ATSIGN/g" \
       -e "s/\$2/$CLIENT_ATSIGN/g" \
       -e "s/\$3/$SSHNP_DEVICE_NAME/g" \
+      -e "s/\$@/$SSHNP_SERVICE_ARGS/g" \
     <"$HOME_PATH/.atsign/temp/$TEMP_PATH/$BINARY_NAME/templates/headless/sshnpd.sh" \
     >"$SSHNPD_SERVICE_BINARY_PATH";
     chmod +x "$SSHNPD_SERVICE_BINARY_PATH";

--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -35,7 +35,7 @@ usage() {
   echo "  -d, --device <address>      Device address (e.g. @alice_device)"
   echo "  -n, --name <device name>    Name of the device"
   echo "  -v, --version <version>     Version to install (default: latest)"
-  echo "      --broadcast             Make the device discoverable by the client"
+  echo "      --pingable              Make the device discoverable by the client"
   echo ""
   echo "Rename options:"
   echo "  -c, --client <address>      Client address (e.g. @alice_client)"
@@ -106,8 +106,8 @@ parse_args() {
         SSHNP_VERSION="$2"
         shift 2
       ;;
-      --broadcast)
-        SSHNP_SERVICE_ARGS="$SSHNP_SERVICE_ARGS --broadcast"
+      --pingable)
+        SSHNP_SERVICE_ARGS="$SSHNP_SERVICE_ARGS --pingable"
         shift 1
       ;;
       *)

--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -292,11 +292,39 @@ restart_service() {
   killall -q -u "$SSHNP_USER" -r "$BINARY_NAME$"
 }
 
+rename_device() {
+  case "$SERVICE_RUN_VERSION" in
+    1.*)
+        echo 1
+        # Old format, no NAME= line
+        SERVICE_RUN_LINE=$(grep 'sshnpd ' < "$SSHNPD_SERVICE_BINARY_PATH")
+        OLD_DEVICE_NAME=$(echo "${SERVICE_RUN_LINE// -d /;/}" | cut -d';' -f2 | cut -d '"' -f2)
+
+        # This replace should be fine since it wraps the device name in quotes
+        # all other quotations in v1.0.0 start with a special character (either $ or @)
+        # these characters are not supported by device name format
+        # so this string will never match anything else in the file
+        sed -i '' "s/\"$OLD_DEVICE_NAME\"/\"$SSHNP_DEVICE_NAME\"/g" "$SSHNPD_SERVICE_BINARY_PATH"
+      ;;
+    2.*)
+        echo 2
+        # New format, NAME= line
+        SERVICE_RUN_LINE=$(grep 'NAME=' < "$SSHNPD_SERVICE_BINARY_PATH")
+        OLD_DEVICE_NAME=$(echo "$SERVICE_RUN_LINE" | cut -d'=' -f2 | cut -d'"' -f2)
+
+        # Since NAME= is on its own line, we can just replace the whole line
+        sed -i '' "s/NAME=\"$OLD_DEVICE_NAME\"/NAME=\"$SSHNP_DEVICE_NAME\"/g" "$SSHNPD_SERVICE_BINARY_PATH"
+      ;;
+  esac
+
+  echo "Renamed $OLD_DEVICE_NAME to $SSHNP_DEVICE_NAME"
+}
+
 # Place custom user based scripts
 setup_service() {
-
   SSHNPD_SERVICE_BINARY_PATH="$HOME_PATH/.local/bin/$BINARY_NAME$CLIENT_ATSIGN";
-  # = is used as the delimiter to avoid escaping / in the path
+  SERVICE_RUN_VERSION="$(sed '2!d' "$SSHNPD_SERVICE_BINARY_PATH" | cut -d'v' -f2)"
+
   if [ "$SSHNP_OP" = 'rename' ] && ! [ -f "$SSHNPD_SERVICE_BINARY_PATH" ]; then
     echo "Error: trying to rename service, but service binary not found";
     exit 1;
@@ -311,10 +339,7 @@ setup_service() {
     >"$SSHNPD_SERVICE_BINARY_PATH";
     chmod +x "$SSHNPD_SERVICE_BINARY_PATH";
   elif [ "$SSHNP_OP" = 'rename' ]; then
-    SERVICE_RUN_LINE=$(grep 'sshnpd ' < "$SSHNPD_SERVICE_BINARY_PATH")
-    OLD_DEVICE_NAME=$(echo "${SERVICE_RUN_LINE// -d /;/}" | cut -d';' -f2 | cut -d '"' -f2)
-    echo "Renaming $OLD_DEVICE_NAME to $SSHNP_DEVICE_NAME"
-    sed -i "s/\"$OLD_DEVICE_NAME\"/\"$SSHNP_DEVICE_NAME\"/g" "$SSHNPD_SERVICE_BINARY_PATH"
+    rename_device
   fi
 
   SSHNP_CRON_SCHEDULE="@reboot";

--- a/packages/sshnoports/templates/headless/sshnpd.sh
+++ b/packages/sshnoports/templates/headless/sshnpd.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#v1.0.0
+#v2.0.0
 # allow machine to bring up network
 sleep 10
 USER=$(whoami)

--- a/packages/sshnoports/templates/headless/sshnpd.sh
+++ b/packages/sshnoports/templates/headless/sshnpd.sh
@@ -4,10 +4,13 @@
 sleep 10
 USER=$(whoami)
 export USER
+DEVICE="$1"
+CLIENT="$2"
+NAME="$3"
 while true; do
   # -a = device atSign
   # -m = client atSign
   # -d = device name
-  $HOME/.local/bin/sshnpd -a "$1" -m "$2"  -u  -d "$3" -v -s
+  "$HOME"/.local/bin/sshnpd -a "$DEVICE" -m "$CLIENT"  -u  -d "$NAME" -v -s "$@"
   sleep 10
 done

--- a/packages/sshnoports/templates/headless/sshrvd.sh
+++ b/packages/sshnoports/templates/headless/sshrvd.sh
@@ -4,9 +4,11 @@
 sleep 10
 USER=$(whoami) 
 export USER
+ATSIGN="$1"
+ADDRESS="$2"
 while true; do
   # -a = atSign
   # -i = FQDN/IP
-  $HOME/.local/bin/sshrvd -a "$1" -i "$2"
+  "$HOME"/.local/bin/sshrvd -a "$ATSIGN" -i "$ADDRESS"
   sleep 10
 done

--- a/packages/sshnoports/templates/headless/sshrvd.sh
+++ b/packages/sshnoports/templates/headless/sshrvd.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#v1.0.0
+#v2.0.0
 # allow machine to bring up network
 sleep 10
 USER=$(whoami) 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Added a negatable `--hidden flag` which is true by default
- You must specify --no-hidden if you want the device to show up in sshnp --list-devices
- Added --no-hidden to the sshnpd installer which will then add the flag to the `sshnpd@<client atSign>` service script
- Updated the sshnpd templates and rename script in accordance with that

Question for @gkc and @cconstab:

- Instead of "hidden" and "no-hidden" should I make the flag "discoverable" or something similar?
Note that discoverable is awkward to type (and -d is already taken).

**- How I did it**

**- How to verify it**

**- Description for the changelog**
feat: make sshnpd ping/heartbeat an opt-in feature
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->