### PR TITLE
ci: alternate_port_test, sshrvd healthcheck, prod_tests

### DIFF
--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -563,12 +563,15 @@ jobs:
           cat service-container-sshnp.yaml >> docker-compose.yaml
           echo '    image: atsigncompany/sshnp-e2e-runtime:local' >> docker-compose.yaml
           echo '    depends_on:' >> docker-compose.yaml
-          echo '      - image-runtime-local' >> docker-compose.yaml
-          echo '      - container-sshnpd' >> docker-compose.yaml
+          echo '      image-runtime-local:' >> docker-compose.yaml
+          echo '       condition: service_healthy' >> docker-compose.yaml
+          echo '      container-sshnpd:' >> docker-compose.yaml
+          echo '       condition: service_healthy' >> docker-compose.yaml
           cat service-container-sshnpd.yaml >> docker-compose.yaml
           echo '    image: atsigncompany/sshnp-e2e-runtime:local' >> docker-compose.yaml
           echo '    depends_on:' >> docker-compose.yaml
-          echo '      - image-runtime-local' >> docker-compose.yaml
+          echo '      image-runtime-local:' >> docker-compose.yaml
+          echo '       condition: service_healthy' >> docker-compose.yaml
 
       - name: docker-compose.yaml
         if: always()

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -564,14 +564,14 @@ jobs:
           echo '    image: atsigncompany/sshnp-e2e-runtime:local' >> docker-compose.yaml
           echo '    depends_on:' >> docker-compose.yaml
           echo '      image-runtime-local:' >> docker-compose.yaml
-          echo '       condition: service_healthy' >> docker-compose.yaml
+          echo '       condition: service_started' >> docker-compose.yaml
           echo '      container-sshnpd:' >> docker-compose.yaml
           echo '       condition: service_healthy' >> docker-compose.yaml
           cat service-container-sshnpd.yaml >> docker-compose.yaml
           echo '    image: atsigncompany/sshnp-e2e-runtime:local' >> docker-compose.yaml
           echo '    depends_on:' >> docker-compose.yaml
           echo '      image-runtime-local:' >> docker-compose.yaml
-          echo '       condition: service_healthy' >> docker-compose.yaml
+          echo '       condition: service_started' >> docker-compose.yaml
 
       - name: docker-compose.yaml
         if: always()

--- a/.github/workflows/prod_tests.yaml
+++ b/.github/workflows/prod_tests.yaml
@@ -110,7 +110,7 @@ jobs:
           echo "        condition: service_healthy" >> docker-compose.yaml
           if [ "${{ matrix.rvd }}" == "@8485wealthy51" ]; then
             echo "      container-sshrvd:" >> docker-compose.yaml
-            echo "        condition: service_started" >> docker-compose.yaml
+            echo "        condition: service_healthy" >> docker-compose.yaml
           fi
           cat service-container-sshnpd.yaml >> docker-compose.yaml
           echo "    image: atsigncompany/sshnp-e2e-runtime:latest" >> docker-compose.yaml
@@ -119,7 +119,7 @@ jobs:
           echo "        condition: service_started" >> docker-compose.yaml
           if [ "${{ matrix.rvd }}" == "@8485wealthy51" ]; then
             echo "      container-sshrvd:" >> docker-compose.yaml
-            echo "        condition: service_started" >> docker-compose.yaml
+            echo "        condition: service_healthy" >> docker-compose.yaml
           fi
 
       - name: Add RVD service to docker-compose.yaml

--- a/.github/workflows/prod_tests.yaml
+++ b/.github/workflows/prod_tests.yaml
@@ -61,14 +61,14 @@ jobs:
         working-directory: tests/end2end_tests/contexts/_init_
         run: |
           ./setup-sshnp-entrypoint.sh \
-            ${{ github.run_id }}${{ github.run_attempt }}a${{ strategy.job-index }} \
+            ${{ github.run_id }}${{ github.run_attempt }}p${{ strategy.job-index }} \
             ${{ env.SSHNP_ATSIGN }} \
             ${{ env.SSHNPD_ATSIGN }} \
             ${{ matrix.rvd }} \
             sshnp_entrypoint.sh
 
           ./setup-sshnpd-entrypoint.sh \
-            ${{ github.run_id }}${{ github.run_attempt }}a${{ strategy.job-index }} \
+            ${{ github.run_id }}${{ github.run_attempt }}p${{ strategy.job-index }} \
             ${{ env.SSHNP_ATSIGN }} \
             ${{ env.SSHNPD_ATSIGN }} \
             sshnpd_entrypoint.sh

