### PR TITLE
fix: use `-f` instead of `-o ForkAfterAuthentication=yes`

### DIFF
--- a/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
@@ -666,7 +666,7 @@ class SSHNPDImpl implements SSHNPD {
             ' -o IdentitiesOnly=yes'
             ' -o BatchMode=yes'
             ' -o ExitOnForwardFailure=yes'
-            ' -o ForkAfterAuthentication=yes'
+            ' -f' // fork after authentication
             ' sleep 15'
         .split(' ');
     logger.info('$sessionId | Executing /usr/bin/ssh ${args.join(' ')}');


### PR DESCRIPTION
fix: use `-f` instead of `-o ForkAfterAuthentication=yes` as `-f` has been available for a lot longer and thus will be supported by older linux / openssh distributions