### PR TITLE
fix: Locations for pub and Docker were mixed up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "docker"
-    directory: "/packages/sshnoports/"
+    directory: "/packages/sshnoports/templates/docker/"
     schedule:
       interval: "daily"
   - package-ecosystem: "docker"
@@ -15,7 +15,7 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "pub"
-    directory: "/packages/sshnoports/templates/docker/"
+    directory: "/packages/sshnoports/"
     schedule:
       interval: "daily"
   - package-ecosystem: "pub"


### PR DESCRIPTION
#455 modified the directory for the wrong ecosystem

**- What I did**

Corrected paths for docker and pub

**- How to verify it**

Review Dependabot insights

**- Description for the changelog**

fix: Locations for pub and Docker were mixed up