--- a/.github/workflows/prod_tests.yaml
+++ b/.github/workflows/prod_tests.yaml
@@ -104,17 +104,22 @@ jobs:
           cat service-container-sshnp.yaml >> docker-compose.yaml
           echo "    image: atsigncompany/sshnp-e2e-runtime:latest" >> docker-compose.yaml
           echo "    depends_on:" >> docker-compose.yaml
-          echo "      - image-runtime-release" >> docker-compose.yaml
-          echo "      - container-sshnpd" >> docker-compose.yaml
+          echo "      image-runtime-release:" >> docker-compose.yaml
+          echo "        condition: service_started" >> docker-compose.yaml
+          echo "      container-sshnpd:" >> docker-compose.yaml
+          echo "        condition: service_healthy" >> docker-compose.yaml
           if [ "${{ matrix.rvd }}" == "@8485wealthy51" ]; then
-            echo "      - container-sshrvd" >> docker-compose.yaml
+            echo "      container-sshrvd:" >> docker-compose.yaml
+            echo "        condition: service_started" >> docker-compose.yaml
           fi
           cat service-container-sshnpd.yaml >> docker-compose.yaml
           echo "    image: atsigncompany/sshnp-e2e-runtime:latest" >> docker-compose.yaml
           echo "    depends_on:" >> docker-compose.yaml
-          echo "      - image-runtime-release" >> docker-compose.yaml
+          echo "      image-runtime-release:" >> docker-compose.yaml
+          echo "        condition: service_started" >> docker-compose.yaml
           if [ "${{ matrix.rvd }}" == "@8485wealthy51" ]; then
-            echo "      - container-sshrvd" >> docker-compose.yaml
+            echo "      container-sshrvd:" >> docker-compose.yaml
+            echo "        condition: service_started" >> docker-compose.yaml
           fi
 
       - name: Add RVD service to docker-compose.yaml
@@ -124,7 +129,8 @@ jobs:
           cat service-container-sshrvd.yaml >> docker-compose.yaml
           echo "    image: atsigncompany/sshnp-e2e-runtime:latest" >> docker-compose.yaml
           echo "    depends_on:" >> docker-compose.yaml
-          echo "      - image-runtime-release" >> docker-compose.yaml
+          echo "      image-runtime-release:" >> docker-compose.yaml
+          echo "        condition: service_started" >> docker-compose.yaml
 
       - name: docker-compose.yaml
         working-directory: tests/end2end_tests/tests

--- a/.github/workflows/prod_tests.yaml
+++ b/.github/workflows/prod_tests.yaml
@@ -1,4 +1,4 @@
-name: prod_tests
+name: prod_rvd_tests
 
 on:
   workflow_dispatch:
@@ -19,7 +19,7 @@ env:
   DOCKER_COMPOSE_UP_CMD: "docker compose up --abort-on-container-exit --timeout 900"
 
 jobs:
-  e2e_test:
+  prod_rvd_test:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/prod_tests.yaml
+++ b/.github/workflows/prod_tests.yaml
@@ -57,18 +57,24 @@ jobs:
           echo "${{ secrets[env.SSHNP_ATKEYS] }}" > sshnp/.atsign/keys/${{ env.SSHNP_ATSIGN }}_key.atKeys
           echo "${{ secrets[env.SSHNPD_ATKEYS] }}" > sshnpd/.atsign/keys/${{ env.SSHNPD_ATSIGN }}_key.atKeys
 
+      - name: Setup Devicename
+        # First two guarantee a unique # per workflow call
+        # Last two guarantee  a unique # per job per strategy in matrix
+        run: |
+          echo "DEVICENAME=${{ github.run_id }}${{ github.run_attempt }}p${{ strategy.job-index }}" >> $GITHUB_ENV
+
       - name: Set up NP/NPD entrypoints
         working-directory: tests/end2end_tests/contexts/_init_
         run: |
           ./setup-sshnp-entrypoint.sh \
-            ${{ github.run_id }}${{ github.run_attempt }}p${{ strategy.job-index }} \
+          ${{ env.DEVICENAME }} \
             ${{ env.SSHNP_ATSIGN }} \
             ${{ env.SSHNPD_ATSIGN }} \
             ${{ matrix.rvd }} \
             sshnp_entrypoint.sh
 
           ./setup-sshnpd-entrypoint.sh \
