### PR TITLE
ci: e2e tests for the installer

### DIFF
--- a/.github/composite/setup_entrypoints/action.yaml
+++ b/.github/composite/setup_entrypoints/action.yaml
@@ -18,6 +18,12 @@ inputs:
   wait_time:
     description: Time to wait for sshnpd to start
     required: false
+  sshnp:
+    description: Source of the sshnp container
+    required: true
+  sshnpd:
+    description: Source of the sshnpd container
+    required: true
 
 runs:
   using: composite
@@ -26,6 +32,32 @@ runs:
       shell: bash
       working-directory: tests/end2end_tests/tools/configuration
       run: |
-        ./setup-sshnp-entrypoint.sh ${{ inputs.devicename }} ${{ inputs.sshnp_atsign }} ${{ inputs.sshnpd_atsign }} ${{ inputs.sshrvd_atsign }} ${{ inputs.wait_time || 10 }}
-        ./setup-sshnpd-entrypoint.sh ${{ inputs.devicename }} ${{ inputs.sshnp_atsign }} ${{ inputs.sshnpd_atsign }} ${{ inputs.sshrvd_atsign }}
+        case "${{ inputs.sshnp }}" in
+          "installer")
+            entrypoint_filename="sshnp_installer_entrypoint.sh"
+            ;;
+          *)
+            entrypoint_filename="sshnp_entrypoint.sh"
+            ;;
+        esac
+        ./setup-sshnp-entrypoint.sh ${{ inputs.devicename }} ${{ inputs.sshnp_atsign }} ${{ inputs.sshnpd_atsign }} ${{ inputs.sshrvd_atsign }} ${{ inputs.wait_time || 10 }} "$entrypoint_filename"
+
+    - name: Setup NPD entrypoint
+      shell: bash
+      working-directory: tests/end2end_tests/tools/configuration
+      run: |
+        case "${{ inputs.sshnpd }}" in
+          "installer")
+            entrypoint_filename="sshnpd_installer_entrypoint.sh"
+            ;;
+          *)
+            entrypoint_filename="sshnpd_entrypoint.sh"
+            ;;
+        esac
+        ./setup-sshnpd-entrypoint.sh ${{ inputs.devicename }} ${{ inputs.sshnp_atsign }} ${{ inputs.sshnpd_atsign }} ${{ inputs.sshrvd_atsign }} "$entrypoint_filename"
+
+    - name: Setup RVD entrypoint
+      shell: bash
+      working-directory: tests/end2end_tests/tools/configuration
+      run: |
         ./setup-sshrvd-entrypoint.sh ${{ inputs.sshrvd_atsign }}

--- a/.github/composite/setup_entrypoints/action.yaml
+++ b/.github/composite/setup_entrypoints/action.yaml
@@ -3,11 +3,14 @@ description: |
   Sets up the environment for e2e tests.
 
 inputs:
-  devicename:
-    description: Unique sshnp devicename
+  sshnp:
+    description: Source of the sshnp container
     required: true
   sshnp_atsign:
     description: sshnp atsign
+    required: true
+  sshnpd:
+    description: Source of the sshnpd container
     required: true
   sshnpd_atsign:
     description: sshnpd atsign
@@ -15,15 +18,12 @@ inputs:
   sshrvd_atsign:
     description: sshrvd atsign
     required: true
+  devicename:
+    description: Unique sshnp devicename
+    required: true
   wait_time:
     description: Time to wait for sshnpd to start
     required: false
-  sshnp:
-    description: Source of the sshnp container
-    required: true
-  sshnpd:
-    description: Source of the sshnpd container
-    required: true
 
 runs:
   using: composite
@@ -40,6 +40,7 @@ runs:
             entrypoint_filename="sshnp_entrypoint.sh"
             ;;
         esac
+        echo "entrypoint_filename: $entrypoint_filename"
         ./setup-sshnp-entrypoint.sh ${{ inputs.devicename }} ${{ inputs.sshnp_atsign }} ${{ inputs.sshnpd_atsign }} ${{ inputs.sshrvd_atsign }} ${{ inputs.wait_time || 10 }} "$entrypoint_filename"
 
     - name: Setup NPD entrypoint
@@ -54,6 +55,7 @@ runs:
             entrypoint_filename="sshnpd_entrypoint.sh"
             ;;
         esac
+        echo "entrypoint_filename: $entrypoint_filename"
         ./setup-sshnpd-entrypoint.sh ${{ inputs.devicename }} ${{ inputs.sshnp_atsign }} ${{ inputs.sshnpd_atsign }} ${{ inputs.sshrvd_atsign }} "$entrypoint_filename"
 
     - name: Setup RVD entrypoint

--- a/.github/composite/setup_entrypoints/action.yaml
+++ b/.github/composite/setup_entrypoints/action.yaml
@@ -17,7 +17,7 @@ inputs:
     required: true
   wait_time:
     description: Time to wait for sshnpd to start
-    default: "10"
+    required: false
 
 runs:
   using: composite

--- a/.github/composite/setup_entrypoints/action.yaml
+++ b/.github/composite/setup_entrypoints/action.yaml
@@ -56,7 +56,7 @@ runs:
             ;;
         esac
         echo "entrypoint_filename: $entrypoint_filename"
-        ./setup-sshnpd-entrypoint.sh ${{ inputs.devicename }} ${{ inputs.sshnp_atsign }} ${{ inputs.sshnpd_atsign }} ${{ inputs.sshrvd_atsign }} "$entrypoint_filename"
+        ./setup-sshnpd-entrypoint.sh ${{ inputs.devicename }} ${{ inputs.sshnp_atsign }} ${{ inputs.sshnpd_atsign }} "$entrypoint_filename"
 
     - name: Setup RVD entrypoint
       shell: bash

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -161,16 +161,22 @@ jobs:
 
       - name: Add runtime-sshnp-installer image to docker-compose.yaml
         working-directory: tests/end2end_tests/tests
-        if: ${{ matrix.np == 'installer' || matrix.npd == 'installer' }}
+        if: ${{ matrix.np == 'installer' }}
         run: |
           cat service-image-runtime-sshnp-installer.yaml >> docker-compose.yaml
+          echo '        - client_atsign=${{ env.SSHNP_ATSIGN }}' >> docker-compose.yaml
+          echo '        - device_atsign=${{ env.SSHNPD_ATSIGN }}' >> docker-compose.yaml
+          echo '        - host_atsign=${{ matrix.rvd_atsign || env.DEFAULT_RVD_ATSIGN }}' >> docker-compose.yaml
           echo '    image: atsigncompany/sshnp-e2e-runtime:sshnp-installer' >> docker-compose.yaml
 
       - name: Add runtime-sshnpd-installer image to docker-compose.yaml
         working-directory: tests/end2end_tests/tests
-        if: ${{ matrix.np == 'installer' || matrix.npd == 'installer' }}
+        if: ${{ matrix.npd == 'installer' }}
         run: |
           cat service-image-runtime-sshnpd-installer.yaml >> docker-compose.yaml
+          echo '        - client_atsign=${{ env.SSHNP_ATSIGN }}' >> docker-compose.yaml
+          echo '        - device_atsign=${{ env.SSHNPD_ATSIGN }}' >> docker-compose.yaml
+          echo '        - device_name=${{ github.run_id }}${{ github.run_attempt }}${{ strategy.job-index }}' >> docker-compose.yaml
           echo '    image: atsigncompany/sshnp-e2e-runtime:sshnpd-installer' >> docker-compose.yaml
 
       - name: Add container-sshnp to docker-compose.yaml

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -164,9 +164,9 @@ jobs:
         if: ${{ matrix.np == 'installer' }}
         run: |
           cat service-image-runtime-sshnp-installer.yaml >> docker-compose.yaml
-          echo '        - client_atsign=${{ env.SSHNP_ATSIGN }}' >> docker-compose.yaml
-          echo '        - device_atsign=${{ env.SSHNPD_ATSIGN }}' >> docker-compose.yaml
-          echo '        - host_atsign=${{ matrix.rvd_atsign || env.DEFAULT_RVD_ATSIGN }}' >> docker-compose.yaml
+          echo '        - client_atsign="${{ env.SSHNP_ATSIGN }}"' >> docker-compose.yaml
+          echo '        - device_atsign="${{ env.SSHNPD_ATSIGN }}"' >> docker-compose.yaml
+          echo '        - host_atsign="${{ matrix.rvd_atsign || env.DEFAULT_RVD_ATSIGN }}"' >> docker-compose.yaml
           echo '    image: atsigncompany/sshnp-e2e-runtime:sshnp-installer' >> docker-compose.yaml
 
       - name: Add runtime-sshnpd-installer image to docker-compose.yaml
@@ -174,9 +174,9 @@ jobs:
         if: ${{ matrix.npd == 'installer' }}
         run: |
           cat service-image-runtime-sshnpd-installer.yaml >> docker-compose.yaml
-          echo '        - client_atsign=${{ env.SSHNP_ATSIGN }}' >> docker-compose.yaml
-          echo '        - device_atsign=${{ env.SSHNPD_ATSIGN }}' >> docker-compose.yaml
-          echo '        - device_name=${{ github.run_id }}${{ github.run_attempt }}${{ strategy.job-index }}' >> docker-compose.yaml
+          echo '        - client_atsign="${{ env.SSHNP_ATSIGN }}"' >> docker-compose.yaml
+          echo '        - device_atsign="${{ env.SSHNPD_ATSIGN }}"' >> docker-compose.yaml
+          echo '        - device_name="${{ github.run_id }}${{ github.run_attempt }}${{ strategy.job-index }}"' >> docker-compose.yaml
           echo '    image: atsigncompany/sshnp-e2e-runtime:sshnpd-installer' >> docker-compose.yaml
 
       - name: Add container-sshnp to docker-compose.yaml

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       max-parallel: 8
       matrix:
-        np: [local, trunk, installer]
-        npd: [local, trunk, installer]
+        np: [local, trunk]
+        npd: [local, trunk]
         exclude:
           # Don't run these against themselves, they're irrelevant
           - np: trunk
@@ -54,7 +54,22 @@ jobs:
             npd: latest
             rvd: local
             rvd_atsign: "@8485wealthy51"
-
+          ### INSTALLER TESTS ###
+          - np: installer
+            npd: local
+            wait: 120
+          - np: local
+            npd: installer
+            wait: 120
+          - np: installer
+            npd: trunk
+            wait: 120
+          - np: trunk
+            npd: installer
+            wait: 120
+          - np: installer
+            npd: installer
+            wait: 120
           ### BACKWARD TESTS WITHOUT SYNC ###
           - np: local
             npd: latest
@@ -79,11 +94,11 @@ jobs:
 
           - np: v3.1.2
             npd: local
-            wait: 60
+            wait: 120
 
           - np: v3.2.0
             npd: local
-            wait: 60
+            wait: 120
     steps:
       - name: Show Matrix Values
         run: |

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -183,7 +183,11 @@ jobs:
         working-directory: tests/end2end_tests/tests
         run: |
           cat service-container-sshnp.yaml >> docker-compose.yaml
