### PR TITLE
fix: Fixed runtime error if running sshnp with invalid arguments (e.g. no arguments)

### DIFF
--- a/packages/sshnoports/lib/sshnp/sshnp_arg.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_arg.dart
@@ -153,4 +153,9 @@ class SSHNPArg {
       format: ArgFormat.flag,
     ),
   ];
+
+  @override
+  String toString() {
+    return 'SSHNPArg{format: $format, name: $name, abbr: $abbr, help: $help, mandatory: $mandatory, defaultsTo: $defaultsTo, type: $type}';
+  }
 }

--- a/packages/sshnoports/lib/sshnp/sshnp_params.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_params.dart
@@ -307,7 +307,7 @@ class SSHNPPartialParams {
             arg.name,
             abbr: arg.abbr,
             mandatory: arg.mandatory,
-            defaultsTo: withDefaults ? arg.defaultsTo : null,
+            defaultsTo: withDefaults ? (arg.defaultsTo != null ? '${arg.defaultsTo}' : null) : null,
             help: arg.help,
           );
           break;


### PR DESCRIPTION
**- What I did**
- Fixed runtime error if running sshnp with invalid arguments (e.g. no arguments)

**- How I did it**
- fix: sshnp_params.dart : because ArgParser.addOption's `defaultsToParameter` is a String?, the default value must also be presented to the parser as a String (or null, if there is no default value)
- feat: added a `toString()` to SSHNPArg

**- How to verify it**
- `dart bin/sshnp.dart` should successfully print usage information and exit

