### PR TITLE
fix: allow ints as options in sshnp_params.dart

### DIFF
--- a/packages/sshnoports/lib/sshnp/sshnp_params.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_params.dart
@@ -307,7 +307,7 @@ class SSHNPPartialParams {
             arg.name,
             abbr: arg.abbr,
             mandatory: arg.mandatory,
-            defaultsTo: withDefaults ? arg.defaultsTo as String? : null,
+            defaultsTo: withDefaults ? arg.defaultsTo : null,
             help: arg.help,
           );
           break;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Port and local port were recently changed from String to int, this cast was missed, and needs to be dropped.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: allow ints as options in sshnp_params.dart
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->