-          echo '    image: atsigncompany/sshnp-e2e-runtime:${{ matrix.np }}' >> docker-compose.yaml
+          if [ "${{ matrix.np }}" = 'installer' ]; then
+            echo '    image: atsigncompany/sshnp-e2e-runtime:sshnp-installer' >> docker-compose.yaml
+          else
+            echo '    image: atsigncompany/sshnp-e2e-runtime:${{ matrix.np }}' >> docker-compose.yaml
+          fi
           echo '    depends_on:' >> docker-compose.yaml
           echo '      - container-sshnpd' >> docker-compose.yaml
           if [ "${{contains(env.RELEASES, matrix.np)}}" = true ]; then
@@ -200,7 +204,11 @@ jobs:
         working-directory: tests/end2end_tests/tests
         run: |
           cat service-container-sshnpd.yaml >> docker-compose.yaml
-          echo '    image: atsigncompany/sshnp-e2e-runtime:${{ matrix.npd }}' >> docker-compose.yaml
+          if [ "${{ matrix.npd }}" = 'installer' ]; then
+            echo '    image: atsigncompany/sshnp-e2e-runtime:sshnpd-installer' >> docker-compose.yaml
+          else
+            echo '    image: atsigncompany/sshnp-e2e-runtime:${{ matrix.npd }}' >> docker-compose.yaml
+          fi
           echo '    depends_on:' >> docker-compose.yaml
           if [ "${{ matrix.rvd }}" = true ]; then
             echo '      - container-sshrvd' >> docker-compose.yaml

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       max-parallel: 8
       matrix:
-        np: [local, trunk]
-        npd: [local, trunk]
+        np: [local, trunk, installer]
+        npd: [local, trunk, installer]
         exclude:
           # Don't run these against themselves, they're irrelevant
           - np: trunk
@@ -159,6 +159,20 @@ jobs:
             echo '    image: atsigncompany/sshnp-e2e-runtime:${{ matrix.rvd }}' >> docker-compose.yaml
           fi
 
+      - name: Add runtime-sshnp-installer image to docker-compose.yaml
+        working-directory: tests/end2end_tests/tests
+        if: ${{ matrix.np == 'installer' || matrix.npd == 'installer' }}
+        run: |
+          cat service-image-runtime-sshnp-installer.yaml >> docker-compose.yaml
+          echo '    image: atsigncompany/sshnp-e2e-runtime:sshnp-installer' >> docker-compose.yaml
+
+      - name: Add runtime-sshnpd-installer image to docker-compose.yaml
+        working-directory: tests/end2end_tests/tests
+        if: ${{ matrix.np == 'installer' || matrix.npd == 'installer' }}
+        run: |
+          cat service-image-runtime-sshnpd-installer.yaml >> docker-compose.yaml
+          echo '    image: atsigncompany/sshnp-e2e-runtime:sshnpd-installer' >> docker-compose.yaml
+
       - name: Add container-sshnp to docker-compose.yaml
         working-directory: tests/end2end_tests/tests
         run: |
@@ -170,6 +184,8 @@ jobs:
             echo '      - image-runtime-release' >> docker-compose.yaml
           elif [ "${{contains(env.BRANCHES, matrix.np)}}" = true ]; then
             echo '      - image-runtime-branch' >> docker-compose.yaml
+          elif [ "${{ matrix.np }}" = 'installer' ]; then
+            echo '      - image-runtime-sshnp-installer' >> docker-compose.yaml
           else
             echo '      - image-runtime-local' >> docker-compose.yaml
           fi
@@ -187,6 +203,8 @@ jobs:
             echo '      - image-runtime-release' >> docker-compose.yaml
           elif [ "${{contains(env.BRANCHES, matrix.npd)}}" = true ]; then
             echo '      - image-runtime-branch' >> docker-compose.yaml
+          elif [ "${{ matrix.npd }}" = 'installer' ]; then
+            echo '      - image-runtime-sshnpd-installer' >> docker-compose.yaml
           else
             echo '      - image-runtime-local' >> docker-compose.yaml
           fi

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       max-parallel: 8
       matrix:
-        np: [local, trunk]
-        npd: [local, trunk]
+        np: [local, trunk, installer]
+        npd: [local, trunk, installer]
         exclude:
           # Don't run these against themselves, they're irrelevant
           - np: trunk

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -125,6 +125,8 @@ jobs:
           sshnpd_atsign: ${{ env.SSHNPD_ATSIGN }}
           sshrvd_atsign: ${{ matrix.rvd_atsign || env.DEFAULT_RVD_ATSIGN }}
           wait_time: ${{ matrix.wait }}
+          sshnp: ${{ matrix.np }}
+          sshnpd: ${{ matrix.npd }}
 
       - name: Ensure entrypoints exist
         working-directory: tests/end2end_tests/contexts

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -54,22 +54,6 @@ jobs:
             npd: latest
             rvd: local
             rvd_atsign: "@8485wealthy51"
-          ### INSTALLER TESTS ###
-          - np: installer
-            npd: local
-            wait: 120
-          - np: local
-            npd: installer
-            wait: 120
-          - np: installer
-            npd: trunk
-            wait: 120
-          - np: trunk
-            npd: installer
-            wait: 120
-          - np: installer
-            npd: installer
-            wait: 120
           ### BACKWARD TESTS WITHOUT SYNC ###
           - np: local
             npd: latest

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -176,7 +176,7 @@ jobs:
           cat service-image-runtime-sshnpd-installer.yaml >> docker-compose.yaml
           echo '        - client_atsign="${{ env.SSHNP_ATSIGN }}"' >> docker-compose.yaml
           echo '        - device_atsign="${{ env.SSHNPD_ATSIGN }}"' >> docker-compose.yaml
-          echo '        - device_name="${{ github.run_id }}${{ github.run_attempt }}${{ strategy.job-index }}"' >> docker-compose.yaml
+          echo '        - device_name=${{ github.run_id }}${{ github.run_attempt }}${{ strategy.job-index }}' >> docker-compose.yaml
           echo '    image: atsigncompany/sshnp-e2e-runtime:sshnpd-installer' >> docker-compose.yaml
 
       - name: Add container-sshnp to docker-compose.yaml

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -38,7 +38,7 @@ jobs:
       max-parallel: 8
       matrix:
         np: [local, trunk, installer]
-        npd: [local, trunk, installer]
+        npd: [local, trunk]
         exclude:
           # Don't run these against themselves, they're irrelevant
           - np: trunk
@@ -54,6 +54,16 @@ jobs:
             npd: latest
             rvd: local
             rvd_atsign: "@8485wealthy51"
+          ### INSTALLER TESTS ###
+          - np: local
+            npd: installer
+            wait: 30
+          - np: trunk
+            npd: installer
+            wait: 30
+          - np: installer
+            npd: installer
+            wait: 30
           ### BACKWARD TESTS WITHOUT SYNC ###
           - np: local
             npd: latest

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -120,13 +120,13 @@ jobs:
       - name: Set up entrypoints
         uses: ./.github/composite/setup_entrypoints
         with:
-          devicename: ${{ github.run_id }}${{ github.run_attempt }}${{ strategy.job-index }}
+          sshnp: ${{ matrix.np }}
           sshnp_atsign: ${{ env.SSHNP_ATSIGN }}
+          sshnpd: ${{ matrix.npd }}
           sshnpd_atsign: ${{ env.SSHNPD_ATSIGN }}
           sshrvd_atsign: ${{ matrix.rvd_atsign || env.DEFAULT_RVD_ATSIGN }}
+          devicename: ${{ github.run_id }}${{ github.run_attempt }}${{ strategy.job-index }}
           wait_time: ${{ matrix.wait }}
-          sshnp: ${{ matrix.np }}
-          sshnpd: ${{ matrix.npd }}
 
       - name: Ensure entrypoints exist
         working-directory: tests/end2end_tests/contexts

--- a/packages/sshnoports/scripts/install_sshnp
+++ b/packages/sshnoports/scripts/install_sshnp
@@ -257,8 +257,6 @@ setup_custom_binary() {
   <"$HOME_PATH/.atsign/temp/$BINARY_NAME/templates/client/sshnp-full.sh" \
   >"$HOME_PATH/.local/bin/$BINARY_NAME$DEVICE_MANAGER_ATSIGN"
   chmod +x "$HOME_PATH/.local/bin/$BINARY_NAME$DEVICE_MANAGER_ATSIGN";
-
-  cat "$HOME_PATH/.local/bin/$BINARY_NAME$DEVICE_MANAGER_ATSIGN";
 }
 
 post_install() {

--- a/packages/sshnoports/scripts/install_sshnp
+++ b/packages/sshnoports/scripts/install_sshnp
@@ -33,6 +33,7 @@ usage() {
   echo "  -c, --client <address>      Client address (e.g. @alice_client)"
   echo "  -d, --device <address>      Device address (e.g. @alice_device)"
   echo "  -h, --host <region code>    Default host rendezvous region code (am, eu, ap)"
+  echo "                              Specify an atSign to override with a custom host"
   echo "  -v, --version <version>     Version to install (default: latest)"
 }
 
@@ -114,13 +115,14 @@ parse_args() {
 
     if [ -z "$HOST_RENDEZVOUS_ATSIGN" ]; then
       echo Pick your default region:
-      echo "  am: Americas"
-      echo "  ap: Asia Pacific"
-      echo "  eu: Europe"
+      echo "  am   : Americas"
+      echo "  ap   : Asia Pacific"
+      echo "  eu   : Europe"
+      echo "  @___ : Specify a custom region atSign"
       read -rp "> " HOST_RENDEZVOUS_ATSIGN;
     fi
 
-    while [[ "$HOST_RENDEZVOUS_ATSIGN" != @rv_* ]]; do
+    while [[ "$HOST_RENDEZVOUS_ATSIGN" != @* ]]; do
       case "$HOST_RENDEZVOUS_ATSIGN" in
         [Aa][Mm]*)
           HOST_RENDEZVOUS_ATSIGN="@rv_am"
@@ -131,11 +133,14 @@ parse_args() {
         [Aa][Pp]*)
           HOST_RENDEZVOUS_ATSIGN="@rv_ap"
           ;;
+        @*)
+          # Do nothing for custom region
+          ;;
+        *)
+          echo "Invalid region: $HOST_RENDEZVOUS_ATSIGN"
+          read -rp "region: " HOST_RENDEZVOUS_ATSIGN;
+          ;;
       esac
-      if [[ "$HOST_RENDEZVOUS_ATSIGN" != @rv_* ]]; then
-        echo "Invalid region: $HOST_RENDEZVOUS_ATSIGN"
-        read -rp "region: " HOST_RENDEZVOUS_ATSIGN;
-      fi
     done
 
     norm_atsign CLIENT_ATSIGN