-            ${{ github.run_id }}${{ github.run_attempt }}p${{ strategy.job-index }} \
+            ${{ env.DEVICENAME }} \
             ${{ env.SSHNP_ATSIGN }} \
             ${{ env.SSHNPD_ATSIGN }} \
             sshnpd_entrypoint.sh

--- a/.github/workflows/prod_tests.yaml
+++ b/.github/workflows/prod_tests.yaml
@@ -1,4 +1,4 @@
-name: prod_rvd_tests
+name: prod_tests
 
 on:
   workflow_dispatch:
@@ -16,7 +16,7 @@ env:
   SSHRVD_AP_ATSIGN: "@rv_ap"
   SSHRVD_EU_ATSIGN: "@rv_eu"
   DOCKER_COMPOSE_BUILD_CMD: "docker compose build"
-  DOCKER_COMPOSE_UP_CMD: "docker compose up --abort-on-container-exit --timeout 900"
+  DOCKER_COMPOSE_UP_CMD: "docker compose up --abort-on-container-exit"
 
 jobs:
   prod_rvd_test:

--- a/.github/workflows/prod_tests.yaml
+++ b/.github/workflows/prod_tests.yaml
@@ -10,11 +10,8 @@ on:
 
 env:
   SSHNP_ATSIGN: "@8incanteater"
-  SSHNP_ATSIGN_KEYS: ${{ secrets.ATKEYS_8INCANTEATER }}
   SSHNPD_ATSIGN: "@8052simple"
-  SSHNPD_ATSIGN_KEYS: ${{ secrets.ATKEYS_8052SIMPLE }}
   SSHRVD_ATSIGN: "@8485wealthy51"
-  SSHRVD_ATSIGN_KEYS: ${{ secrets.ATKEYS_8485WEALTHY51 }}
   SSHRVD_AM_ATSIGN: "@rv_am"
   SSHRVD_AP_ATSIGN: "@rv_ap"
   SSHRVD_EU_ATSIGN: "@rv_eu"
@@ -51,6 +48,9 @@ jobs:
           SSHNPD_ATKEYS="$(tr '[:lower:]' '[:upper:]' <<< '${{ env.SSHNPD_ATSIGN }}')"
           echo "SSHNPD_ATKEYS=ATKEYS_${SSHNPD_ATKEYS:1}" >> $GITHUB_ENV
 
+          SSHRVD_ATKEYS="$(tr '[:lower:]' '[:upper:]' <<< '${{ env.SSHRVD_ATSIGN }}')"
+          echo "SSHRVD_ATKEYS=ATKEYS_${SSHRVD_ATKEYS:1}" >> $GITHUB_ENV
+
       - name: Setup NP/NPD keys
         working-directory: tests/end2end_tests/contexts
         run: |
@@ -78,7 +78,7 @@ jobs:
         working-directory: tests/end2end_tests
         run: |
           # setup keys
-          echo "${{ env.SSHRVD_ATSIGN_KEYS }}" > contexts/sshrvd/.atsign/keys/${{ env.SSHRVD_ATSIGN }}_key.atKeys
+          echo "${{ secrets[env.SSHRVD_ATKEYS] }}" > contexts/sshrvd/.atsign/keys/${{ env.SSHRVD_ATSIGN }}_key.atKeys
 
           # set up sshrvd entrypoint
           cd contexts/_init_

--- a/.github/workflows/prod_tests.yaml
+++ b/.github/workflows/prod_tests.yaml
@@ -67,7 +67,7 @@ jobs:
         working-directory: tests/end2end_tests/contexts/_init_
         run: |
           ./setup-sshnp-entrypoint.sh \
-          ${{ env.DEVICENAME }} \
+            ${{ env.DEVICENAME }} \
             ${{ env.SSHNP_ATSIGN }} \
             ${{ env.SSHNPD_ATSIGN }} \
             ${{ matrix.rvd }} \

--- a/.github/workflows/prod_tests.yaml
+++ b/.github/workflows/prod_tests.yaml
@@ -61,14 +61,14 @@ jobs:
         working-directory: tests/end2end_tests/contexts/_init_
         run: |
           ./setup-sshnp-entrypoint.sh \
-            ${{ github.run_id }}${{ github.run_attempt }}${{ strategy.job-index }} \
+            ${{ github.run_id }}${{ github.run_attempt }}a${{ strategy.job-index }} \
             ${{ env.SSHNP_ATSIGN }} \
             ${{ env.SSHNPD_ATSIGN }} \
             ${{ matrix.rvd }} \
             sshnp_entrypoint.sh
 
           ./setup-sshnpd-entrypoint.sh \
