### PR TITLE
fix: Dockerfile(s) location for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "pub"
-    directory: "/packages/sshnoports/"
+    directory: "/packages/sshnoports/templates/docker/"
     schedule:
       interval: "daily"
   - package-ecosystem: "pub"


### PR DESCRIPTION
Refactoring of the Dockerfile location didn't update Dependabot

**- What I did**

Revised the directory parameter to point to where the Dockerfile(s) now live

**- How I did it**

A look at [Dependabot Insights](https://github.com/atsign-foundation/sshnoports/network/updates) revealed that runs were failing due to Dockerfile not found.

**- How to verify it**

Rerun Dependabot for that package ecosystem and it will generate PRs for Dart 3.1.1 etc.

**- Description for the changelog**

fix: Dockerfile(s) location for Dependabot