### PR TITLE
chore: make empty string the default for the ssh public key instead of 'false'

### DIFF
--- a/packages/sshnoports/lib/sshnp/sshnp.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp.dart
@@ -150,7 +150,7 @@ abstract class SSHNP {
   static const defaultDevice = 'default';
   static const defaultPort = 22;
   static const defaultLocalPort = 0;
-  static const defaultSendSshPublicKey = 'false';
+  static const defaultSendSshPublicKey = '';
   static const defaultLocalSshOptions = <String>[];
   static const defaultVerbose = false;
   static const defaultRsa = false;
@@ -168,7 +168,7 @@ abstract class SSHNP {
     required String username,
     required String homeDirectory,
     required String sessionId,
-    String sendSshPublicKey = 'false',
+    String sendSshPublicKey = SSHNP.defaultSendSshPublicKey,
     required List<String> localSshOptions,
     bool rsa = false,
     // volatile fields

--- a/packages/sshnoports/lib/sshnp/sshnp_impl.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_impl.dart
@@ -179,10 +179,17 @@ class SSHNPImpl implements SSHNP {
       Directory(sshHomeDirectory).createSync();
     }
 
-    if (sendSshPublicKey != 'false') {
-      publicKeyFileName = '$sshHomeDirectory$sendSshPublicKey';
+    // previously, the default value for sendSshPublicKey was 'false' instead of ''
+    // immediately set it to '' to avoid the program from attempting to
+    // search for a public key file called 'false'
+    if (sendSshPublicKey == 'false' || sendSshPublicKey.isEmpty) {
+      publicKeyFileName = '';
+    } else if (path
+        .normalize(sendSshPublicKey)
+        .contains(Platform.pathSeparator)) {
+      publicKeyFileName = sendSshPublicKey;
     } else {
-      publicKeyFileName = 'false';
+      publicKeyFileName = '$sshHomeDirectory$sendSshPublicKey';
     }
   }
 
@@ -306,8 +313,13 @@ class SSHNPImpl implements SSHNP {
         .subscribe(regex: '$sessionId.$namespace@', shouldDecrypt: true)
         .listen(handleSshnpdResponses);
 
-    if (publicKeyFileName != 'false' && !File(publicKeyFileName).existsSync()) {
+    if (publicKeyFileName.isNotEmpty && !File(publicKeyFileName).existsSync()) {
       throw ('\n Unable to find ssh public key file : $publicKeyFileName');
+    }
+
+    if (publicKeyFileName.isNotEmpty &&
+        !File(publicKeyFileName.replaceAll('.pub', '')).existsSync()) {
+      throw ('\n Unable to find matching ssh private key for public key : $publicKeyFileName');
     }
 
     remoteUsername ?? await fetchRemoteUserName();
@@ -526,7 +538,7 @@ class SSHNPImpl implements SSHNP {
       return SSHNPFailed(
           'sshnp connection timeout: waiting for daemon response');
     }
-    
+
     if (sshnpdAckErrors) {
       return SSHNPFailed('sshnp failed: with sshnpd acknowledgement errors');
     }
@@ -615,26 +627,26 @@ class SSHNPImpl implements SSHNP {
   }
 
   Future<void> sharePublicKeyWithSshnpdIfRequired() async {
-    if (publicKeyFileName != 'false') {
-      try {
-        String toSshPublicKey = await File(publicKeyFileName).readAsString();
-        if (!toSshPublicKey.startsWith('ssh-')) {
-          throw ('$publicKeyFileName does not look like a public key file');
-        }
-        AtKey sendOurPublicKeyToSshnpd = AtKey()
-          ..key = 'sshpublickey'
-          ..sharedBy = clientAtSign
-          ..sharedWith = sshnpdAtSign
-          ..metadata = (Metadata()
-            ..ttr = -1
-            ..ttl = 10000);
-        await _notify(sendOurPublicKeyToSshnpd, toSshPublicKey);
-      } catch (e) {
-        stderr.writeln(
-            "Error opening or validating public key file or sending to remote atSign: $e");
-        await cleanUpAfterReverseSsh(this);
-        rethrow;
+    if (publicKeyFileName.isEmpty) return;
+
+    try {
+      String toSshPublicKey = await File(publicKeyFileName).readAsString();
+      if (!toSshPublicKey.startsWith('ssh-')) {
+        throw ('$publicKeyFileName does not look like a public key file');
       }
+      AtKey sendOurPublicKeyToSshnpd = AtKey()
+        ..key = 'sshpublickey'
+        ..sharedBy = clientAtSign
+        ..sharedWith = sshnpdAtSign
+        ..metadata = (Metadata()
+          ..ttr = -1
+          ..ttl = 10000);
+      await _notify(sendOurPublicKeyToSshnpd, toSshPublicKey);
+    } catch (e) {
+      stderr.writeln(
+          "Error opening or validating public key file or sending to remote atSign: $e");
+      await cleanUpAfterReverseSsh(this);
+      rethrow;
     }
   }
 

--- a/packages/sshnoports/lib/sshnp/sshnp_impl.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_impl.dart
@@ -184,12 +184,11 @@ class SSHNPImpl implements SSHNP {
     // search for a public key file called 'false'
     if (sendSshPublicKey == 'false' || sendSshPublicKey.isEmpty) {
       publicKeyFileName = '';
-    } else if (path
-        .normalize(sendSshPublicKey)
-        .contains(Platform.pathSeparator)) {
-      publicKeyFileName = sendSshPublicKey;
+    } else if (path.normalize(sendSshPublicKey).contains('/') ||
+        path.normalize(sendSshPublicKey).contains(r'\')) {
+      publicKeyFileName = path.normalize(path.absolute(sendSshPublicKey));
     } else {
-      publicKeyFileName = '$sshHomeDirectory$sendSshPublicKey';
+      publicKeyFileName = path.normalize('$sshHomeDirectory$sendSshPublicKey');
     }
   }
 

--- a/packages/sshnoports/lib/sshnp/sshnp_result.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_result.dart
@@ -41,8 +41,7 @@ class SSHCommand extends SSHNPResult {
 
   static bool shouldIncludePrivateKey(String? privateKeyFileName) =>
       privateKeyFileName != null &&
-      privateKeyFileName.isNotEmpty &&
-      privateKeyFileName != 'false';
+      privateKeyFileName.isNotEmpty;
 
   @override
   String toString() {

--- a/packages/sshnoports/templates/config/sshnp-config-template.env
+++ b/packages/sshnoports/templates/config/sshnp-config-template.env
@@ -24,6 +24,8 @@ PORT=
 LOCAL_PORT=
 
 # Public key file from ~/.ssh to be appended to authorized_hosts on the remote device
+# If no path is specified, the default is ~/.ssh/<file name>
+# To specify a file in the current directory use: ./<file name>
 SSH_PUBLIC_KEY=
 
 # Add these commands to the local ssh command

--- a/packages/sshnoports/test/sshnp_test.dart
+++ b/packages/sshnoports/test/sshnp_test.dart
@@ -40,17 +40,17 @@ void main() {
       expect(p.sshnpdAtSign, '@bob');
       expect(p.host, 'host.subdomain.test');
 
-      expect(p.device, 'default');
-      expect(p.port, '22');
-      expect(p.localPort, '0');
+      expect(p.device, SSHNP.defaultDevice);
+      expect(p.port, SSHNP.defaultPort);
+      expect(p.localPort, SSHNP.defaultLocalPort);
       expect(p.username, getUserName(throwIfNull: true));
       expect(p.homeDirectory, getHomeDirectory(throwIfNull: true));
       expect(p.atKeysFilePath,
           getDefaultAtKeysFilePath(p.homeDirectory, p.clientAtSign ?? ''));
-      expect(p.sendSshPublicKey, 'false');
-      expect(p.localSshOptions, []);
-      expect(p.rsa, false);
-      expect(p.verbose, false);
+      expect(p.sendSshPublicKey, SSHNP.defaultSendSshPublicKey);
+      expect(p.localSshOptions, SSHNP.defaultLocalSshOptions);
+      expect(p.rsa, SSHNP.defaultRsa);
+      expect(p.verbose, SSHNP.defaultVerbose);
       expect(p.remoteUsername, null);
     });
 

--- a/packages/sshnoports/test/sshnp_test.dart
+++ b/packages/sshnoports/test/sshnp_test.dart
@@ -40,17 +40,17 @@ void main() {
       expect(p.sshnpdAtSign, '@bob');
       expect(p.host, 'host.subdomain.test');
 
-      expect(p.device, SSHNP.defaultDevice);
-      expect(p.port, SSHNP.defaultPort);
-      expect(p.localPort, SSHNP.defaultLocalPort);
+      expect(p.device, 'default');
+      expect(p.port, 22);
+      expect(p.localPort, 0);
       expect(p.username, getUserName(throwIfNull: true));
       expect(p.homeDirectory, getHomeDirectory(throwIfNull: true));
       expect(p.atKeysFilePath,
           getDefaultAtKeysFilePath(p.homeDirectory, p.clientAtSign ?? ''));
-      expect(p.sendSshPublicKey, SSHNP.defaultSendSshPublicKey);
-      expect(p.localSshOptions, SSHNP.defaultLocalSshOptions);
-      expect(p.rsa, SSHNP.defaultRsa);
-      expect(p.verbose, SSHNP.defaultVerbose);
+      expect(p.sendSshPublicKey, '');
+      expect(p.localSshOptions, []);
+      expect(p.rsa, false);
+      expect(p.verbose, false);
       expect(p.remoteUsername, null);
     });
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Made the default value for the Ssh Public Key '' instead of 'false'
- If a path separator is included in Ssh Public Key, then SSHNP assumes it is a file path rather than a file in ~/.ssh
- If no path separator is found, then it assumes the file is within ~/.ssh
- Updated some outdated unit tests with the correct expected values

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: make empty string the default for the ssh public key instead of ''
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->