### PR TITLE
fix: sshnpd headless template ARGS behaviour

### DIFF
--- a/packages/sshnoports/scripts/install_sshnp
+++ b/packages/sshnoports/scripts/install_sshnp
@@ -225,8 +225,8 @@ download() {
 
   if [ -n "$SSHNP_DEV_MODE" ]; then
     echo "DEV MODE: Installing from local repo: $SSHNP_DEV_MODE";
-    cp -R "$SSHNP_DEV_MODE/templates/" "$HOME_PATH/.atsign/temp/$BINARY_NAME/templates/";
-    cp "$SSHNP_DEV_MODE"/scripts/* "$HOME_PATH/.atsign/temp/$BINARY_NAME";
+    cp -R "$SSHNP_DEV_MODE/packages/sshnoports/templates/" "$HOME_PATH/.atsign/temp/$BINARY_NAME/templates/";
+    cp "$SSHNP_DEV_MODE"/packages/sshnoports/scripts/* "$HOME_PATH/.atsign/temp/$BINARY_NAME";
   fi
 }
 

--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -204,6 +204,8 @@ parse_env() {
 
   if [ -z "$SSHNP_SERVICE_ARGS_PARSED" ]; then
     SSHNP_SERVICE_ARGS="-v";
+  else
+    SSHNP_SERVICE_ARGS="${SSHNP_SERVICE_ARGS//\"/\\\"}";
   fi
 }
 

--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -27,7 +27,7 @@ usage() {
   echo "  -d, --device <address>      Device address (e.g. @alice_device)"
   echo "  -n, --name <device name>    Name of the device"
   echo "  -v, --version <version>     Version to install (default: latest)"
-  echo "      --args <args>           Additional arguments to sshnpd ("-v" by default)"
+  echo "      --args <args>           Additional arguments to sshnpd (\"-v\" by default)"
   echo "      Possible args:"
   echo "        -s, --[no-]sshpublickey      Update authorized_keys to include public key from sshnp"
   echo "        -u, --[no-]un-hide           When set, makes various information visible to the manager atSign - e.g. username, version, etc"

--- a/packages/sshnoports/templates/headless/sshnpd.sh
+++ b/packages/sshnoports/templates/headless/sshnpd.sh
@@ -9,6 +9,7 @@ CLIENT="$2"
 NAME="$3"
 ARGS="$*"
 while true; do
-  "$HOME"/.local/bin/sshnpd -a "$DEVICE" -m "$CLIENT" -d "$NAME" "$ARGS"
+  # shellcheck disable=SC2086
+  "$HOME"/.local/bin/sshnpd -a "$DEVICE" -m "$CLIENT" -d "$NAME" $ARGS
   sleep 10
 done


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Removed the quotes wrapping `$ARGS` so that the args will word split as intended.
Escaped quotes in $ARGS as well.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: sshnpd headless template ARGS behaviour
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->