-            ${{ github.run_id }}${{ github.run_attempt }}${{ strategy.job-index }} \
+            ${{ github.run_id }}${{ github.run_attempt }}a${{ strategy.job-index }} \
             ${{ env.SSHNP_ATSIGN }} \
             ${{ env.SSHNPD_ATSIGN }} \
             sshnpd_entrypoint.sh

--- a/.github/workflows/prod_tests.yaml
+++ b/.github/workflows/prod_tests.yaml
@@ -108,7 +108,7 @@ jobs:
           echo "        condition: service_started" >> docker-compose.yaml
           echo "      container-sshnpd:" >> docker-compose.yaml
           echo "        condition: service_healthy" >> docker-compose.yaml
-          if [ "${{ matrix.rvd }}" == "@8485wealthy51" ]; then
+          if [ "${{ matrix.rvd }}" == "${{ env.SSHRVD_ATSIGN }}" ]; then
             echo "      container-sshrvd:" >> docker-compose.yaml
             echo "        condition: service_healthy" >> docker-compose.yaml
           fi
@@ -117,7 +117,7 @@ jobs:
           echo "    depends_on:" >> docker-compose.yaml
           echo "      image-runtime-release:" >> docker-compose.yaml
           echo "        condition: service_started" >> docker-compose.yaml
-          if [ "${{ matrix.rvd }}" == "@8485wealthy51" ]; then
+          if [ "${{ matrix.rvd }}" == "${{ env.SSHRVD_ATSIGN }}" ]; then
             echo "      container-sshrvd:" >> docker-compose.yaml
             echo "        condition: service_healthy" >> docker-compose.yaml
           fi

--- a/tests/end2end_tests/contexts/_init_/setup-sshrvd-entrypoint.sh
+++ b/tests/end2end_tests/contexts/_init_/setup-sshrvd-entrypoint.sh
@@ -5,7 +5,7 @@
 # example usage: ./setup-sshrvd-entrypoint.sh @alice
 
 sshrvd=$1 # e.g. @alice
-template_name=$2
+template_name=$2 # e.g. "sshrvd_entrypoint.sh"
 
 cp ../../entrypoints/"$template_name" ../sshrvd/entrypoint.sh # copy template to the mounted folder
 

--- a/tests/end2end_tests/entrypoints/sshnp_entrypoint.sh
+++ b/tests/end2end_tests/entrypoints/sshnp_entrypoint.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 echo "SSHNP START ENTRY"
-SSHNP_COMMAND="$HOME/.local/bin/sshnp -f @sshnpatsign -t @sshnpdatsign -d deviceName -h @sshrvdatsign -s id_ed25519.pub -v > logs.txt"
+SSHNP_COMMAND="$HOME/.local/bin/sshnp -f @sshnpatsign -t @sshnpdatsign -d deviceName -h @sshrvdatsign -s id_ed25519.pub -v > sshnp.log"
 echo "Running: $SSHNP_COMMAND"
 eval "$SSHNP_COMMAND"
-cat logs.txt
-tail -n 5 logs.txt | grep "ssh -p" > sshcommand.txt
+cat sshnp.log
+tail -n 5 sshnp.log | grep "ssh -p" > sshcommand.txt
 
 if [ ! -s sshcommand.txt ]; then
     # try again
     echo "Running: $SSHNP_COMMAND"
     eval "$SSHNP_COMMAND"
-    cat logs.txt
-    tail -n 5 logs.txt | grep "ssh -p" > sshcommand.txt
+    cat sshnp.log
+    tail -n 5 sshnp.log | grep "ssh -p" > sshcommand.txt
     if [ ! -s sshcommand.txt ]; then
-        echo "could not find 'ssh -p' command in logs.txt"
-        echo "last 5 lines of logs.txt:"
-        tail -n 5 logs.txt || echo
+        echo "could not find 'ssh -p' command in sshnp.log"
+        echo "last 5 lines of sshnp.log:"
+        tail -n 5 sshnp.log || echo
         exit 1
     fi
 fi

--- a/tests/end2end_tests/entrypoints/sshnp_installer_entrypoint.sh
+++ b/tests/end2end_tests/entrypoints/sshnp_installer_entrypoint.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 sleep WAITING_TIME # time for sshnpd to share device name
 
