### PR TITLE
chore: disable unreliable checks in sshnpd installer

### DIFF
--- a/scripts/install_sshnpd
+++ b/scripts/install_sshnpd
@@ -183,8 +183,8 @@ check_requirements() {
     echo "  [X] Missing required dependency: ssh"
   elif [ -z "$REQ_SSHD" ]; then
     echo "  [X] Missing required dependency: sshd"
-  elif [ -z "$REQ_SSHD_SERVICE" ]; then
-    echo "  [X] sshd is not running"
+  # elif [ -z "$REQ_SSHD_SERVICE" ]; then
+  #   echo "  [X] sshd is not running"
   fi
   if [ -z "$REQ_CURL" ] && [ -z "$SSHNP_DEV_MODE" ] && [ -z "$SSHNP_LOCAL" ]; then
     echo "  [X] Missing required dependency: curl"
@@ -194,8 +194,8 @@ check_requirements() {
   fi
   if [ -z "$REQ_CRON" ]; then
     echo "  [X] Missing required dependency: cron"
-  elif [ -z "$REQ_CRON_SERVICE" ]; then
-    echo "  [X] cron is not running"
+  # elif [ -z "$REQ_CRON_SERVICE" ]; then
+  #   echo "  [X] cron is not running"
   fi
   if [ -z "$REQ_TMUX" ] && [ -z "$REQ_LOGR" ]; then
     echo "  [X] Missing required dependency"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

The checks for sshd running and cron running are not reliable enough and sometimes prevent the installer from running on devices where these things are enable (macOS is the biggest culprit)

FYI: I've only commented them out as I intend to add them back in later once I can ensure that they work as intended

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: disable unreliable checks in sshnpd installer
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->