### PR TITLE
fix: exit on any container != 0

### DIFF
--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -16,7 +16,7 @@ on:
 env:
   SSHNP_ATSIGN: "@8incanteater"
   SSHNPD_ATSIGN: "@8052simple"
-  DOCKER_COMPOSE_UP_CMD: "docker compose up"
+  DOCKER_COMPOSE_UP_CMD: "docker compose up --abort-on-container-exit"
 
   # Fallback values for missing matrix values
   DEFAULT_RVD_ATSIGN: "@rv_am"

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -16,7 +16,7 @@ on:
 env:
   SSHNP_ATSIGN: "@8incanteater"
   SSHNPD_ATSIGN: "@8052simple"
-  DOCKER_COMPOSE_UP_CMD: "docker compose up --exit-code-from=container-sshnp"
+  DOCKER_COMPOSE_UP_CMD: "docker compose up"
 
   # Fallback values for missing matrix values
   DEFAULT_RVD_ATSIGN: "@rv_am"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Docker would solely depend on the exit code from a container when specified with the `--exit-code-from=<docker compose service>`
- This flag does not account for when sshnpd fails, which is why I am removing this flag

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

closes #362 