-SSHNP_COMMAND="$HOME/.local/bin/sshnp -f @sshnpatsign -t @sshnpdatsign -d deviceName -h @sshrvdatsign -s id_ed25519.pub -v > logs.txt"
+SSHNP_COMMAND="$HOME/.local/bin/sshnp -f @sshnpatsign -t @sshnpdatsign -d deviceName -h @sshrvdatsign -s id_ed25519.pub -v > sshnp.log"
 echo "Running: $SSHNP_COMMAND"
 eval "$SSHNP_COMMAND"
-cat logs.txt
-tail -n 5 logs.txt | grep "ssh -p" > sshcommand.txt
+cat sshnp.log
+tail -n 5 sshnp.log | grep "ssh -p" > sshcommand.txt
 
 if [ ! -s sshcommand.txt ]; then
     # try again
     echo "Running: $SSHNP_COMMAND"
     eval "$SSHNP_COMMAND"
-    cat logs.txt
-    tail -n 5 logs.txt | grep "ssh -p" > sshcommand.txt
+    cat sshnp.log
+    tail -n 5 sshnp.log | grep "ssh -p" > sshcommand.txt
     if [ ! -s sshcommand.txt ]; then
-        echo "could not find 'ssh -p' command in logs.txt"
-        echo "last 5 lines of logs.txt:"
-        tail -n 5 logs.txt || echo
+        echo "could not find 'ssh -p' command in sshnp.log"
+        echo "last 5 lines of sshnp.log:"
+        tail -n 5 sshnp.log || echo
         exit 1
     fi
 fi

--- a/tests/end2end_tests/entrypoints/sshnpd_entrypoint.sh
+++ b/tests/end2end_tests/entrypoints/sshnpd_entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 echo "SSHNPD START ENTRY"
-SSHNPD_COMMAND="$HOME/.local/bin/sshnpd -a @sshnpdatsign -m @sshnpatsign -d deviceName -s -u -v 2>&1 | tee all.txt"
+SSHNPD_COMMAND="$HOME/.local/bin/sshnpd -a @sshnpdatsign -m @sshnpatsign -d deviceName -s -u -v 2>&1 | tee -a sshnpd.log"
 echo "Running: $SSHNPD_COMMAND"
 eval "$SSHNPD_COMMAND"

--- a/tests/end2end_tests/entrypoints/sshnpd_installer_entrypoint.sh
+++ b/tests/end2end_tests/entrypoints/sshnpd_installer_entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-SSHNPD_COMMAND="$HOME/.local/bin/sshnpd@sshnpatsign 2>&1 | tee all.txt"
+SSHNPD_COMMAND="$HOME/.local/bin/sshnpd@sshnpatsign 2>&1 | tee -a sshnpd.log"
 echo "Running: $SSHNPD_COMMAND"
 eval "$SSHNPD_COMMAND"

--- a/tests/end2end_tests/entrypoints/sshrvd_entrypoint.sh
+++ b/tests/end2end_tests/entrypoints/sshrvd_entrypoint.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-"$HOME"/.local/bin/sshrvd -a @sshrvdatsign -i "$(hostname -i)" -v -s 2>&1 | tee -a sshrvd.log
+"$HOME"/.local/bin/sshrvd -a @sshrvdatsign -i "$(hostname -i)" -v -s &> sshrvd.log

--- a/tests/end2end_tests/entrypoints/sshrvd_entrypoint.sh
+++ b/tests/end2end_tests/entrypoints/sshrvd_entrypoint.sh
@@ -1,4 +1,2 @@
 #!/bin/bash
-"$HOME"/.local/bin/sshrvd -a @sshrvdatsign -i "$(hostname -i)" -v -s
-sleep 60 # sleep 60 because other containers depend on it. And if it's not being used (let's say you're using @rv_am), then it will just sleep until sshnp exits
-exit 0
+"$HOME"/.local/bin/sshrvd -a @sshrvdatsign -i "$(hostname -i)" -v -s 2>&1 | tee -a sshrvd.log

--- a/tests/end2end_tests/entrypoints/sshrvd_entrypoint.sh
+++ b/tests/end2end_tests/entrypoints/sshrvd_entrypoint.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-"$HOME"/.local/bin/sshrvd -a @sshrvdatsign -i "$(hostname -i)" -v -s &> sshrvd.log
+"$HOME"/.local/bin/sshrvd -a @sshrvdatsign -i "$(hostname -i)" -v -s > sshrvd.log

