### PR TITLE
chore: Dependabot for sshnp_gui and Python SDK

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,12 +18,11 @@ updates:
     directory: "/packages/sshnoports/"
     schedule:
       interval: "daily"
-      interval: "daily"
   - package-ecosystem: "pub"
     directory: "/packages/sshnp_gui/"
     schedule:
       interval: "daily"
   - package-ecosystem: "pip"
-    directory: "/packages/noports_sdk_python/"
+    directory: "/packages/sshnoports_sdk_python/"
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,11 @@ updates:
     directory: "/packages/sshnoports/"
     schedule:
       interval: "daily"
+      interval: "daily"
+  - package-ecosystem: "pub"
+    directory: "/packages/sshnp_gui/"
+    schedule:
+      interval: "daily"
   - package-ecosystem: "pip"
     directory: "/packages/noports_sdk_python/"
     schedule:


### PR DESCRIPTION
Dependabot fixed the issue with archive on the main package, but not the GUI as it's not presently covered

The Python SDK directory was renamed without a corresponding update to Dependabot config.

**- What I did**

* Added pub section for GUI
* Fixed directory name for Python SDK

**- How to verify it**

Dependabot will raise PR for archive

**- Description for the changelog**

chore: Dependabot for sshnp_gui and Python SDK