### PR TITLE
fix: Fix behaviour for various flags

### DIFF
--- a/packages/sshnoports/lib/sshnpd/sshnpd.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd.dart
@@ -36,11 +36,12 @@ abstract class SSHNPD {
   /// Defaults to false.
   ///
   /// When true, sshnpd should
-  /// 1. notify a value for `@managerAtSign:username.$device.sshnp@deviceAtSign` when it starts
-  /// 2. create a `@managerAtSign:device_info.$device.sshnp@deviceAtSign` record when it starts
-  /// 3. respond to 'ping' notifications
+  /// 1. notify a value for `@managerAtSign:username.$device.sshnp@deviceAtSign`
+  /// when it starts
+  /// 2. create a `@managerAtSign:device_info.$device.sshnp@deviceAtSign`
+  /// record when it starts, and update it periodically thereafter
   ///
-  /// When false, none of the above should happen
+  /// When false, neither of the above should happen
   abstract final bool makeDeviceInfoVisible;
 
   /// When true, sshnpd will respond to requests to add public keys to its

--- a/packages/sshnoports/lib/sshnpd/sshnpd.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd.dart
@@ -27,10 +27,26 @@ abstract class SSHNPD {
   abstract final String device;
 
   String get deviceAtsign;
+
   abstract final String managerAtsign;
 
   /// The ssh client to use when doing reverse ssh
   abstract final SupportedSshClient sshClient;
+
+  /// Defaults to false.
+  ///
+  /// When true, sshnpd should
+  /// 1. notify a value for `@managerAtSign:username.$device.sshnp@deviceAtSign` when it starts
+  /// 2. create a `@managerAtSign:device_info.$device.sshnp@deviceAtSign` record when it starts
+  /// 3. respond to 'ping' notifications
+  ///
+  /// When false, none of the above should happen
+  abstract final bool makeDeviceInfoVisible;
+
+  /// When true, sshnpd will respond to requests to add public keys to its
+  /// authorized_keys file.
+  /// This flag should default to false.
+  abstract final bool addSshPublicKeys;
 
   /// true once [init] has completed
   @visibleForTesting
@@ -44,14 +60,18 @@ abstract class SSHNPD {
       required String homeDirectory,
       required String device,
       required String managerAtsign,
-      required SupportedSshClient sshClient}) {
+      required SupportedSshClient sshClient,
+      required bool makeDeviceInfoVisible,
+      required bool addSshPublicKeys}) {
     return SSHNPDImpl(
         atClient: atClient,
         username: username,
         homeDirectory: homeDirectory,
         device: device,
         managerAtsign: managerAtsign,
-        sshClient: sshClient);
+        sshClient: sshClient,
+        makeDeviceInfoVisible: makeDeviceInfoVisible,
+        addSshPublicKeys: addSshPublicKeys);
   }
 
   static Future<SSHNPD> fromCommandLineArgs(List<String> args) async {

--- a/packages/sshnoports/lib/sshnpd/sshnpd_params.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_params.dart
@@ -11,6 +11,8 @@ class SSHNPDParams {
   late final String sendSshPublicKey;
   late final String deviceAtsign;
   late final bool verbose;
+  late final bool makeDeviceInfoVisible;
+  late final bool addSshPublicKeys;
   late final SupportedSshClient sshClient;
   late final String rootDomain;
 
@@ -46,6 +48,10 @@ class SSHNPDParams {
         .firstWhere((c) => c.cliArg == r['ssh-client']);
 
     rootDomain = r['root-domain'];
+
+    makeDeviceInfoVisible = r['un-hide'];
+
+    addSshPublicKeys = r['sshpublickey'];
   }
 
   static ArgParser _createArgParser() {
@@ -83,13 +89,17 @@ class SSHNPDParams {
     parser.addFlag(
       'sshpublickey',
       abbr: 's',
-      help: 'Update authorized_keys to include public key from sshnp',
+      defaultsTo: false,
+      help:
+          'When set, will update authorized_keys to include public key sent by manager',
     );
     parser.addFlag(
-      'username',
+      'un-hide',
       abbr: 'u',
+      aliases: const ['username'],
+      defaultsTo: false,
       help:
-          'Send username to the manager to allow sshnp to display username in command line',
+          'When set, makes various information visible to the manager atSign - e.g. username, version, etc',
     );
     parser.addFlag(
       'verbose',


### PR DESCRIPTION
See also discussion in #329 

**- What I did**
fix: Fix behaviour for the obscurity flag `-u` which was broken during the Great Code Restructure a couple months ago
fix: Implement behaviour for the 'add ssh public keys' flag `-s` which was never actually implemented
fix: Add a ttl of 10 seconds for the values of `ping` responses

**- How I did it**
- Re-purposed the existing `-u` flag so it now means "un-hide" and is used to control both (a) whether the sshnpd shares its local username and (b) whether the sshnpd shares other info e.g. version - because in both cases, the the sharing results in there being a record in the data store like `@managerAtSign:<username|device_info>.$device.sshnp@deviceAtSign` and we don't want to make device names visible in this way unless  specifically configured to do so
- Added `makeDeviceInfoVisible` boolean to SSHNPDParams / SSHNPDImpl / SSHNPD and ensure that neither of the `username.$device.sshnp` and `device_info.$device.sshnp` records are created unless `makeDeviceInfoVisible` is true (i.e. the `-u` for 'un-hide' flag has been passed on the command line)
- Added `addSshPublicKeys` boolean to SSHNPDParams / SSHNPDImpl / SSHNPD, which takes its value from the `-s` command-line flag (default false) and guard the `_handlePublicKeyNotification` method with the `addSshPublicKeys` flag

**- How to verify it**
Tests pass