--- a/tests/end2end_tests/entrypoints/sshrvd_entrypoint.sh
+++ b/tests/end2end_tests/entrypoints/sshrvd_entrypoint.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-"$HOME"/.local/bin/sshrvd -a @sshrvdatsign -i "$(hostname -i)" -v -s > sshrvd.log
+"$HOME"/.local/bin/sshrvd -a @sshrvdatsign -i "$(hostname -i)" -v -s 2>&1 | tee -a sshrvd.log

--- a/tests/end2end_tests/image/Dockerfile
+++ b/tests/end2end_tests/image/Dockerfile
@@ -57,7 +57,7 @@ WORKDIR ${HOMEDIR}
 
 USER ${USER}
 
-ENTRYPOINT cp -r /mount/. /atsign && sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
+ENTRYPOINT cp -r /mount/. ${HOMEDIR} && sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
 # END BRANCH
 
 # LOCAL
@@ -90,7 +90,7 @@ WORKDIR ${HOMEDIR}
 
 USER ${USER}
 
-ENTRYPOINT cp -r /mount/. /atsign && sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
+ENTRYPOINT cp -r /mount/. ${HOMEDIR} && sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
 # END LOCAL
 
 # RELEASE
@@ -139,7 +139,7 @@ WORKDIR ${HOMEDIR}
 
 USER ${USER}
 
-ENTRYPOINT cp -r /mount/. /atsign && sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
+ENTRYPOINT cp -r /mount/. ${HOMEDIR} && sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
 # END RELEASE
 
 # SSHNP INSTALLER
@@ -170,7 +170,7 @@ FROM build-sshnp-installer AS runtime-sshnp-installer
 USER ${USER}
 WORKDIR ${HOMEDIR}
 
-ENTRYPOINT cp -r /mount/. /atsign && sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
+ENTRYPOINT cp -r /mount/. ${HOMEDIR} && sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
 # END SSHNP INSTALLER
 
 # SSHNPD INSTALLER
@@ -204,7 +204,7 @@ FROM build-sshnpd-installer AS runtime-sshnpd-installer
 USER ${USER}
 WORKDIR ${HOMEDIR}
 
-ENTRYPOINT cp -r /mount/. /atsign && sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
+ENTRYPOINT cp -r /mount/. ${HOMEDIR} && sudo service ssh start && sh ${HOMEDIR}/entrypoint.sh
 # END SSHNPD INSTALLER
 
 # MANUAL

--- a/tests/end2end_tests/tests/service-container-sshnpd.yaml
+++ b/tests/end2end_tests/tests/service-container-sshnpd.yaml
@@ -5,7 +5,7 @@
     networks:
       - sshnpd
     healthcheck:
-      test: grep -Eq "monitor started for @" /atsign/all.txt
+      test: ["CMD", "grep", "-Eq", "monitor started for @", "/atsign/all.txt"]
       start_period: 10s # Wait 10 seconds before checking
       interval: 5s # Check every 5 seconds
       timeout: 1s # If a check takes longer than a second, consider it a failed check

--- a/tests/end2end_tests/tests/service-container-sshnpd.yaml
+++ b/tests/end2end_tests/tests/service-container-sshnpd.yaml
@@ -5,7 +5,7 @@
     networks:
       - sshnpd
     healthcheck:
-      test: ["CMD", "grep", "-Eq", "\"monitor started for @\"", "/atsign/all.txt"]
+      test: ["CMD", "grep", "-Eq", "\"monitor started for @\"", "/atsign/sshnpd.log"]
       start_period: 1s # Wait 10 seconds before checking
       interval: 1s # Check every 5 seconds
       timeout: 1s # If a check takes longer than a second, consider it a failed check

--- a/tests/end2end_tests/tests/service-container-sshnpd.yaml
+++ b/tests/end2end_tests/tests/service-container-sshnpd.yaml
@@ -5,11 +5,11 @@
     networks:
       - sshnpd
     healthcheck:
-      test: ["CMD", "grep", "-Eq", "monitor started for @", "/atsign/all.txt"]
-      start_period: 10s # Wait 10 seconds before checking
-      interval: 5s # Check every 5 seconds
+      test: ["CMD", "grep", "-Eq", "\"monitor started for @\"", "/atsign/all.txt"]
+      start_period: 1s # Wait 10 seconds before checking
+      interval: 1s # Check every 5 seconds
       timeout: 1s # If a check takes longer than a second, consider it a failed check
-      retries: 180 # Retry the check 180 times (180 * 5s = 15 mins)
+      retries: 180 # Retry the check 180 times (180 * 1s = 2 mins)
     # auto added:
     # - image
     # - depends_on: (sshrvd + runtime service)

