### PR TITLE
fix: sshnpd installer merge bug

### DIFF
--- a/packages/sshnoports/scripts/install_sshnpd
+++ b/packages/sshnoports/scripts/install_sshnpd
@@ -436,7 +436,7 @@ rename_device() {
 }
 
 # Place custom user based scripts
-setup_service() {
+setup_service_script() {
   SSHNPD_SERVICE_BINARY_PATH="$HOME_PATH/.local/bin/$BINARY_NAME$CLIENT_ATSIGN";
   SERVICE_RUN_VERSION="$(sed '2!d' "$SSHNPD_SERVICE_BINARY_PATH" | cut -d'v' -f2)"
 

--- a/scripts/install_sshnpd
+++ b/scripts/install_sshnpd
@@ -436,7 +436,7 @@ rename_device() {
 }
 
 # Place custom user based scripts
-setup_service() {
+setup_service_script() {
   SSHNPD_SERVICE_BINARY_PATH="$HOME_PATH/.local/bin/$BINARY_NAME$CLIENT_ATSIGN";
   SERVICE_RUN_VERSION="$(sed '2!d' "$SSHNPD_SERVICE_BINARY_PATH" | cut -d'v' -f2)"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

An bug introduced in merge conflict resolution regressed the name of one of the install functions for sshnpd. There were two setup_service functions when there should be a setup_service which calls setup_service_script. Renamed the incorrect one to setup_service_script.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: sshnpd installer merge bug
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->