### PR TITLE
fix: gui namespace

### DIFF
--- a/packages/sshnp_gui/lib/src/repository/authentication_repository.dart
+++ b/packages/sshnp_gui/lib/src/repository/authentication_repository.dart
@@ -11,6 +11,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sshnoports/sshnpd/sshnpd.dart';
 import 'package:sshnp_gui/src/presentation/widgets/utility/custom_snack_bar.dart';
 import 'package:sshnp_gui/src/controllers/navigation_controller.dart';
 import 'package:sshnp_gui/src/repository/navigation_repository.dart';
@@ -53,14 +54,10 @@ class AuthenticationRepository {
 
     return AtClientPreference()
       ..rootDomain = AtEnv.rootDomain
-      ..namespace = AtEnv.appNamespace
+      ..namespace = SSHNPD.namespace
       ..hiveStoragePath = dir.path
       ..commitLogPath = dir.path
       ..isLocalStoreRequired = true;
-    // TODO
-    // * By default, this configuration is suitable for most applications
-    // * In advanced cases you may need to modify [AtClientPreference]
-    // * Read more here: https://pub.dev/documentation/at_client/latest/at_client/AtClientPreference-class.html
   }
 
   /// Signs user into the @platform.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Set the sshnp_gui namespace to the same one as the sshnoports package uses (SSHNPD.namespace)
- This caused a bug in the gui with #439 since the sshpublickey wasn't being shared correctly when using the gui, this will prevent further issues if the namespace of a key is not explicit.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: gui namespace
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->