--- a/tests/end2end_tests/tests/service-container-sshnpd.yaml
+++ b/tests/end2end_tests/tests/service-container-sshnpd.yaml
@@ -4,6 +4,7 @@
       - ../contexts/sshnpd:/mount
     networks:
       - sshnpd
+    condition: service_healthy
     healthcheck:
       test: ["CMD", "grep", "-Eq", "\"monitor started for @\"", "/atsign/sshnpd.log"]
       start_period: 10s # Wait 10 seconds before checking

--- a/tests/end2end_tests/tests/service-container-sshnpd.yaml
+++ b/tests/end2end_tests/tests/service-container-sshnpd.yaml
@@ -4,7 +4,6 @@
       - ../contexts/sshnpd:/mount
     networks:
       - sshnpd
-    condition: service_healthy
     healthcheck:
       test: ["CMD", "grep", "-Eq", "\"monitor started for @\"", "/atsign/sshnpd.log"]
       start_period: 10s # Wait 10 seconds before checking

--- a/tests/end2end_tests/tests/service-container-sshnpd.yaml
+++ b/tests/end2end_tests/tests/service-container-sshnpd.yaml
@@ -6,10 +6,10 @@
       - sshnpd
     healthcheck:
       test: ["CMD", "grep", "-Eq", "\"monitor started for @\"", "/atsign/sshnpd.log"]
-      start_period: 1s # Wait 10 seconds before checking
-      interval: 1s # Check every 5 seconds
+      start_period: 10s # Wait 10 seconds before checking
+      interval: 1s # Check every second
       timeout: 1s # If a check takes longer than a second, consider it a failed check
-      retries: 180 # Retry the check 180 times (180 * 1s = 2 mins)
+      retries: 900 # Retry the check n times (900 * 1s = 15 mins)
     # auto added:
     # - image
     # - depends_on: (sshrvd + runtime service)

--- a/tests/end2end_tests/tests/service-container-sshnpd.yaml
+++ b/tests/end2end_tests/tests/service-container-sshnpd.yaml
@@ -5,7 +5,7 @@
     networks:
       - sshnpd
     healthcheck:
-      test: ["CMD", "grep", "-Eq", "\"monitor started for @\"", "/atsign/sshnpd.log"]
+      test: ["CMD", "grep", "-Eq", "monitor started for @", "/atsign/sshnpd.log"]
       start_period: 10s # Wait 10 seconds before checking
       interval: 5s # Check every 5 seconds
       timeout: 1s # If a check takes longer than a second, consider it a failed check

--- a/tests/end2end_tests/tests/service-container-sshnpd.yaml
+++ b/tests/end2end_tests/tests/service-container-sshnpd.yaml
@@ -7,9 +7,9 @@
     healthcheck:
       test: ["CMD", "grep", "-Eq", "\"monitor started for @\"", "/atsign/sshnpd.log"]
       start_period: 10s # Wait 10 seconds before checking
-      interval: 1s # Check every second
+      interval: 5s # Check every 5 seconds
       timeout: 1s # If a check takes longer than a second, consider it a failed check
-      retries: 900 # Retry the check n times (900 * 1s = 15 mins)
+      retries: 180 # Retry the check n times (180 * 5s = 15 mins)
     # auto added:
     # - image
     # - depends_on: (sshrvd + runtime service)

--- a/tests/end2end_tests/tests/service-container-sshnpd.yaml
+++ b/tests/end2end_tests/tests/service-container-sshnpd.yaml
@@ -9,7 +9,7 @@
       start_period: 10s # Wait 10 seconds before checking
       interval: 5s # Check every 5 seconds
       timeout: 1s # If a check takes longer than a second, consider it a failed check
-      retries: 180 # Retry the check n times (180 * 5s = 15 mins)
+      retries: 36 # Retry the check n times
     # auto added:
     # - image
     # - depends_on: (sshrvd + runtime service)

--- a/tests/end2end_tests/tests/service-container-sshrvd.yaml
+++ b/tests/end2end_tests/tests/service-container-sshrvd.yaml
@@ -4,7 +4,7 @@
       - ../contexts/sshrvd:/mount
     network_mode: host
     healthcheck:
