### PR TITLE
fix: build_dart_binaries in install_sshnp

### DIFF
--- a/scripts/install_sshnp
+++ b/scripts/install_sshnp
@@ -289,7 +289,17 @@ make_dirs() {
 # Build the dart binaries from the provided repo
 build_dart_binaries() {
   echo "DEV MODE: Installing from local repo: $SSHNP_DEV_MODE";
-  cp -R "$SSHNP_DEV_MODE/packages/sshnoports/templates/" "$HOME_PATH/.atsign/temp/$BINARY_NAME/templates/";
+  mkdir -p "$HOME_PATH/.atsign/temp/$BINARY_NAME/templates/"
+
+  cp -R "$SSHNP_DEV_MODE"/packages/sshnoports/templates/* "$HOME_PATH/.atsign/temp/$BINARY_NAME/templates/";
+
+  dart pub get -C "$SSHNP_DEV_MODE/packages/sshnoports"
+
+  dart compile exe "$SSHNP_DEV_MODE/packages/sshnoports/bin/sshnp.dart" -o "$HOME_PATH/.atsign/temp/$BINARY_NAME/sshnp";
+  dart compile exe "$SSHNP_DEV_MODE/packages/sshnoports/bin/sshnpd.dart" -o "$HOME_PATH/.atsign/temp/$BINARY_NAME/sshnpd";
+  dart compile exe "$SSHNP_DEV_MODE/packages/sshnoports/bin/sshrv.dart" -o "$HOME_PATH/.atsign/temp/$BINARY_NAME/sshrv";
+  dart compile exe "$SSHNP_DEV_MODE/packages/sshnoports/bin/sshrvd.dart" -o "$HOME_PATH/.atsign/temp/$BINARY_NAME/sshrvd";
+  dart compile exe "$SSHNP_DEV_MODE/packages/sshnoports/bin/activate_cli.dart" -o "$HOME_PATH/.atsign/temp/$BINARY_NAME/at_activate";
 }
 
 # Make a copy of the locally provided archive


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Dart binaries aren't actually being built from the local repo when attempting to install via repo, fixed that.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: build_dart_binaries in install_sshnp
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->