### PR TITLE
fix: sshnp -o flag should not prepend -o to the output option

### DIFF
--- a/packages/sshnoports/lib/sshnp/sshnp_result.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_result.dart
@@ -3,8 +3,8 @@ part of 'sshnp.dart';
 abstract class SSHNPResult {}
 
 const _optionsWithPrivateKey = [
-  'StrictHostKeyChecking=accept-new',
-  'IdentitiesOnly=yes'
+  '-o StrictHostKeyChecking=accept-new',
+  '-o IdentitiesOnly=yes'
 ];
 
 class SSHNPFailed extends SSHNPResult {}
@@ -33,7 +33,7 @@ class SSHCommand extends SSHNPResult {
     sb.write(' ');
     sb.write('-p $localPort');
     sb.write(' ');
-    sb.write(sshOptions.map((e) => '-o $e').join(' '));
+    sb.write(sshOptions.join(' '));
     sb.write(' ');
     sb.write('$remoteUsername@$host');
     if (privateKeyFileName != null) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

closes #391 

**- What I did**

Fixing backward compatibility of the -o flag in SSHNPResult

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: sshnp -o flag should not prepend -o to the output option
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->