--- a/packages/sshnoports/scripts/install_sshnp
+++ b/packages/sshnoports/scripts/install_sshnp
@@ -4,7 +4,7 @@ BINARY_NAME="sshnp";
 
 norm_atsign() {
   KEY="$1" # Get the variable name
-  INPUT=${!KEY} # Get the value of the variable
+  eval INPUT="\$$KEY" # Get the value of the variable
   shopt -s extglob
   ATSIGN=${INPUT/#?(\@)/\@} # Add @ if missing
   shopt -u extglob

--- a/packages/sshnoports/scripts/install_sshnp
+++ b/packages/sshnoports/scripts/install_sshnp
@@ -38,7 +38,8 @@ usage() {
 }
 
 parse_args() {
-   SSHNP_OP="install"
+  echo "ARGS: $*"
+  SSHNP_OP="install"
   while [ $# -gt 0 ]; do
     case "$1" in
       -u|--update)

--- a/packages/sshnoports/scripts/install_sshnp
+++ b/packages/sshnoports/scripts/install_sshnp
@@ -115,7 +115,7 @@ parse_args() {
       read -rp "> " HOST_RENDEZVOUS_ATSIGN;
     fi
 
-    while echo "$HOST_RENDEZVOUS_ATSIGN" | grep  -Eq "@.*"; do
+    while ! echo "$HOST_RENDEZVOUS_ATSIGN" | grep  -Eq "@.*"; do
       case "$HOST_RENDEZVOUS_ATSIGN" in
         [Aa][Mm]*)
           HOST_RENDEZVOUS_ATSIGN="@rv_am"
@@ -136,8 +136,8 @@ parse_args() {
       esac
     done
 
-    CLIENT_ATSIGN="$(norm_atsign CLIENT_ATSIGN)"
-    DEVICE_MANAGER_ATSIGN="$(norm_atsign DEVICE_MANAGER_ATSIGN)"
+    CLIENT_ATSIGN="$(norm_atsign "$CLIENT_ATSIGN")"
+    DEVICE_MANAGER_ATSIGN="$(norm_atsign "$DEVICE_MANAGER_ATSIGN")"
     echo;
   fi
 }
@@ -151,7 +151,7 @@ parse_env() {
   if [ -z "$SSHNP_VERSION" ]; then
     SSHNP_VERSION="latest";
   else
-    SSHNP_VERSION="$(norm_version SSHNP_VERSION)"
+    SSHNP_VERSION="$(norm_version "$SSHNP_VERSION")"
   fi
   URL="https://api.github.com/repos/atsign-foundation/sshnoports/releases/$SSHNP_VERSION";
 

--- a/packages/sshnoports/scripts/install_sshnp
+++ b/packages/sshnoports/scripts/install_sshnp
@@ -123,7 +123,7 @@ parse_args() {
       read -rp "> " HOST_RENDEZVOUS_ATSIGN;
     fi
 
-    while [[ "$HOST_RENDEZVOUS_ATSIGN" != @* ]]; do
+    while echo "$HOST_RENDEZVOUS_ATSIGN" | grep  -Eq "@.*"; do
       case "$HOST_RENDEZVOUS_ATSIGN" in
         [Aa][Mm]*)
           HOST_RENDEZVOUS_ATSIGN="@rv_am"

--- a/packages/sshnoports/scripts/install_sshnp
+++ b/packages/sshnoports/scripts/install_sshnp
@@ -140,10 +140,6 @@ parse_args() {
     DEVICE_MANAGER_ATSIGN="$(norm_atsign "$DEVICE_MANAGER_ATSIGN")"
     echo;
   fi
-
-  echo "CLIENT_ATSIGN: $CLIENT_ATSIGN"
-  echo "DEVICE_MANAGER_ATSIGN: $DEVICE_MANAGER_ATSIGN"
-  echo "HOST_RENDEZVOUS_ATSIGN: $HOST_RENDEZVOUS_ATSIGN"
 }
 
 parse_env() {
@@ -173,7 +169,7 @@ parse_env() {
       ;;
   esac
 
-  if [ "$PLATFORM" == "Unknown" ]; then
+  if [ "$PLATFORM" = "Unknown" ]; then
     echo "Unsupported platform: $(uname)";
     exit 1;
   fi
@@ -187,7 +183,7 @@ parse_env() {
     *) ARCH="Unknown";;
   esac
 
-  if [ "$ARCH" == "Unknown" ]; then
+  if [ "$ARCH" = "Unknown" ]; then
     echo "Unsupported architecture: $(uname -m)";
     exit 1;
   fi

--- a/packages/sshnoports/scripts/install_sshnp
+++ b/packages/sshnoports/scripts/install_sshnp
@@ -257,6 +257,8 @@ setup_custom_binary() {
   <"$HOME_PATH/.atsign/temp/$BINARY_NAME/templates/client/sshnp-full.sh" \
   >"$HOME_PATH/.local/bin/$BINARY_NAME$DEVICE_MANAGER_ATSIGN"
   chmod +x "$HOME_PATH/.local/bin/$BINARY_NAME$DEVICE_MANAGER_ATSIGN";
+
+  cat "$HOME_PATH/.local/bin/$BINARY_NAME$DEVICE_MANAGER_ATSIGN";
 }
 
 post_install() {

--- a/packages/sshnoports/scripts/install_sshnp
+++ b/packages/sshnoports/scripts/install_sshnp
@@ -4,12 +4,12 @@ BINARY_NAME="sshnp";
 
 norm_atsign() {
   # shellcheck disable=SC2001
-  atsign="@$(echo "$1" | sed 's/^@//g')"
+  atsign="@$(echo "$1" | sed -e 's/"//g' -e 's/^@//g')"
   echo "$atsign"
 }
 
 norm_version() {
-  version="tags/v$(echo "$1" | sed -e 's/^tags\///g' -e 's/^v//g')"
+  version="tags/v$(echo "$1" | sed -e 's/"//g' -e 's/^tags\///g' -e 's/^v//g')"
   echo "$version"
 }
 

--- a/packages/sshnoports/scripts/install_sshnp
+++ b/packages/sshnoports/scripts/install_sshnp
@@ -30,7 +30,6 @@ usage() {
 }
 
 parse_args() {
-  echo "ARGS: $*"
   SSHNP_OP="install"
   while [ $# -gt 0 ]; do
     case "$1" in

--- a/packages/sshnoports/scripts/install_sshnp
+++ b/packages/sshnoports/scripts/install_sshnp
@@ -3,22 +3,14 @@
 BINARY_NAME="sshnp";
 
 norm_atsign() {
-  KEY="$1" # Get the variable name
-  eval INPUT="\$$KEY" # Get the value of the variable
-  shopt -s extglob
-  ATSIGN=${INPUT/#?(\@)/\@} # Add @ if missing
-  shopt -u extglob
-  export "${KEY}"="$ATSIGN" # Set the variable to new value
+  # shellcheck disable=SC2001
+  atsign="@$(echo "$1" | sed 's/^@//g')"
+  echo "$atsign"
 }
 
 norm_version() {
-  KEY="$1" # Get the variable name
-  INPUT=${!KEY} # Get the value of the variable
-  shopt -s extglob
-  OUTPUT=${INPUT#tags\/} # Remove tags prefix if present
-  OUTPUT=${OUTPUT#v} # Remove v prefix if present
-  shopt -u extglob
-  export "${KEY}"="tags/v$OUTPUT" # Add full tags/v prefix
+  version="tags/v$(echo "$1" | sed -e 's/^tags\///g' -e 's/^v//g')"
+  echo "$version"
 }
 
 usage() {
@@ -144,8 +136,8 @@ parse_args() {
       esac
     done
 
-    norm_atsign CLIENT_ATSIGN
-    norm_atsign DEVICE_MANAGER_ATSIGN
+    CLIENT_ATSIGN="$(norm_atsign CLIENT_ATSIGN)"
+    DEVICE_MANAGER_ATSIGN="$(norm_atsign DEVICE_MANAGER_ATSIGN)"
     echo;
   fi
 }
@@ -159,7 +151,7 @@ parse_env() {
   if [ -z "$SSHNP_VERSION" ]; then
     SSHNP_VERSION="latest";
   else
-    norm_version SSHNP_VERSION
+    SSHNP_VERSION="$(norm_version SSHNP_VERSION)"
   fi
   URL="https://api.github.com/repos/atsign-foundation/sshnoports/releases/$SSHNP_VERSION";
 

--- a/packages/sshnoports/scripts/install_sshnp
+++ b/packages/sshnoports/scripts/install_sshnp
@@ -140,6 +140,10 @@ parse_args() {
     DEVICE_MANAGER_ATSIGN="$(norm_atsign "$DEVICE_MANAGER_ATSIGN")"
     echo;
   fi
+
+  echo "CLIENT_ATSIGN: $CLIENT_ATSIGN"
+  echo "DEVICE_MANAGER_ATSIGN: $DEVICE_MANAGER_ATSIGN"
+  echo "HOST_RENDEZVOUS_ATSIGN: $HOST_RENDEZVOUS_ATSIGN"
 }
 
 parse_env() {

--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -325,8 +325,8 @@ setup_service() {
   fi
 
   CRONTAB_CONTENTS=$(crontab -l 2>/dev/null);
-  PREVIOUS_CRON_ENTRY=$(grep -Fxq "$SSHNP_CRON_SCHEDULE $SSHNP_COMMAND" <<< "$CRONTAB_CONTENTS")
-  if [ -z "$PREVIOUS_CRON_ENTRY" ]; then
+  PREVIOUS_CRON_ENTRY=$(echo "$CRONTAB_CONTENTS" | grep -Fxq "$SSHNP_CRON_SCHEDULE $SSHNP_COMMAND")
+  if [ -n "$PREVIOUS_CRON_ENTRY" ]; then
     NO_RUN=1;
     echo "Cron job already installed: '$SSHNP_CRON_SCHEDULE $SSHNP_COMMAND'";
   else
@@ -334,11 +334,14 @@ setup_service() {
     echo "Installed cron job: '$SSHNP_CRON_SCHEDULE $SSHNP_COMMAND'";
   fi
 
+  
   if [ "$SSHNPD_SERVICE_MECHANISM" = "cron" ]; then
-    if grep -Fxq "$LOGROTATE" <(crontab -l 2>/dev/null); then
+    CRONTAB_CONTENTS=$(crontab -l 2>/dev/null);
+    PREVIOUS_LOGROTATE_ENTRY=$(echo "$CRONTAB_CONTENTS" | grep -Fxq "$LOGROTATE")
+    if [ -n "$PREVIOUS_LOGROTATE_ENTRY" ]; then
       echo "Cron job already installed: '$LOGROTATE'";
     else
-      (crontab -l 2>/dev/null; echo "$LOGROTATE") | crontab -
+      (echo "$CRONTAB_CONTENTS"; echo "$LOGROTATE") | crontab -
       echo "Installed cron job: '$LOGROTATE'";
     fi
   fi

--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -325,11 +325,12 @@ setup_service() {
   fi
 
   CRONTAB_CONTENTS=$(crontab -l 2>/dev/null);
-  if grep -Fxq "$SSHNP_CRON_SCHEDULE $SSHNP_COMMAND" <<< "$CRONTAB_CONTENTS"; then
+  PREVIOUS_CRON_ENTRY=$(grep -Fxq "$SSHNP_CRON_SCHEDULE $SSHNP_COMMAND" <<< "$CRONTAB_CONTENTS")
+  if [ -z "$PREVIOUS_CRON_ENTRY" ]; then
     NO_RUN=1;
     echo "Cron job already installed: '$SSHNP_CRON_SCHEDULE $SSHNP_COMMAND'";
   else
-    (crontab -l 2>/dev/null; echo "$SSHNP_CRON_SCHEDULE $SSHNP_COMMAND") | crontab -
+    (echo "$CRONTAB_CONTENTS"; echo "$SSHNP_CRON_SCHEDULE $SSHNP_COMMAND") | crontab -
     echo "Installed cron job: '$SSHNP_CRON_SCHEDULE $SSHNP_COMMAND'";
   fi
 

--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -324,7 +324,8 @@ setup_service() {
     LOGROTATE="40 6 * * * logrotate -f $HOME_PATH/.$BINARY_NAME/logs/$CLIENT_ATSIGN.log"
   fi
 
-  if grep -Fxq "$SSHNP_CRON_SCHEDULE $SSHNP_COMMAND" <(crontab -l 2>/dev/null); then
+  CRONTAB_CONTENTS=$(crontab -l 2>/dev/null);
+  if grep -Fxq "$SSHNP_CRON_SCHEDULE $SSHNP_COMMAND" <<< "$CRONTAB_CONTENTS"; then
     NO_RUN=1;
     echo "Cron job already installed: '$SSHNP_CRON_SCHEDULE $SSHNP_COMMAND'";
   else

--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -300,7 +300,12 @@ setup_service() {
     SERVICE_RUN_LINE=$(grep 'sshnpd ' < "$SSHNPD_SERVICE_BINARY_PATH")
     OLD_DEVICE_NAME=$(echo "${SERVICE_RUN_LINE// -d /;/}" | cut -d';' -f2 | cut -d '"' -f2)
     echo "Renaming $OLD_DEVICE_NAME to $SSHNP_DEVICE_NAME"
-    sed -i "s/\"$OLD_DEVICE_NAME\"/\"$SSHNP_DEVICE_NAME\"/g" "$SSHNPD_SERVICE_BINARY_PATH"
+    if [[ "$PLATFORM" = "macos" ]];
+    then
+      sed -i '' "s/\"$OLD_DEVICE_NAME\"/\"$SSHNP_DEVICE_NAME\"/g" "$SSHNPD_SERVICE_BINARY_PATH"
+    else
+      sed -i "s/\"$OLD_DEVICE_NAME\"/\"$SSHNP_DEVICE_NAME\"/g" "$SSHNPD_SERVICE_BINARY_PATH"
+    fi
   fi
 
   SSHNP_CRON_SCHEDULE="@reboot";
@@ -326,7 +331,7 @@ setup_service() {
     echo "Installed cron job: '$SSHNP_CRON_SCHEDULE $SSHNP_COMMAND'";
   fi
 
-  
+
   if [ "$SSHNPD_SERVICE_MECHANISM" = "cron" ]; then
     CRONTAB_CONTENTS=$(crontab -l 2>/dev/null);
     PREVIOUS_LOGROTATE_ENTRY=$(echo "$CRONTAB_CONTENTS" | grep -Fxq "$LOGROTATE")

--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -125,8 +125,8 @@ parse_args() {
           read -rp "Device name: " SSHNP_DEVICE_NAME;
       done;
 
-      CLIENT_ATSIGN="$(norm_atsign CLIENT_ATSIGN)"
-      DEVICE_MANAGER_ATSIGN="$(norm_atsign DEVICE_MANAGER_ATSIGN)"
+      CLIENT_ATSIGN="$(norm_atsign "$CLIENT_ATSIGN")"
+      DEVICE_MANAGER_ATSIGN="$(norm_atsign "$DEVICE_MANAGER_ATSIGN")"
       echo;
   esac
 }
@@ -140,7 +140,7 @@ parse_env() {
   if [ -z "$SSHNP_VERSION" ]; then
     SSHNP_VERSION="latest";
   else
-    SSHNP_VERSION="$(norm_version SSHNP_VERSION)"
+    SSHNP_VERSION="$(norm_version "$SSHNP_VERSION")"
   fi
   URL="https://api.github.com/repos/atsign-foundation/sshnoports/releases/$SSHNP_VERSION";
 

--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -314,7 +314,7 @@ rename_device() {
         then
           sed -i '' "s/\"$OLD_DEVICE_NAME\"/\"$SSHNP_DEVICE_NAME\"/g" "$SSHNPD_SERVICE_BINARY_PATH"
         else
-          sed -i '' "s/\"$OLD_DEVICE_NAME\"/\"$SSHNP_DEVICE_NAME\"/g" "$SSHNPD_SERVICE_BINARY_PATH"
+          sed -i "s/\"$OLD_DEVICE_NAME\"/\"$SSHNP_DEVICE_NAME\"/g" "$SSHNPD_SERVICE_BINARY_PATH"
         fi
       ;;
     2.*)

--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -4,7 +4,7 @@ BINARY_NAME="sshnpd";
 
 norm_atsign() {
   KEY="$1" # Get the variable name
-  INPUT=${!KEY} # Get the value of the variable
+  eval INPUT="\$$KEY" # Get the value of the variable
   shopt -s extglob
   ATSIGN=${INPUT/#?(\@)/\@} # Add @ if missing
   shopt -u extglob

--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -158,7 +158,7 @@ parse_env() {
       ;;
   esac
 
-  if [ "$PLATFORM" == "Unknown" ]; then
+  if [ "$PLATFORM" = "Unknown" ]; then
     echo "Unsupported platform: $(uname)";
     exit 1;
   fi
@@ -172,7 +172,7 @@ parse_env() {
     *) ARCH="Unknown";;
   esac
 
-  if [ "$ARCH" == "Unknown" ]; then
+  if [ "$ARCH" = "Unknown" ]; then
     echo "Unsupported architecture: $(uname -m)";
     exit 1;
   fi
@@ -222,7 +222,7 @@ download() {
       echo;
       echo "Please try again, or download manually from $DOWNLOAD";
       echo "After downloading manually, run the following command to install:";
-      if [ "$0" == 'bash' ]; then
+      if [ "$0" = 'bash' ]; then
         echo "bash -c \"\$(curl https://getsshnpd.noports.com)\" -- -l <path to $EXT file>";
       else
         echo "  $0 -l <path to $EXT file>";

--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -3,22 +3,14 @@
 BINARY_NAME="sshnpd";
 
 norm_atsign() {
-  KEY="$1" # Get the variable name
-  eval INPUT="\$$KEY" # Get the value of the variable
-  shopt -s extglob
-  ATSIGN=${INPUT/#?(\@)/\@} # Add @ if missing
-  shopt -u extglob
-  export "${KEY}"="$ATSIGN" # Set the variable to new value
+  # shellcheck disable=SC2001
+  atsign="@$(echo "$1" | sed 's/^@//g')"
+  echo "$atsign"
 }
 
 norm_version() {
-  KEY="$1" # Get the variable name
-  INPUT=${!KEY} # Get the value of the variable
-  shopt -s extglob
-  OUTPUT=${INPUT#tags\/} # Remove tags prefix if present
-  OUTPUT=${OUTPUT#v} # Remove v prefix if present
-  shopt -u extglob
-  export "${KEY}"="tags/v$OUTPUT" # Add full tags/v prefix
+  version="tags/v$(echo "$1" | sed -e 's/^tags\///g' -e 's/^v//g')"
+  echo "$version"
 }
 
 usage() {
@@ -133,8 +125,8 @@ parse_args() {
           read -rp "Device name: " SSHNP_DEVICE_NAME;
       done;
 
-      norm_atsign CLIENT_ATSIGN
-      norm_atsign DEVICE_MANAGER_ATSIGN
+      CLIENT_ATSIGN="$(norm_atsign CLIENT_ATSIGN)"
+      DEVICE_MANAGER_ATSIGN="$(norm_atsign DEVICE_MANAGER_ATSIGN)"
       echo;
   esac
 }
@@ -148,7 +140,7 @@ parse_env() {
   if [ -z "$SSHNP_VERSION" ]; then
     SSHNP_VERSION="latest";
   else
-    norm_version SSHNP_VERSION
+    SSHNP_VERSION="$(norm_version SSHNP_VERSION)"
   fi
   URL="https://api.github.com/repos/atsign-foundation/sshnoports/releases/$SSHNP_VERSION";
 

--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -128,7 +128,7 @@ parse_args() {
 
       while [ -z "$SSHNP_DEVICE_NAME" ] ||
         [ "${#SSHNP_DEVICE_NAME}" -gt 15 ] ||
-        [[ "$SSHNP_DEVICE_NAME" =~ [^a-zA-Z0-9_] ]]; do
+        echo "$SSHNP_DEVICE_NAME" |  grep -Eq "[^a-zA-Z0-9_]"; do
           echo "Device name must be between 1 and 15 characters and only contain alphanumeric characters or \"_\"";
           read -rp "Device name: " SSHNP_DEVICE_NAME;
       done;

--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -4,12 +4,12 @@ BINARY_NAME="sshnpd";
 
 norm_atsign() {
   # shellcheck disable=SC2001
-  atsign="@$(echo "$1" | sed 's/^@//g')"
+  atsign="@$(echo "$1" | sed -e 's/"//g' -e 's/^@//g')"
   echo "$atsign"
 }
 
 norm_version() {
-  version="tags/v$(echo "$1" | sed -e 's/^tags\///g' -e 's/^v//g')"
+  version="tags/v$(echo "$1" | sed -e 's/"//g' -e 's/^tags\///g' -e 's/^v//g')"
   echo "$version"
 }
 

--- a/tests/end2end_tests/image/Dockerfile
+++ b/tests/end2end_tests/image/Dockerfile
@@ -85,7 +85,7 @@ CMD sudo service ssh start
 
 RUN set -eux ; \
   apt-get update ; \
-  apt-get install -y openssh-server sudo vim nano iproute2 nmap tmux cron ; \
+  apt-get install -y openssh-server sudo vim nano iproute2 nmap tmux curl cron ; \
   groupadd --gid ${GROUP_ID} ${USER} ; \
   useradd --system --shell /bin/bash --home ${HOMEDIR} --uid ${USER_ID} --gid ${GROUP_ID} ${USER} ; \
   usermod -aG sudo ${USER} ; \

--- a/tests/end2end_tests/image/Dockerfile
+++ b/tests/end2end_tests/image/Dockerfile
@@ -153,7 +153,7 @@ ENV USE_INSTALLER=1
 
 ENTRYPOINT sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
 
-FROM base AS runtime-sshnpd-installer
+FROM base AS build-sshnpd-installer
 
 WORKDIR ${HOMEDIR}
 USER ${USER}
@@ -175,9 +175,11 @@ RUN set -eux ; \
   -d ${device_atsign} \
   -n ${device_name};
 
-RUN cat /atsign/.local/bin/sshnpd@8incanteater
+FROM base AS runtime-sshnpd-installer
 
-ENTRYPOINT sudo service cron start && sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
+ENV USE_INSTALLER=1
+
+ENTRYPOINT sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
 
 FROM runtime-branch AS manual-branch
 

--- a/tests/end2end_tests/image/Dockerfile
+++ b/tests/end2end_tests/image/Dockerfile
@@ -174,6 +174,7 @@ RUN set -eux ; \
   -d ${device_atsign} \
   -n ${device_name};
 
+RUN cat /atsign/.local/bin/sshnpd@${client_atsign}
 # FROM build-sshnpd-installer AS runtime-sshnpd-installer
 
 ENV USE_INSTALLER=1

--- a/tests/end2end_tests/image/Dockerfile
+++ b/tests/end2end_tests/image/Dockerfile
@@ -141,11 +141,12 @@ ARG CLIENT_ATSIGN
 ARG DEVICE_ATSIGN
 ARG HOST_ATSIGN
 
+ENV USE_INSTALLER=1
+
 RUN sh ${REPO_DIR}/packages/sshnoports/scripts/install_sshnp \
   -c ${CLIENT_ATSIGN} \
   -d ${DEVICE_ATSIGN} \
-  -h ${HOST_ATSIGN}; \
-  sed -i 's/USE_INSTALLER=0/USE_INSTALLER=1/g' ${HOMEDIR}/entrypoint.sh;
+  -h ${HOST_ATSIGN};
 
 ENTRYPOINT sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
 
@@ -163,13 +164,14 @@ ARG CLIENT_ATSIGN
 ARG DEVICE_ATSIGN
 ARG DEVICE_NAME
 
+ENV USE_INSTALLER=1
+
 RUN sudo service cron start; \
   sleep 2; \
   sh ${REPO_DIR}/packages/sshnoports/scripts/install_sshnpd \
   -c ${CLIENT_ATSIGN} \
   -d ${DEVICE_ATSIGN} \
-  -n ${DEVICE_NAME}; \
-  sed -i 's/USE_INSTALLER=0/USE_INSTALLER=1/g' ${HOMEDIR}/entrypoint.sh;
+  -n ${DEVICE_NAME};
 
 ENTRYPOINT sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
 

--- a/tests/end2end_tests/image/Dockerfile
+++ b/tests/end2end_tests/image/Dockerfile
@@ -129,8 +129,8 @@ ENTRYPOINT sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
 
 FROM base AS build-sshnp-installer
 
-WORKDIR ${HOMEDIR}
 USER ${USER}
+WORKDIR ${HOMEDIR}
 
 ENV REPO_DIR=/app/repo
 
@@ -149,14 +149,17 @@ RUN set -eux; \
 
 FROM build-sshnp-installer AS runtime-sshnp-installer
 
+USER ${USER}
+WORKDIR ${HOMEDIR}
+
 ENV USE_INSTALLER=1
 
 ENTRYPOINT sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
 
 FROM base AS build-sshnpd-installer
 
-WORKDIR ${HOMEDIR}
 USER ${USER}
+WORKDIR ${HOMEDIR}
 
 ENV REPO_DIR=/app/repo
 ENV USE_INSTALLER=1
@@ -176,6 +179,9 @@ RUN set -eux ; \
   -n ${device_name};
 
 FROM base AS runtime-sshnpd-installer
+
+USER ${USER}
+WORKDIR ${HOMEDIR}
 
 ENV USE_INSTALLER=1
 

--- a/tests/end2end_tests/image/Dockerfile
+++ b/tests/end2end_tests/image/Dockerfile
@@ -137,16 +137,16 @@ ENV REPO_DIR=/app/repo
 # context must be the root of the repo
 COPY . ${REPO_DIR}
 
-ARG CLIENT_ATSIGN
-ARG DEVICE_ATSIGN
-ARG HOST_ATSIGN
+ARG client_atsign
+ARG device_atsign
+ARG host_atsign
 
 ENV USE_INSTALLER=1
 
 RUN sh ${REPO_DIR}/packages/sshnoports/scripts/install_sshnp \
-  -c ${CLIENT_ATSIGN} \
-  -d ${DEVICE_ATSIGN} \
-  -h ${HOST_ATSIGN};
+  -c ${client_atsign} \
+  -d ${device_atsign} \
+  -h ${host_atsign};
 
 ENTRYPOINT sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
 
@@ -160,18 +160,18 @@ ENV REPO_DIR=/app/repo
 # context must be the root of the repo
 COPY . ${REPO_DIR}
 
-ARG CLIENT_ATSIGN
-ARG DEVICE_ATSIGN
-ARG DEVICE_NAME
+ARG client_atsign
+ARG device_atsign
+ARG device_name
 
 ENV USE_INSTALLER=1
 
 RUN sudo service cron start; \
   sleep 2; \
   sh ${REPO_DIR}/packages/sshnoports/scripts/install_sshnpd \
-  -c ${CLIENT_ATSIGN} \
-  -d ${DEVICE_ATSIGN} \
-  -n ${DEVICE_NAME};
+  -c ${client_atsign} \
+  -d ${device_atsign} \
+  -n ${device_name};
 
 ENTRYPOINT sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
 

--- a/tests/end2end_tests/image/Dockerfile
+++ b/tests/end2end_tests/image/Dockerfile
@@ -85,7 +85,7 @@ CMD sudo service ssh start
 
 RUN set -eux ; \
   apt-get update ; \
-  apt-get install -y openssh-server sudo vim nano iproute2 nmap tmux ; \
+  apt-get install -y openssh-server sudo vim nano iproute2 nmap tmux cron ; \
   groupadd --gid ${GROUP_ID} ${USER} ; \
   useradd --system --shell /bin/bash --home ${HOMEDIR} --uid ${USER_ID} --gid ${GROUP_ID} ${USER} ; \
   usermod -aG sudo ${USER} ; \
@@ -124,6 +124,54 @@ COPY --chown=${USER}:${USER} --from=build-local /app/output ${HOMEDIR}/.local/bi
 WORKDIR ${HOMEDIR}
 
 USER ${USER}
+
+ENTRYPOINT sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
+
+FROM base AS runtime-sshnp-installer
+
+WORKDIR ${HOMEDIR}
+USER ${USER}
+
+ENV REPO_DIR=/app/repo
+
+# context must be the root of the repo
+COPY . ${REPO_DIR}
+
+ARG CLIENT_ATSIGN
+ARG DEVICE_ATSIGN
+ARG HOST_ATSIGN
+
+RUN sudo service cron start && \
+  sleep 2 && \
+  sh ${REPO_DIR}/packages/sshnoports/scripts/install_sshnp.sh \
+  -c ${CLIENT_ATSIGN} \
+  -d ${DEVICE_ATSIGN} \
+  -h ${HOST_ATSIGN} \
+  sed -i 's/USE_INSTALLER=0/USE_INSTALLER=1/g' ${HOMEDIR}/entrypoint.sh;
+
+ENTRYPOINT sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
+
+FROM base AS runtime-sshnpd-installer
+
+WORKDIR ${HOMEDIR}
+USER ${USER}
+
+ENV REPO_DIR=/app/repo
+
+# context must be the root of the repo
+COPY . ${REPO_DIR}
+
+ARG CLIENT_ATSIGN
+ARG DEVICE_ATSIGN
+ARG DEVICE_NAME
+
+RUN sudo service cron start && \
+  sleep 2 && \
+  sh ${REPO_DIR}/packages/sshnoports/scripts/install_sshnp.sh \
+  -c ${CLIENT_ATSIGN} \
+  -d ${DEVICE_ATSIGN} \
+  -n ${DEVICE_NAME} \
+  sed -i 's/USE_INSTALLER=0/USE_INSTALLER=1/g' ${HOMEDIR}/entrypoint.sh;
 
 ENTRYPOINT sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
 

--- a/tests/end2end_tests/image/Dockerfile
+++ b/tests/end2end_tests/image/Dockerfile
@@ -178,7 +178,7 @@ RUN set -eux ; \
   -d ${device_atsign} \
   -n ${device_name};
 
-FROM base AS runtime-sshnpd-installer
+FROM build-sshnpd-installer AS runtime-sshnpd-installer
 
 USER ${USER}
 WORKDIR ${HOMEDIR}

--- a/tests/end2end_tests/image/Dockerfile
+++ b/tests/end2end_tests/image/Dockerfile
@@ -127,7 +127,7 @@ USER ${USER}
 
 ENTRYPOINT sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
 
-FROM base AS runtime-sshnp-installer
+FROM base AS build-sshnp-installer
 
 WORKDIR ${HOMEDIR}
 USER ${USER}
@@ -141,17 +141,19 @@ ARG client_atsign
 ARG device_atsign
 ARG host_atsign
 
-ENV USE_INSTALLER=1
-
 RUN set -eux; \
   sh ${REPO_DIR}/packages/sshnoports/scripts/install_sshnp \
   -c ${client_atsign} \
   -d ${device_atsign} \
   -h ${host_atsign};
 
+FROM build-sshnp-installer AS runtime-sshnp-installer
+
+ENV USE_INSTALLER=1
+
 ENTRYPOINT sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
 
-FROM base AS runtime-sshnpd-installer
+FROM base AS build-sshnpd-installer
 
 WORKDIR ${HOMEDIR}
 USER ${USER}
@@ -165,8 +167,6 @@ ARG client_atsign
 ARG device_atsign
 ARG device_name
 
-ENV USE_INSTALLER=1
-
 RUN set -eux ; \
   sudo service cron start; \
   sh ${REPO_DIR}/packages/sshnoports/scripts/install_sshnpd \
@@ -174,7 +174,11 @@ RUN set -eux ; \
   -d ${device_atsign} \
   -n ${device_name};
 
-ENTRYPOINT sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
+FROM build-sshnpd-installer AS runtime-sshnpd-installer
+
+ENV USE_INSTALLER=1
+
+ENTRYPOINT sudo service cron start && sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
 
 FROM runtime-branch AS manual-branch
 

--- a/tests/end2end_tests/image/Dockerfile
+++ b/tests/end2end_tests/image/Dockerfile
@@ -169,7 +169,6 @@ ENV USE_INSTALLER=1
 
 RUN set -eux ; \
   sudo service cron start; \
-  sleep 2; \
   sh ${REPO_DIR}/packages/sshnoports/scripts/install_sshnpd \
   -c ${client_atsign} \
   -d ${device_atsign} \

--- a/tests/end2end_tests/image/Dockerfile
+++ b/tests/end2end_tests/image/Dockerfile
@@ -159,6 +159,7 @@ WORKDIR ${HOMEDIR}
 USER ${USER}
 
 ENV REPO_DIR=/app/repo
+ENV USE_INSTALLER=1
 
 # context must be the root of the repo
 COPY . ${REPO_DIR}
@@ -174,10 +175,7 @@ RUN set -eux ; \
   -d ${device_atsign} \
   -n ${device_name};
 
-RUN cat /atsign/.local/bin/sshnpd@${client_atsign}
-# FROM build-sshnpd-installer AS runtime-sshnpd-installer
-
-ENV USE_INSTALLER=1
+RUN cat /atsign/.local/bin/sshnpd@8incanteater
 
 ENTRYPOINT sudo service cron start && sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
 

--- a/tests/end2end_tests/image/Dockerfile
+++ b/tests/end2end_tests/image/Dockerfile
@@ -143,7 +143,7 @@ ARG HOST_ATSIGN
 
 RUN sudo service cron start && \
   sleep 2 && \
-  sh ${REPO_DIR}/packages/sshnoports/scripts/install_sshnp.sh \
+  sh ${REPO_DIR}/packages/sshnoports/scripts/install_sshnp \
   -c ${CLIENT_ATSIGN} \
   -d ${DEVICE_ATSIGN} \
   -h ${HOST_ATSIGN} \
@@ -167,7 +167,7 @@ ARG DEVICE_NAME
 
 RUN sudo service cron start && \
   sleep 2 && \
-  sh ${REPO_DIR}/packages/sshnoports/scripts/install_sshnp.sh \
+  sh ${REPO_DIR}/packages/sshnoports/scripts/install_sshnpd \
   -c ${CLIENT_ATSIGN} \
   -d ${DEVICE_ATSIGN} \
   -n ${DEVICE_NAME} \

--- a/tests/end2end_tests/image/Dockerfile
+++ b/tests/end2end_tests/image/Dockerfile
@@ -141,12 +141,10 @@ ARG CLIENT_ATSIGN
 ARG DEVICE_ATSIGN
 ARG HOST_ATSIGN
 
-RUN sudo service cron start && \
-  sleep 2 && \
-  sh ${REPO_DIR}/packages/sshnoports/scripts/install_sshnp \
+RUN sh ${REPO_DIR}/packages/sshnoports/scripts/install_sshnp \
   -c ${CLIENT_ATSIGN} \
   -d ${DEVICE_ATSIGN} \
-  -h ${HOST_ATSIGN} \
+  -h ${HOST_ATSIGN}; \
   sed -i 's/USE_INSTALLER=0/USE_INSTALLER=1/g' ${HOMEDIR}/entrypoint.sh;
 
 ENTRYPOINT sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
@@ -165,12 +163,12 @@ ARG CLIENT_ATSIGN
 ARG DEVICE_ATSIGN
 ARG DEVICE_NAME
 
-RUN sudo service cron start && \
-  sleep 2 && \
+RUN sudo service cron start; \
+  sleep 2; \
   sh ${REPO_DIR}/packages/sshnoports/scripts/install_sshnpd \
   -c ${CLIENT_ATSIGN} \
   -d ${DEVICE_ATSIGN} \
-  -n ${DEVICE_NAME} \
+  -n ${DEVICE_NAME}; \
   sed -i 's/USE_INSTALLER=0/USE_INSTALLER=1/g' ${HOMEDIR}/entrypoint.sh;
 
 ENTRYPOINT sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh

--- a/tests/end2end_tests/image/Dockerfile
+++ b/tests/end2end_tests/image/Dockerfile
@@ -143,7 +143,8 @@ ARG host_atsign
 
 ENV USE_INSTALLER=1
 
-RUN sh ${REPO_DIR}/packages/sshnoports/scripts/install_sshnp \
+RUN set -eux; \
+  sh ${REPO_DIR}/packages/sshnoports/scripts/install_sshnp \
   -c ${client_atsign} \
   -d ${device_atsign} \
   -h ${host_atsign};
@@ -166,7 +167,8 @@ ARG device_name
 
 ENV USE_INSTALLER=1
 
-RUN sudo service cron start; \
+RUN set -eux ; \
+  sudo service cron start; \
   sleep 2; \
   sh ${REPO_DIR}/packages/sshnoports/scripts/install_sshnpd \
   -c ${client_atsign} \
@@ -190,10 +192,6 @@ ENTRYPOINT sudo service ssh start && bash
 FROM base AS manual-blank
 
 WORKDIR ${HOMEDIR}
-
-RUN set -eux ; \
-  apt-get update ; \
-  apt-get install -y curl ;
 
 USER ${USER}
 

--- a/tests/end2end_tests/image/Dockerfile
+++ b/tests/end2end_tests/image/Dockerfile
@@ -153,7 +153,7 @@ ENV USE_INSTALLER=1
 
 ENTRYPOINT sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
 
-FROM base AS build-sshnpd-installer
+FROM base AS runtime-sshnpd-installer
 
 WORKDIR ${HOMEDIR}
 USER ${USER}
@@ -174,7 +174,7 @@ RUN set -eux ; \
   -d ${device_atsign} \
   -n ${device_name};
 
-FROM build-sshnpd-installer AS runtime-sshnpd-installer
+# FROM build-sshnpd-installer AS runtime-sshnpd-installer
 
 ENV USE_INSTALLER=1
 

--- a/tests/end2end_tests/templates/sshnp_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnp_entrypoint.sh
@@ -8,7 +8,7 @@ else
     SSHNP_CUSTOM_FILE_VERSION="$(sed -e '2!d' "$HOME"/.local/bin/sshnp@sshnpdatsign | cut -d'v' -f2)"
     case "$SSHNP_CUSTOM_FILE_VERSION" in
     1*)
-        SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign -h @sshrvdatsign deviceName -v > logs.txt"
+        SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign -h @sshrvdatsign deviceName > logs.txt"
         ;;
     *)
         SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign -h @sshrvdatsign -d deviceName -s id_ed25519.pub -v > logs.txt"

--- a/tests/end2end_tests/templates/sshnp_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnp_entrypoint.sh
@@ -8,10 +8,10 @@ else
     SSHNP_CUSTOM_FILE_VERSION="$(sed -e '2!d' "$HOME"/.local/bin/sshnp@sshnpdatsign | cut -d'v' -f2)"
     case "$SSHNP_CUSTOM_FILE_VERSION" in
     1*)
-        SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign -h @sshrvdatsign deviceName > logs.txt"
+        SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign -h \"@sshrvdatsign\" deviceName > logs.txt"
         ;;
     *)
-        SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign -h @sshrvdatsign -d deviceName -s id_ed25519.pub -v > logs.txt"
+        SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign -h \"@sshrvdatsign\" -d deviceName -s id_ed25519.pub -v > logs.txt"
         ;;
     esac
 fi

--- a/tests/end2end_tests/templates/sshnp_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnp_entrypoint.sh
@@ -8,7 +8,7 @@ else
     SSHNP_CUSTOM_FILE_VERSION="$(sed -e '2!d' "$HOME"/.local/bin/sshnp@sshnpdatsign | cut -d'v' -f2)"
     case "$SSHNP_CUSTOM_FILE_VERSION" in
     1*)
-        SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign deviceName -h @sshrvdatsign > logs.txt"
+        SSHNP_COMMAND="\$($HOME/.local/bin/sshnp@sshnpdatsign deviceName) > logs.txt"
         ;;
     *)
         SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign -d deviceName -h @sshrvdatsign -s id_ed25519.pub -v > logs.txt"

--- a/tests/end2end_tests/templates/sshnp_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnp_entrypoint.sh
@@ -1,23 +1,7 @@
 #!/bin/bash
 sleep WAITING_TIME # time for sshnpd to share device name
 
-if [ -z "$USE_INSTALLER" ]; then
-    SSHNP_COMMAND="$HOME/.local/bin/sshnp -f @sshnpatsign -t @sshnpdatsign -d deviceName -h @sshrvdatsign -s id_ed25519.pub -v > logs.txt"
-else
-    SSHNP_CUSTOM_FILE_VERSION="$(sed -e '2!d' "$HOME"/.local/bin/sshnp@sshnpdatsign | cut -d'v' -f2)"
-    case "$SSHNP_CUSTOM_FILE_VERSION" in
-    1*)
-        # Version 1 of the file cannot be tested in this environment since the
-        # keys are cut separately and cannot be passed into this version of the file
-        # SSHNP_COMMAND="\$($HOME/.local/bin/sshnp@sshnpdatsign deviceName) > logs.txt"
-
-        SSHNP_COMMAND="$HOME/.local/bin/sshnp -f @sshnpatsign -t @sshnpdatsign -d deviceName -h @sshrvdatsign -s id_ed25519.pub -v > logs.txt"
-        ;;
-    *)
-        SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign -d deviceName -h @sshrvdatsign -s id_ed25519.pub -v > logs.txt"
-        ;;
-    esac
-fi
+SSHNP_COMMAND="$HOME/.local/bin/sshnp -f @sshnpatsign -t @sshnpdatsign -d deviceName -h @sshrvdatsign -s id_ed25519.pub -v > logs.txt"
 echo "Running: $SSHNP_COMMAND"
 eval "$SSHNP_COMMAND"
 cat logs.txt
@@ -36,7 +20,7 @@ if [ ! -s sshcommand.txt ]; then
         exit 1
     fi
 fi
-echo -n " -o StrictHostKeyChecking=no " >> sshcommand.txt ;
+echo "$(sed '1!d' sshcommand.txt) -o StrictHostKeyChecking=no " > sshcommand.txt ;
 echo "ssh -p command: $(cat sshcommand.txt)"
 echo "sh test.sh " | eval "$(cat sshcommand.txt)"
 sleep 2 # time for ssh connection to properly exit

--- a/tests/end2end_tests/templates/sshnp_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnp_entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 sleep WAITING_TIME # time for sshnpd to share device name
-USE_INSTALLER=0
-if [ "$USE_INSTALLER" = 0 ]; then
+
+if [ -z "$USE_INSTALLER" ]; then
     SSHNP_COMMAND="$HOME/.local/bin/sshnp -f @sshnpatsign -t @sshnpdatsign -d deviceName -h @sshrvdatsign -s id_ed25519.pub -v > logs.txt"
-elif [ "$USE_INSTALLER" = 1 ]; then
+else
     SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign -d deviceName -s id_ed25519.pub -v > logs.txt"
 fi
 echo "Running: $SSHNP_COMMAND"

--- a/tests/end2end_tests/templates/sshnp_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnp_entrypoint.sh
@@ -36,7 +36,7 @@ if [ ! -s sshcommand.txt ]; then
         exit 1
     fi
 fi
-echo " -o StrictHostKeyChecking=no " >> sshcommand.txt ;
+echo -n " -o StrictHostKeyChecking=no " >> sshcommand.txt ;
 echo "ssh -p command: $(cat sshcommand.txt)"
 echo "sh test.sh " | eval "$(cat sshcommand.txt)"
 sleep 2 # time for ssh connection to properly exit

--- a/tests/end2end_tests/templates/sshnp_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnp_entrypoint.sh
@@ -8,10 +8,10 @@ else
     SSHNP_CUSTOM_FILE_VERSION="$(sed -e '2!d' "$HOME"/.local/bin/sshnp@sshnpdatsign | cut -d'v' -f2)"
     case "$SSHNP_CUSTOM_FILE_VERSION" in
     1*)
-        SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign -h \"@sshrvdatsign\" deviceName > logs.txt"
+        SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign deviceName -h @sshrvdatsign > logs.txt"
         ;;
     *)
-        SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign -h \"@sshrvdatsign\" -d deviceName -s id_ed25519.pub -v > logs.txt"
+        SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign -d deviceName -h @sshrvdatsign -s id_ed25519.pub -v > logs.txt"
         ;;
     esac
 fi

--- a/tests/end2end_tests/templates/sshnp_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnp_entrypoint.sh
@@ -4,6 +4,7 @@ sleep WAITING_TIME # time for sshnpd to share device name
 if [ -z "$USE_INSTALLER" ]; then
     SSHNP_COMMAND="$HOME/.local/bin/sshnp -f @sshnpatsign -t @sshnpdatsign -d deviceName -h @sshrvdatsign -s id_ed25519.pub -v > logs.txt"
 else
+    cat "$HOME/.local/bin/sshnp@sshnpdatsign"
     SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign -d deviceName -s id_ed25519.pub -v > logs.txt"
 fi
 echo "Running: $SSHNP_COMMAND"

--- a/tests/end2end_tests/templates/sshnp_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnp_entrypoint.sh
@@ -1,21 +1,24 @@
 #!/bin/bash
 sleep WAITING_TIME # time for sshnpd to share device name
-SSHNP_COMMAND="~/.local/bin/sshnp -f @sshnpatsign -t @sshnpdatsign -d deviceName -h @sshrvdatsign -s id_ed25519.pub -v > logs.txt"
+USE_INSTALLER=0
+if [ "$USE_INSTALLER" = 0 ]; then
+    SSHNP_COMMAND="$HOME/.local/bin/sshnp -f @sshnpatsign -t @sshnpdatsign -d deviceName -h @sshrvdatsign -s id_ed25519.pub -v > logs.txt"
+elif [ "$USE_INSTALLER" = 1 ]; then
+    SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign -d deviceName -s id_ed25519.pub -v > logs.txt"
+fi
 echo "Running: $SSHNP_COMMAND"
-eval $SSHNP_COMMAND
+eval "$SSHNP_COMMAND"
 cat logs.txt
 tail -n 5 logs.txt | grep "ssh -p" > sshcommand.txt
 
-if [ ! -s sshcommand.txt ]
-then
+if [ ! -s sshcommand.txt ]; then
     # try again
     echo "Running: $SSHNP_COMMAND"
-    eval $SSHNP_COMMAND
+    eval "$SSHNP_COMMAND"
     cat logs.txt
     tail -n 5 logs.txt | grep "ssh -p" > sshcommand.txt
-    if [ ! -s sshcommand.txt ]
-    then
-        echo "could not find \'ssh -p\' command in logs.txt"
+    if [ ! -s sshcommand.txt ]; then
+        echo "could not find 'ssh -p' command in logs.txt"
         echo "last 5 lines of logs.txt:"
         tail -n 5 logs.txt || echo
         exit 1
@@ -23,5 +26,5 @@ then
 fi
 echo " -o StrictHostKeyChecking=no " >> sshcommand.txt ;
 echo "ssh -p command: $(cat sshcommand.txt)"
-echo "sh test.sh " | $(cat sshcommand.txt)
+echo "sh test.sh " | eval "$(cat sshcommand.txt)"
 sleep 2 # time for ssh connection to properly exit

--- a/tests/end2end_tests/templates/sshnp_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnp_entrypoint.sh
@@ -4,7 +4,6 @@ sleep WAITING_TIME # time for sshnpd to share device name
 if [ -z "$USE_INSTALLER" ]; then
     SSHNP_COMMAND="$HOME/.local/bin/sshnp -f @sshnpatsign -t @sshnpdatsign -d deviceName -h @sshrvdatsign -s id_ed25519.pub -v > logs.txt"
 else
-    cat "$HOME/.local/bin/sshnp@sshnpdatsign"
     SSHNP_CUSTOM_FILE_VERSION="$(sed -e '2!d' "$HOME"/.local/bin/sshnp@sshnpdatsign | cut -d'v' -f2)"
     case "$SSHNP_CUSTOM_FILE_VERSION" in
     1*)

--- a/tests/end2end_tests/templates/sshnp_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnp_entrypoint.sh
@@ -8,7 +8,11 @@ else
     SSHNP_CUSTOM_FILE_VERSION="$(sed -e '2!d' "$HOME"/.local/bin/sshnp@sshnpdatsign | cut -d'v' -f2)"
     case "$SSHNP_CUSTOM_FILE_VERSION" in
     1*)
-        SSHNP_COMMAND="\$($HOME/.local/bin/sshnp@sshnpdatsign deviceName) > logs.txt"
+        # Version 1 of the file cannot be tested in this environment since the
+        # keys are cut separately and cannot be passed into this version of the file
+        # SSHNP_COMMAND="\$($HOME/.local/bin/sshnp@sshnpdatsign deviceName) > logs.txt"
+
+        SSHNP_COMMAND="$HOME/.local/bin/sshnp -f @sshnpatsign -t @sshnpdatsign -d deviceName -h @sshrvdatsign -s id_ed25519.pub -v > logs.txt"
         ;;
     *)
         SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign -d deviceName -h @sshrvdatsign -s id_ed25519.pub -v > logs.txt"

--- a/tests/end2end_tests/templates/sshnp_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnp_entrypoint.sh
@@ -5,7 +5,15 @@ if [ -z "$USE_INSTALLER" ]; then
     SSHNP_COMMAND="$HOME/.local/bin/sshnp -f @sshnpatsign -t @sshnpdatsign -d deviceName -h @sshrvdatsign -s id_ed25519.pub -v > logs.txt"
 else
     cat "$HOME/.local/bin/sshnp@sshnpdatsign"
-    SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign -d deviceName -s id_ed25519.pub -v > logs.txt"
+    SSHNP_CUSTOM_FILE_VERSION="$(sed -e '2!d' "$HOME"/.local/bin/sshnp@sshnpdatsign | cut -d'v' -f2)"
+    case "$SSHNP_CUSTOM_FILE_VERSION" in
+    1*)
+        SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign -h @sshrvdatsign deviceName -v > logs.txt"
+        ;;
+    *)
+        SSHNP_COMMAND="$HOME/.local/bin/sshnp@sshnpdatsign -h @sshrvdatsign -d deviceName -s id_ed25519.pub -v > logs.txt"
+        ;;
+    esac
 fi
 echo "Running: $SSHNP_COMMAND"
 eval "$SSHNP_COMMAND"

--- a/tests/end2end_tests/templates/sshnp_installer_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnp_installer_entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+sleep WAITING_TIME # time for sshnpd to share device name
+
+SSHNP_COMMAND="$HOME/.local/bin/sshnp -f @sshnpatsign -t @sshnpdatsign -d deviceName -h @sshrvdatsign -s id_ed25519.pub -v > logs.txt"
+echo "Running: $SSHNP_COMMAND"
+eval "$SSHNP_COMMAND"
+cat logs.txt
+tail -n 5 logs.txt | grep "ssh -p" > sshcommand.txt
+
+if [ ! -s sshcommand.txt ]; then
+    # try again
+    echo "Running: $SSHNP_COMMAND"
+    eval "$SSHNP_COMMAND"
+    cat logs.txt
+    tail -n 5 logs.txt | grep "ssh -p" > sshcommand.txt
+    if [ ! -s sshcommand.txt ]; then
+        echo "could not find 'ssh -p' command in logs.txt"
+        echo "last 5 lines of logs.txt:"
+        tail -n 5 logs.txt || echo
+        exit 1
+    fi
+fi
+echo "$(sed '1!d' sshcommand.txt) -o StrictHostKeyChecking=no " > sshcommand.txt ;
+echo "ssh -p command: $(cat sshcommand.txt)"
+echo "sh test.sh " | eval "$(cat sshcommand.txt)"
+sleep 2 # time for ssh connection to properly exit

--- a/tests/end2end_tests/templates/sshnpd_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnpd_entrypoint.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
-if [ -z "$USE_INSTALLER" ]; then
-  SSHNPD_COMMAND="$HOME/.local/bin/sshnpd -a @sshnpdatsign -m @sshnpatsign -d deviceName -s -u -v"
-else
-  SSHNPD_COMMAND="$HOME/.local/bin/sshnpd@sshnpatsign"
-fi
+
+SSHNPD_COMMAND="$HOME/.local/bin/sshnpd -a @sshnpdatsign -m @sshnpatsign -d deviceName -s -u -v"
 echo "Running: $SSHNPD_COMMAND"
 eval "$SSHNPD_COMMAND"

--- a/tests/end2end_tests/templates/sshnpd_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnpd_entrypoint.sh
@@ -2,7 +2,7 @@
 if [ -z "$USE_INSTALLER" ]; then
   SSHNPD_COMMAND="$HOME/.local/bin/sshnpd -a @sshnpdatsign -m @sshnpatsign -d deviceName -s -u -v"
 else
-    SSHNPD_COMMAND="bash"
+    SSHNPD_COMMAND="sleep 60"
 fi
 echo "Running: $SSHNPD_COMMAND"
 eval "$SSHNPD_COMMAND"

--- a/tests/end2end_tests/templates/sshnpd_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnpd_entrypoint.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-USE_INSTALLER=0
-if [ "$USE_INSTALLER" = 0 ]; then
+if [ -z "$USE_INSTALLER" ]; then
   SSHNPD_COMMAND="$HOME/.local/bin/sshnpd -a @sshnpdatsign -m @sshnpatsign -d deviceName -s -u -v"
-elif [ "$USE_INSTALLER" = 1 ]; then
+else
     SSHNPD_COMMAND=true # noop
 fi
 echo "Running: $SSHNPD_COMMAND"

--- a/tests/end2end_tests/templates/sshnpd_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnpd_entrypoint.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
-if [ -z "$USE_INSTALLER" ]; then
-  SSHNPD_COMMAND="$HOME/.local/bin/sshnpd -a @sshnpdatsign -m @sshnpatsign -d deviceName -s -u -v"
-else
-  SSHNPD_COMMAND="$HOME/.local/bin/sshnpd@sshnpatsign"
-fi
+SSHNPD_COMMAND="$HOME/.local/bin/sshnpd -a @sshnpdatsign -m @sshnpatsign -d deviceName -s -u -v"
 echo "Running: $SSHNPD_COMMAND"
 eval "$SSHNPD_COMMAND"

--- a/tests/end2end_tests/templates/sshnpd_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnpd_entrypoint.sh
@@ -2,7 +2,10 @@
 if [ -z "$USE_INSTALLER" ]; then
   SSHNPD_COMMAND="$HOME/.local/bin/sshnpd -a @sshnpdatsign -m @sshnpatsign -d deviceName -s -u -v"
 else
-    SSHNPD_COMMAND="sleep 60"
+  crontab -l
+  tmux ls
+  ps aux | grep sshnpd
+  SSHNPD_COMMAND="sleep 60"
 fi
 echo "Running: $SSHNPD_COMMAND"
 eval "$SSHNPD_COMMAND"

--- a/tests/end2end_tests/templates/sshnpd_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnpd_entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-
-SSHNPD_COMMAND="$HOME/.local/bin/sshnpd -a @sshnpdatsign -m @sshnpatsign -d deviceName -s -u -v"
+if [ -z "$USE_INSTALLER" ]; then
+  SSHNPD_COMMAND="$HOME/.local/bin/sshnpd -a @sshnpdatsign -m @sshnpatsign -d deviceName -s -u -v"
+else
+  SSHNPD_COMMAND="$HOME/.local/bin/sshnpd@sshnpatsign"
+fi
 echo "Running: $SSHNPD_COMMAND"
 eval "$SSHNPD_COMMAND"

--- a/tests/end2end_tests/templates/sshnpd_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnpd_entrypoint.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
-SSHNPD_COMMAND="~/.local/bin/sshnpd -a @sshnpdatsign -m @sshnpatsign -d deviceName -s -u -v"
+USE_INSTALLER=0
+if [ "$USE_INSTALLER" = 0 ]; then
+  SSHNPD_COMMAND="$HOME/.local/bin/sshnpd -a @sshnpdatsign -m @sshnpatsign -d deviceName -s -u -v"
+elif [ "$USE_INSTALLER" = 1 ]; then
+    SSHNPD_COMMAND=true # noop
+fi
 echo "Running: $SSHNPD_COMMAND"
-eval $SSHNPD_COMMAND
+eval "$SSHNPD_COMMAND"

--- a/tests/end2end_tests/templates/sshnpd_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnpd_entrypoint.sh
@@ -2,10 +2,7 @@
 if [ -z "$USE_INSTALLER" ]; then
   SSHNPD_COMMAND="$HOME/.local/bin/sshnpd -a @sshnpdatsign -m @sshnpatsign -d deviceName -s -u -v"
 else
-  crontab -l
-  tmux ls
-  ps aux | grep sshnpd
-  SSHNPD_COMMAND="sleep 60"
+  SSHNPD_COMMAND="$HOME/.local/bin/sshnpd@sshnpatsign"
 fi
 echo "Running: $SSHNPD_COMMAND"
 eval "$SSHNPD_COMMAND"

--- a/tests/end2end_tests/templates/sshnpd_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnpd_entrypoint.sh
@@ -2,7 +2,7 @@
 if [ -z "$USE_INSTALLER" ]; then
   SSHNPD_COMMAND="$HOME/.local/bin/sshnpd -a @sshnpdatsign -m @sshnpatsign -d deviceName -s -u -v"
 else
-    SSHNPD_COMMAND=true # noop
+    SSHNPD_COMMAND="bash"
 fi
 echo "Running: $SSHNPD_COMMAND"
 eval "$SSHNPD_COMMAND"

--- a/tests/end2end_tests/templates/sshnpd_installer_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshnpd_installer_entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+SSHNPD_COMMAND="$HOME/.local/bin/sshnpd@sshnpatsign"
+echo "Running: $SSHNPD_COMMAND"
+eval "$SSHNPD_COMMAND"

--- a/tests/end2end_tests/templates/sshrvd_entrypoint.sh
+++ b/tests/end2end_tests/templates/sshrvd_entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-~/.local/bin/sshrvd -a @sshrvdatsign -i $(hostname -i) -v -s
+"$HOME"/.local/bin/sshrvd -a @sshrvdatsign -i "$(hostname -i)" -v -s
 sleep 60 # sleep 60 because other containers depend on it. And if it's not being used (let's say you're using @rv_am), then it will just sleep until sshnp exits
 exit 0

--- a/tests/end2end_tests/tests/service-image-runtime-sshnp-installer.yaml
+++ b/tests/end2end_tests/tests/service-image-runtime-sshnp-installer.yaml
@@ -1,4 +1,4 @@
-  image-runtime-release:
+  image-runtime-sshnp-installer:
     deploy:
       mode: replicated
       replicas: 0

--- a/tests/end2end_tests/tests/service-image-runtime-sshnp-installer.yaml
+++ b/tests/end2end_tests/tests/service-image-runtime-sshnp-installer.yaml
@@ -3,8 +3,8 @@
       mode: replicated
       replicas: 0
     build:
-      context: ../image/
-      dockerfile: ./Dockerfile
+      context: ../../../
+      dockerfile: ./tests/end2end_tests/image/Dockerfile
       target: runtime-sshnp-installer
       args:
         # auto added:

--- a/tests/end2end_tests/tests/service-image-runtime-sshnp-installer.yaml
+++ b/tests/end2end_tests/tests/service-image-runtime-sshnp-installer.yaml
@@ -1,0 +1,15 @@
+  image-runtime-release:
+    deploy:
+      mode: replicated
+      replicas: 0
+    build:
+      context: ../image/
+      dockerfile: ./Dockerfile
+      target: runtime-sshnp-installer
+      args:
+        # auto added:
+        # - client_atsign
+        # - device_atsign
+        # - host_atsign
+    # auto added:
+    # - image

--- a/tests/end2end_tests/tests/service-image-runtime-sshnpd-installer.yaml
+++ b/tests/end2end_tests/tests/service-image-runtime-sshnpd-installer.yaml
@@ -1,0 +1,15 @@
+  image-runtime-release:
+    deploy:
+      mode: replicated
+      replicas: 0
+    build:
+      context: ../image/
+      dockerfile: ./Dockerfile
+      target: runtime-sshnpd-installer
+      args:
+        # auto added:
+        # - client_atsign
+        # - device_atsign
+        # - device_name
+    # auto added:
+    # - image

--- a/tests/end2end_tests/tests/service-image-runtime-sshnpd-installer.yaml
+++ b/tests/end2end_tests/tests/service-image-runtime-sshnpd-installer.yaml
@@ -1,4 +1,4 @@
-  image-runtime-release:
+  image-runtime-sshnpd-installer:
     deploy:
       mode: replicated
       replicas: 0

--- a/tests/end2end_tests/tests/service-image-runtime-sshnpd-installer.yaml
+++ b/tests/end2end_tests/tests/service-image-runtime-sshnpd-installer.yaml
@@ -3,8 +3,8 @@
       mode: replicated
       replicas: 0
     build:
-      context: ../image/
-      dockerfile: ./Dockerfile
+      context: ../../../
+      dockerfile: ./tests/end2end_tests/image/Dockerfile
       target: runtime-sshnpd-installer
       args:
         # auto added:

--- a/tests/end2end_tests/tools/configuration/setup-sshnp-entrypoint.sh
+++ b/tests/end2end_tests/tools/configuration/setup-sshnp-entrypoint.sh
@@ -9,8 +9,9 @@ sshnp=$2 # e.g. @alice
 sshnpd=$3 # e.g. @alice
 sshrvd=$4 # e.g. @alice
 waitingTime=$5 # e.g. 30
+template_name=$6 # e.g. sshnp_entrypoint.sh
 
-cp ../../templates/sshnp_entrypoint.sh ../../contexts/sshnp/entrypoint.sh
+cp ../../templates/"$template_name" ../../contexts/sshnp/entrypoint.sh
 
 prefix="sed -i"
 

--- a/tests/end2end_tests/tools/configuration/setup-sshnp-entrypoint.sh
+++ b/tests/end2end_tests/tools/configuration/setup-sshnp-entrypoint.sh
@@ -20,8 +20,8 @@ then
     prefix="$prefix ''"
 fi
 
-eval $prefix "s/@sshnpatsign/${sshnp}/g" ../../contexts/sshnp/entrypoint.sh
-eval $prefix "s/@sshnpdatsign/${sshnpd}/g" ../../contexts/sshnp/entrypoint.sh
-eval $prefix "s/@sshrvdatsign/${sshrvd}/g" ../../contexts/sshnp/entrypoint.sh
-eval $prefix "s/deviceName/${device}/g" ../../contexts/sshnp/entrypoint.sh
-eval $prefix "s/WAITING_TIME/${waitingTime}/g" ../../contexts/sshnp/entrypoint.sh
+eval "$prefix" "s/@sshnpatsign/${sshnp}/g" ../../contexts/sshnp/entrypoint.sh
+eval "$prefix" "s/@sshnpdatsign/${sshnpd}/g" ../../contexts/sshnp/entrypoint.sh
+eval "$prefix" "s/@sshrvdatsign/${sshrvd}/g" ../../contexts/sshnp/entrypoint.sh
+eval "$prefix" "s/deviceName/${device}/g" ../../contexts/sshnp/entrypoint.sh
+eval "$prefix" "s/WAITING_TIME/${waitingTime}/g" ../../contexts/sshnp/entrypoint.sh

--- a/tests/end2end_tests/tools/configuration/setup-sshnp-keys.sh
+++ b/tests/end2end_tests/tools/configuration/setup-sshnp-keys.sh
@@ -5,7 +5,7 @@
 
 sshnp=$1
 
-cp ~/.atsign/keys/${sshnp}_key.atKeys ../../contexts/sshnp/keys/${sshnp}_key.atKeys
+cp ~/.atsign/keys/"$sshnp"_key.atKeys ../../contexts/sshnp/keys/"$sshnp"_key.atKeys
 
 if [[ ! -f ../../contexts/sshnp/keys/${sshnp}_key.atKeys ]];
 then

--- a/tests/end2end_tests/tools/configuration/setup-sshnpd-entrypoint.sh
+++ b/tests/end2end_tests/tools/configuration/setup-sshnpd-entrypoint.sh
@@ -18,6 +18,6 @@ then
     prefix="$prefix ''"
 fi
 
-eval $prefix "s/@sshnpatsign/${sshnp}/g" ../../contexts/sshnpd/entrypoint.sh
-eval $prefix "s/@sshnpdatsign/${sshnpd}/g" ../../contexts/sshnpd/entrypoint.sh
-eval $prefix "s/deviceName/${device}/g" ../../contexts/sshnpd/entrypoint.sh
+eval "$prefix" "s/@sshnpatsign/${sshnp}/g" ../../contexts/sshnpd/entrypoint.sh
+eval "$prefix" "s/@sshnpdatsign/${sshnpd}/g" ../../contexts/sshnpd/entrypoint.sh
+eval "$prefix" "s/deviceName/${device}/g" ../../contexts/sshnpd/entrypoint.sh

--- a/tests/end2end_tests/tools/configuration/setup-sshnpd-entrypoint.sh
+++ b/tests/end2end_tests/tools/configuration/setup-sshnpd-entrypoint.sh
@@ -7,8 +7,9 @@
 device=$1 # e.g. e2e
 sshnp=$2 # e.g. @alice
 sshnpd=$3 # e.g. @alice
+template_name=$4 # e.g. sshnpd_entrypoint.sh
 
-cp ../../templates/sshnpd_entrypoint.sh ../../contexts/sshnpd/entrypoint.sh
+cp ../../templates/"$template_name" ../../contexts/sshnpd/entrypoint.sh
 
 prefix="sed -i"
 

--- a/tests/end2end_tests/tools/configuration/setup-sshnpd-keys.sh
+++ b/tests/end2end_tests/tools/configuration/setup-sshnpd-keys.sh
@@ -5,7 +5,7 @@
 
 sshnpd=$1
 
-cp ~/.atsign/keys/${sshnpd}_key.atKeys ../../contexts/sshnpd/keys/${sshnpd}_key.atKeys
+cp ~/.atsign/keys/"$sshnpd"_key.atKeys ../../contexts/sshnpd/keys/"$sshnpd"_key.atKeys
 
 if [[ ! -f ../../contexts/sshnpd/keys/${sshnpd}_key.atKeys ]];
 then

--- a/tests/end2end_tests/tools/configuration/setup-sshrvd-entrypoint.sh
+++ b/tests/end2end_tests/tools/configuration/setup-sshrvd-entrypoint.sh
@@ -16,4 +16,4 @@ then
     prefix="$prefix ''"
 fi
 
-eval $prefix "s/@sshrvdatsign/${sshrvd}/g" ../../contexts/sshrvd/entrypoint.sh
+eval "$prefix" "s/@sshrvdatsign/${sshrvd}/g" ../../contexts/sshrvd/entrypoint.sh

--- a/tests/end2end_tests/tools/configuration/setup-sshrvd-keys.sh
+++ b/tests/end2end_tests/tools/configuration/setup-sshrvd-keys.sh
@@ -5,7 +5,7 @@
 
 sshrvd=$1
 
-cp ~/.atsign/keys/${sshrvd}_key.atKeys ../../contexts/sshrvd/keys/${sshrvd}_key.atKeys
+cp ~/.atsign/keys/"$sshrvd"_key.atKeys ../../contexts/sshrvd/keys/"$sshrvd"_key.atKeys
 
 if [[ ! -f ../../contexts/sshrvd/keys/${sshrvd}_key.atKeys ]];
 then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

closes #317 

**- What I did**

Working on e2e tests so we can comfortably merge #320 

Added end2end tests that test the sshnp and sshnpd installers against local and trunk.

Updated the sshnp and sshnpd installers in order to get it running on the debian slim test image, had to cut back on certain shell features which weren't available in the slim environment.

On the sshnp side, it does not test the custom script, I will think about doing a later update once the newer script template is released, since the newer script template allows passing custom args to sshnp.


On the sshnpd side, it tests the custom script, but doesn't test the job used to install the script (i.e. with cron/tmux/etc.).

This is a start, there is room for improvement but it is good enough for now.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
ci: e2e tests for the installer
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->