### PR TITLE
fix: send ssh public key

### DIFF
--- a/packages/sshnoports/lib/sshnp/sshnp_impl.dart
+++ b/packages/sshnoports/lib/sshnp/sshnp_impl.dart
@@ -638,6 +638,7 @@ class SSHNPImpl implements SSHNP {
         ..key = 'sshpublickey'
         ..sharedBy = clientAtSign
         ..sharedWith = sshnpdAtSign
+        ..namespace = namespace
         ..metadata = (Metadata()
           ..ttr = -1
           ..ttl = 10000);

--- a/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
+++ b/packages/sshnoports/lib/sshnpd/sshnpd_impl.dart
@@ -295,10 +295,6 @@ class SSHNPDImpl implements SSHNPD {
 
     late final String sshPublicKey;
     try {
-      var sshHomeDirectory = '$homeDirectory/.ssh/';
-      if (Platform.isWindows) {
-        sshHomeDirectory = '$homeDirectory\\.ssh\\';
-      }
       logger.info(
           'ssh Public Key received from ${notification.from} notification id : ${notification.id}');
       sshPublicKey = notification.value!;
@@ -309,7 +305,9 @@ class SSHNPDImpl implements SSHNPD {
       }
 
       // Check to see if the ssh Publickey is already in the file if not append to the ~/.ssh/authorized_keys file
-      var authKeys = File('${sshHomeDirectory}authorized_keys');
+      var authKeysFilePath = [homeDirectory, '.ssh', 'authorized_keys']
+          .join(Platform.pathSeparator);
+      var authKeys = File(authKeysFilePath);
 
       var authKeysContent = await authKeys.readAsString();
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Added the namespace to the sshpublickey, since the daemon wasn't receiving it
- Switched to using `Platform.pathSeperator` for generating the authorized_keys file path

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: send ssh public key
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->