### PR TITLE
feat: add warning message when using default installation args for sshnpd

### DIFF
--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -266,6 +266,12 @@ parse_env() {
   fi
 
   if [ -z "$SSHNP_SERVICE_ARGS_PARSED" ]; then
+    echo "Warning: For security reasons, as of v3.5.0 the installer no longer sets -u and -s"
+    echo "  -s when set, will update authorized_keys to include public key from sshnp"
+    echo "  -u when set, makes various information visible to the manager atSign - e.g. username, version, etc"
+    echo "  -v when set, enables more logging (on by default)"
+    echo "To pass additional arguments to sshnpd at install time, use --args"
+    echo "  e.g. <rest of install command> --args \"-s -u -v\""
     SSHNP_SERVICE_ARGS="-v";
   else
     SSHNP_SERVICE_ARGS="${SSHNP_SERVICE_ARGS//\"/\\\"}";


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added a warning message when installing sshnpd and --args was unset

**- How I did it**

**- How to verify it**
Running the added echos in the terminal:
```
~ 
➜ echo "Warning: For security reasons, as of v3.5.0 the installer no longer sets -u and -s";
    echo "  -s when set, will update authorized_keys to include public key from sshnp";
    echo "  -u when set, makes various information visible to the manager atSign - e.g. username, version, etc";
    echo "  -v when set, enables more logging (on by default)";
    echo "To pass additional arguments to sshnpd at install time, use --args";
    echo "  e.g. <rest of install command> --args \"-s -u -v\"";
Warning: For security reasons, as of v3.5.0 the installer no longer sets -u and -s
  -s when set, will update authorized_keys to include public key from sshnp
  -u when set, makes various information visible to the manager atSign - e.g. username, version, etc
  -v when set, enables more logging (on by default)
To pass additional arguments to sshnpd at install time, use --args
  e.g. <rest of install command> --args "-s -u -v"
```

**- Description for the changelog**
feat: add warning message when using default installation args for sshnpd
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->