### PR TITLE
ci: e2e tests timeout max 6 minutes

### DIFF
--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -16,7 +16,7 @@ on:
 env:
   SSHNP_ATSIGN: "@8incanteater"
   SSHNPD_ATSIGN: "@8052simple"
-  DOCKER_COMPOSE_UP_CMD: "docker compose up --abort-on-container-exit"
+  DOCKER_COMPOSE_UP_CMD: "docker compose up --abort-on-container-exit --timeout 360"
 
   # Fallback values for missing matrix values
   DEFAULT_RVD_ATSIGN: "@rv_am"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- docker services will be max up 6 minutes
- some tests will run forever and never fail
**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->