### PR TITLE
feat: Add sshnp option for local sshd to run on alternative port than 22

### DIFF
--- a/packages/sshnoports/bin/sshrv.dart
+++ b/packages/sshnoports/bin/sshrv.dart
@@ -17,7 +17,7 @@ Future<void> main(List<String> args) async {
     // ignore: unused_local_variable
     var socketStream = await SocketConnector.socketToSocket(
         socketAddressA: InternetAddress.loopbackIPv4,
-        socketPortA: 22,
+        socketPortA: 8022,
         socketAddressB: hosts[0],
         socketPortB: int.parse(streamingPort),
         verbose: false);

--- a/packages/sshnoports/bin/sshrv.dart
+++ b/packages/sshnoports/bin/sshrv.dart
@@ -5,19 +5,25 @@ import 'dart:io';
 import 'package:socket_connector/socket_connector.dart';
 
 Future<void> main(List<String> args) async {
-  if (args.length < 2 || args.length > 2) {
-    print('sshrv <host> <port>');
+  if (args.length < 2 || args.length > 3) {
+    print('sshrv <host> <port> [<local ssh port>]');
     exit(-1);
   }
   String host = args[0];
   String streamingPort = args[1];
+  String localSshPort ="22";
+  if (args.length == 3) {
+    localSshPort = args[3];
+  }
+    
+  
   try {
     var hosts = await InternetAddress.lookup(host);
 
     // ignore: unused_local_variable
     var socketStream = await SocketConnector.socketToSocket(
         socketAddressA: InternetAddress.loopbackIPv4,
-        socketPortA: 8022,
+        socketPortA: int.parse(localSshPort),
         socketAddressB: hosts[0],
         socketPortB: int.parse(streamingPort),
         verbose: false);

--- a/packages/sshnoports/bin/sshrv.dart
+++ b/packages/sshnoports/bin/sshrv.dart
@@ -13,7 +13,7 @@ Future<void> main(List<String> args) async {
   String streamingPort = args[1];
   String localSshPort ="22";
   if (args.length == 3) {
-    localSshPort = args[3];
+    localSshPort = args[2];
   }
     
   

--- a/packages/sshnoports/bin/sshrv.dart
+++ b/packages/sshnoports/bin/sshrv.dart
@@ -6,7 +6,7 @@ import 'package:socket_connector/socket_connector.dart';
 
 Future<void> main(List<String> args) async {
   if (args.length < 2 || args.length > 3) {
-    print('sshrv <host> <port> [<local ssh port>]');
+    print('sshrv <host> <port> [localhost sshd port, defaults to 22]');
     exit(-1);
   }
   String host = args[0];

--- a/packages/sshnoports/lib/common/utils.dart
+++ b/packages/sshnoports/lib/common/utils.dart
@@ -32,7 +32,7 @@ String? getHomeDirectory({bool throwIfNull = false}) {
 /// Get the local username or null if unknown
 String? getUserName({bool throwIfNull = false}) {
   Map<String, String> envVars = Platform.environment;
-  if (Platform.isLinux || Platform.isMacOS) {
+  if (Platform.isLinux || Platform.isMacOS || Platform.isAndroid) {
     return envVars['USER'];
   } else if (Platform.isWindows) {
     return envVars['USERPROFILE'];

--- a/packages/sshnoports/lib/common/utils.dart
+++ b/packages/sshnoports/lib/common/utils.dart
@@ -31,6 +31,7 @@ String? getHomeDirectory({bool throwIfNull = false}) {
 
 /// Get the local username or null if unknown
 String? getUserName({bool throwIfNull = false}) {
+  print(Platform.environment);
   Map<String, String> envVars = Platform.environment;
   if (Platform.isLinux || Platform.isMacOS || Platform.isAndroid) {
     return envVars['USER'];

--- a/packages/sshnoports/lib/common/utils.dart
+++ b/packages/sshnoports/lib/common/utils.dart
@@ -31,9 +31,8 @@ String? getHomeDirectory({bool throwIfNull = false}) {
 
 /// Get the local username or null if unknown
 String? getUserName({bool throwIfNull = false}) {
-  print(Platform.environment);
   Map<String, String> envVars = Platform.environment;
-  if (Platform.isLinux || Platform.isMacOS || Platform.isAndroid) {
+  if (!Platform.isWindows) {
     return envVars['USER'];
   } else if (Platform.isWindows) {
     return envVars['USERPROFILE'];

--- a/packages/sshnoports/lib/sshnp/sshnp.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp.dart
@@ -63,6 +63,11 @@ abstract class SSHNP {
   /// is set to '0' then
   abstract String localPort;
 
+  /// Port that local sshd is listening on localhost interface
+  /// Default set to 22
+
+  abstract String localSshdPort;
+
   // ====================================================================
   // Derived final instance variables, set during construction or init
   // ====================================================================
@@ -137,6 +142,7 @@ abstract class SSHNP {
       required String localPort,
       String? remoteUsername,
       bool verbose = false,
+      required String localSshdPort,
       required bool legacyDaemon}) {
     return SSHNPImpl(
         atClient: atClient,
@@ -151,6 +157,7 @@ abstract class SSHNP {
         host: host,
         port: port,
         localPort: localPort,
+        localSshdPort: localSshdPort,
         remoteUsername: remoteUsername,
         verbose: verbose,
         legacyDaemon: legacyDaemon);

--- a/packages/sshnoports/lib/sshnp/sshnp.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp.dart
@@ -142,7 +142,7 @@ abstract class SSHNP {
       required String localPort,
       String? remoteUsername,
       bool verbose = false,
-      required String localSshdPort,
+      String localSshdPort = '22',
       required bool legacyDaemon}) {
     return SSHNPImpl(
         atClient: atClient,

--- a/packages/sshnoports/lib/sshnp/sshnp_arg.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_arg.dart
@@ -126,6 +126,15 @@ class SSHNPArg {
       format: ArgFormat.option,
     ),
     SSHNPArg(
+      name: 'local-sshd-port',
+      help: 'port sshd is listening locally on localhost',
+      defaultsTo: '22',
+      abbr: 'P',
+      mandatory: false,
+      format: ArgFormat.option,
+    ),
+
+    SSHNPArg(
       name: 'legacy-daemon',
       defaultsTo: true,
       help: 'Request is to a legacy (< 3.5.0) noports daemon',

--- a/packages/sshnoports/lib/sshnp/sshnp_impl.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_impl.dart
@@ -56,6 +56,9 @@ class SSHNPImpl implements SSHNP {
   @override
   final List<String> localSshOptions;
 
+  @override
+  late final String localSshdPort;
+
   /// When false, we generate [sshPublicKey] and [sshPrivateKey] using ed25519.
   /// When true, we generate [sshPublicKey] and [sshPrivateKey] using RSA.
   /// Defaults to false
@@ -179,7 +182,8 @@ class SSHNPImpl implements SSHNP {
       required this.localPort,
       this.remoteUsername,
       this.verbose = false,
-      required this.legacyDaemon}) {
+      required this.legacyDaemon,
+      required this.localSshdPort}) {
     namespace = '$device.sshnp';
     clientAtSign = atClient.getCurrentAtSign()!;
     logger.hierarchicalLoggingEnabled = true;
@@ -247,6 +251,7 @@ class SSHNPImpl implements SSHNP {
           port: p.port,
           localPort: p.localPort,
           localSshOptions: p.localSshOptions,
+          localSshdPort: p.localSshdPort,
           rsa: p.rsa,
           sendSshPublicKey: p.sendSshPublicKey,
           remoteUsername: p.remoteUsername,
@@ -417,7 +422,7 @@ class SSHNPImpl implements SSHNP {
     List<String> args = '$remoteUsername@$host'
             ' -p $_sshrvdPort'
             ' -i ${publicKeyFileName.replaceFirst(RegExp(r'.pub$'), '')}'
-            ' -L $localPort:localhost:8022'
+            ' -L $localPort:localhost:$localSshdPort'
             ' -o LogLevel=VERBOSE'
             ' -t -t'
             ' -o StrictHostKeyChecking=accept-new'
@@ -715,7 +720,7 @@ class SSHNPImpl implements SSHNP {
 
     // Set up a safe authorized_keys file, for the reverse ssh tunnel
     File('${sshHomeDirectory}authorized_keys').writeAsStringSync(
-        'command="echo \\"ssh session complete\\";sleep 20",PermitOpen="localhost:8022" ${sshPublicKey.trim()} $sessionId\n',
+        'command="echo \\"ssh session complete\\";sleep 20",PermitOpen="localhost:$localSshdPort" ${sshPublicKey.trim()} $sessionId\n',
         mode: FileMode.append);
   }
 

--- a/packages/sshnoports/lib/sshnp/sshnp_impl.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_impl.dart
@@ -183,7 +183,8 @@ class SSHNPImpl implements SSHNP {
       this.remoteUsername,
       this.verbose = false,
       required this.legacyDaemon,
-      required this.localSshdPort}) {
+      this.localSshdPort = '22'
+    }) {
     namespace = '$device.sshnp';
     clientAtSign = atClient.getCurrentAtSign()!;
     logger.hierarchicalLoggingEnabled = true;

--- a/packages/sshnoports/lib/sshnp/sshnp_impl.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_impl.dart
@@ -417,7 +417,7 @@ class SSHNPImpl implements SSHNP {
     List<String> args = '$remoteUsername@$host'
             ' -p $_sshrvdPort'
             ' -i ${publicKeyFileName.replaceFirst(RegExp(r'.pub$'), '')}'
-            ' -L $localPort:localhost:22'
+            ' -L $localPort:localhost:8022'
             ' -o LogLevel=VERBOSE'
             ' -t -t'
             ' -o StrictHostKeyChecking=accept-new'
@@ -715,7 +715,7 @@ class SSHNPImpl implements SSHNP {
 
     // Set up a safe authorized_keys file, for the reverse ssh tunnel
     File('${sshHomeDirectory}authorized_keys').writeAsStringSync(
-        'command="echo \\"ssh session complete\\";sleep 20",PermitOpen="localhost:22" ${sshPublicKey.trim()} $sessionId\n',
+        'command="echo \\"ssh session complete\\";sleep 20",PermitOpen="localhost:8022" ${sshPublicKey.trim()} $sessionId\n',
         mode: FileMode.append);
   }
 

--- a/packages/sshnoports/lib/sshnp/sshnp_impl.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_impl.dart
@@ -222,7 +222,12 @@ class SSHNPImpl implements SSHNP {
 
       // Check atKeyFile selected exists
       if (!await fileExists(p.atKeysFilePath)) {
-        throw ('\nUnable to find .atKeys file : ${p.atKeysFilePath}');
+        throw ArgumentError('\nUnable to find .atKeys file : ${p.atKeysFilePath}');
+      }
+
+      if (int.parse(p.localSshdPort) > 65535 ||
+          int.parse(p.localSshdPort) < 1) {
+        throw ArgumentError('\nInvalid port number for sshd (1-65535) : ${p.localSshdPort}');
       }
 
       String sessionId = Uuid().v4();
@@ -520,8 +525,9 @@ class SSHNPImpl implements SSHNP {
   Future<void> legacyStartReverseSsh() async {
     // Connect to rendezvous point using background process.
     // sshnp (this program) can then exit without issue.
-    
-    unawaited(Process.run(getSshrvCommand(), [host, _sshrvdPort, localSshdPort]));
+
+    unawaited(
+        Process.run(getSshrvCommand(), [host, _sshrvdPort, localSshdPort]));
 
     // send request to the daemon via notification
     await _notify(

--- a/packages/sshnoports/lib/sshnp/sshnp_impl.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_impl.dart
@@ -479,7 +479,9 @@ class SSHNPImpl implements SSHNP {
   Future<void> startReverseSsh() async {
     // Connect to rendezvous point using background process.
     // sshnp (this program) can then exit without issue.
-    unawaited(Process.run(getSshrvCommand(), [host, _sshrvdPort, localSshdPort]));
+
+    unawaited(
+        Process.run(getSshrvCommand(), [host, _sshrvdPort, localSshdPort]));
 
     // send request to the daemon via notification
     await _notify(
@@ -518,7 +520,8 @@ class SSHNPImpl implements SSHNP {
   Future<void> legacyStartReverseSsh() async {
     // Connect to rendezvous point using background process.
     // sshnp (this program) can then exit without issue.
-    unawaited(Process.run(getSshrvCommand(), [host, _sshrvdPort]));
+    
+    unawaited(Process.run(getSshrvCommand(), [host, _sshrvdPort, localSshdPort]));
 
     // send request to the daemon via notification
     await _notify(

--- a/packages/sshnoports/lib/sshnp/sshnp_impl.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_impl.dart
@@ -225,7 +225,13 @@ class SSHNPImpl implements SSHNP {
       if (!await fileExists(p.atKeysFilePath)) {
         throw ArgumentError('\nUnable to find .atKeys file : ${p.atKeysFilePath}');
       }
+     
+     // Check to see if localSshdPort has been set as a number
+      if (int.tryParse(p.localSshdPort) == null ) {
+        throw ArgumentError('\nInvalid port number for sshd (1-65535) : ${p.localSshdPort}');
+      }
 
+     // Check to see if the port number is in range for TCP ports
       if (int.parse(p.localSshdPort) > 65535 ||
           int.parse(p.localSshdPort) < 1) {
         throw ArgumentError('\nInvalid port number for sshd (1-65535) : ${p.localSshdPort}');

--- a/packages/sshnoports/lib/sshnp/sshnp_impl.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_impl.dart
@@ -479,7 +479,7 @@ class SSHNPImpl implements SSHNP {
   Future<void> startReverseSsh() async {
     // Connect to rendezvous point using background process.
     // sshnp (this program) can then exit without issue.
-    unawaited(Process.run(getSshrvCommand(), [host, _sshrvdPort]));
+    unawaited(Process.run(getSshrvCommand(), [host, _sshrvdPort, localSshdPort]));
 
     // send request to the daemon via notification
     await _notify(

--- a/packages/sshnoports/lib/sshnp/sshnp_params.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_params.dart
@@ -28,6 +28,7 @@ class SSHNPParams {
   late final String? remoteUsername;
   late final bool verbose;
   late final String rootDomain;
+  late final String localSshdPort;
   late final bool legacyDaemon;
 
   /// Special Arguments
@@ -47,6 +48,7 @@ class SSHNPParams {
       this.remoteUsername,
       String? atKeysFilePath,
       this.rootDomain = 'root.atsign.org',
+      this.localSshdPort = '22',
       this.listDevices = false,
       required this.legacyDaemon}) {
     // Do we have a username ?
@@ -84,6 +86,7 @@ class SSHNPParams {
         remoteUsername: partial.remoteUsername,
         atKeysFilePath: partial.atKeysFilePath,
         rootDomain: partial.rootDomain ?? 'root.atsign.org',
+        localSshdPort: partial.localSshdPort ?? '22',
         listDevices: partial.listDevices,
         legacyDaemon: partial.legacyDaemon ?? true);
   }
@@ -143,6 +146,7 @@ class SSHNPParams {
       'remote-user-name': remoteUsername,
       'verbose': verbose,
       'root-domain': rootDomain,
+      'local-sshd-port': localSshdPort
     };
   }
 
@@ -178,6 +182,7 @@ class SSHNPPartialParams {
   late final String? remoteUsername;
   late final bool? verbose;
   late final String? rootDomain;
+  late final String? localSshdPort;
   late final bool? legacyDaemon;
 
   /// Special Params
@@ -201,6 +206,7 @@ class SSHNPPartialParams {
       this.remoteUsername,
       this.verbose,
       this.rootDomain,
+      this.localSshdPort,
       this.listDevices = false,
       this.legacyDaemon = true});
 
@@ -228,6 +234,7 @@ class SSHNPPartialParams {
       remoteUsername: params2.remoteUsername ?? params1.remoteUsername,
       verbose: params2.verbose ?? params1.verbose,
       rootDomain: params2.rootDomain ?? params1.rootDomain,
+      localSshdPort: params1.localSshdPort ?? params2.localSshdPort,
       listDevices: params2.listDevices || params1.listDevices,
       legacyDaemon: params2.legacyDaemon ?? params1.legacyDaemon,
     );
@@ -248,6 +255,7 @@ class SSHNPPartialParams {
       remoteUsername: args['remote-user-name'],
       verbose: args['verbose'],
       rootDomain: args['root-domain'],
+      localSshdPort: args['local-sshd-port'],
       listDevices: args['list-devices'] ?? false,
       legacyDaemon: args['legacy-daemon'],
     );


### PR DESCRIPTION
**- What I did**

Added optional parameter to sshnp (-P / --local-sshd-port)

**- How I did it**
Followed existing patterns to add optional parameter that defaults to 22 
Added 3rd (optional) parameter to sshrv to forward port X to sshrvd

**- How to verify it**
Ran tests locally (I need help to make an automated test please! BEFORE Merging)

**- Description for the changelog**
Added sshnp optional parameter to select local sshd on alternative port (useful on Android/ioS devices that are not rooted)