### PR TITLE
ci: allow dockerhub image name to be selected for promotion

### DIFF
--- a/.github/workflows/dockerhub_promote_to_latest.yaml
+++ b/.github/workflows/dockerhub_promote_to_latest.yaml
@@ -34,4 +34,4 @@ jobs:
       - name: Get version
         run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - name: Promote image to latest
-        run: docker buildx imagetools create -t atsigncompany/${{ inputs.name }}:latest atsigncompany/${{ matrix.name }}:release-${{ env.VERSION }}
+        run: docker buildx imagetools create -t atsigncompany/${{ inputs.name }}:latest atsigncompany/${{ inputs.name }}:release-${{ env.VERSION }}

--- a/.github/workflows/dockerhub_promote_to_latest.yaml
+++ b/.github/workflows/dockerhub_promote_to_latest.yaml
@@ -2,16 +2,21 @@ name: dockerhub_promote_to_latest
 
 on:
   workflow_dispatch:
+    inputs:
+      name:
+        description: "Name of the image to promote"
+        required: true
+        default: sshnpd
+        type: choice
+        options:
+          - sshnpd
+          - activate_sshnpd
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
 
 jobs:
   docker:
-    strategy:
-      matrix:
-        include:
-          - name: [sshnpd, activate_sshnpd]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,4 +34,4 @@ jobs:
       - name: Get version
         run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - name: Promote image to latest
-        run: docker buildx imagetools create -t atsigncompany/${{ matrix.name }}:latest atsigncompany/${{ matrix.name }}:release-${{ env.VERSION }}
+        run: docker buildx imagetools create -t atsigncompany/${{ inputs.name }}:latest atsigncompany/${{ matrix.name }}:release-${{ env.VERSION }}

--- a/packages/sshnoports/lib/version.dart
+++ b/packages/sshnoports/lib/version.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 // Note: if you update this version also update pubspec.yaml
-const String version = "4.0.0-rc.2";
+const String version = "4.0.0-rc.3";
 
 /// Print version number
 void printVersion() {

--- a/packages/sshnoports/pubspec.yaml
+++ b/packages/sshnoports/pubspec.yaml
@@ -3,7 +3,7 @@ description: Encrypted/Secure control plane for ssh/d or other commands in the f
 
 # NOTE: If you update the version number here, you
 # must also update it in version.dart
-version: 3.4.1
+version: 4.0.0-rc.3
 
 homepage: https://docs.atsign.com/
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- created tag v4.0.0-rc.3 off the most recent trunk with the intent to promote the activate_sshnpd image to latest (since we don't have one published yet)
- modified the promote to latest script to accept the name of the image to promote
  - Did this as a dropdown selection rather than input, so that it is limited to the two images generated in this repo, and cannot be abused to mess with the rest of the atsigncompany dockerhub images 

**- How I did it**

**- How to verify it**

**- Description for the changelog**
ci: allow dockerhub image name to be selected for promotion
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->