-      test: ["CMD", "grep", "-Eq", "\"monitor started for @\"", "/atsign/sshrvd.log"]
+      test: ["CMD", "grep", "-Eq", "monitor started for @", "/atsign/sshrvd.log"]
       start_period: 10s # Wait 10 seconds before checking
       interval: 5s # Check every 5 seconds
       timeout: 1s # If a check takes longer than a second, consider it a failed check

--- a/tests/end2end_tests/tests/service-container-sshrvd.yaml
+++ b/tests/end2end_tests/tests/service-container-sshrvd.yaml
@@ -4,11 +4,11 @@
       - ../contexts/sshrvd:/mount
     network_mode: host
     healthcheck:
-      test: ["CMD", "grep", "-Eq", "\"monitor started for @\"", "/atsign/sshrvd.log"]
-      start_period: 1s # Wait 10 seconds before checking
-      interval: 1s # Check every 5 seconds
+      test: ["CMD", "grep", "-Eq", "\"monitor started for @\"", "/atsign/sshnpd.log"]
+      start_period: 10s # Wait 10 seconds before checking
+      interval: 1s # Check every second
       timeout: 1s # If a check takes longer than a second, consider it a failed check
-      retries: 180 # Retry the check 180 times (180 * 1s = 2 mins)
+      retries: 900 # Retry the check n times (900 * 1s = 15 mins)
     # auto added:
     # - image
     # - depends_on: (runtime service)

--- a/tests/end2end_tests/tests/service-container-sshrvd.yaml
+++ b/tests/end2end_tests/tests/service-container-sshrvd.yaml
@@ -8,7 +8,7 @@
       start_period: 10s # Wait 10 seconds before checking
       interval: 5s # Check every 5 seconds
       timeout: 1s # If a check takes longer than a second, consider it a failed check
-      retries: 180 # Retry the check n times (180 * 5s = 15 mins)
+      retries: 36 # Retry the check n times (180 * 5s = 15 mins)
     # auto added:
     # - image
     # - depends_on: (runtime service)

--- a/tests/end2end_tests/tests/service-container-sshrvd.yaml
+++ b/tests/end2end_tests/tests/service-container-sshrvd.yaml
@@ -3,6 +3,12 @@
     volumes:
       - ../contexts/sshrvd:/mount
     network_mode: host
+    healthcheck:
+      test: ["CMD", "grep", "-Eq", "\"monitor started for @\"", "/atsign/sshrvd.log"]
+      start_period: 1s # Wait 10 seconds before checking
+      interval: 1s # Check every 5 seconds
+      timeout: 1s # If a check takes longer than a second, consider it a failed check
+      retries: 180 # Retry the check 180 times (180 * 1s = 2 mins)
     # auto added:
     # - image
     # - depends_on: (runtime service)

--- a/tests/end2end_tests/tests/service-container-sshrvd.yaml
+++ b/tests/end2end_tests/tests/service-container-sshrvd.yaml
@@ -4,11 +4,11 @@
       - ../contexts/sshrvd:/mount
     network_mode: host
     healthcheck:
-      test: ["CMD", "grep", "-Eq", "\"monitor started for @\"", "/atsign/sshnpd.log"]
+      test: ["CMD", "grep", "-Eq", "\"monitor started for @\"", "/atsign/sshrvd.log"]
       start_period: 10s # Wait 10 seconds before checking
-      interval: 1s # Check every second
+      interval: 5s # Check every 5 seconds
       timeout: 1s # If a check takes longer than a second, consider it a failed check
-      retries: 900 # Retry the check n times (900 * 1s = 15 mins)
+      retries: 180 # Retry the check n times (180 * 5s = 15 mins)
     # auto added:
     # - image
     # - depends_on: (runtime service)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- alternate_port_test now has `condition:` under its dependencies.. sometimes device name would not be shared
- prod_tests now use env keys
- alternate_port_test device name is more unique with `a` token
- prod_tests device name is more unique with `d` token
- prod_tests now has `condition:` for docker compose dependencies
- setup-sshrvd-entrypoint refactored with template name
- dockerfile image now uses `${HOMEDIR}` instead of `/atsign`
- we now use `sshnp.log`, `sshnpd.log`, `sshrvd.log`.
- retries for healthcheck from 180 to 36. if it doesn't fail in 3 minutes, the service probably isn't working

**- How I did it**

**- How to verify it**

prod tests passing more consistently - https://github.com/atsign-foundation/sshnoports/actions/runs/6178173013/job/16770893463

![image](https://github.com/atsign-foundation/sshnoports/assets/79019866/5a6dd632-04b1-4a90-94b5-e55f3c4aabf5)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->