### PR TITLE
ci: fix false positives in end-to-end tests

### DIFF
--- a/tests/end2end_tests/entrypoints/sshnp_entrypoint.sh
+++ b/tests/end2end_tests/entrypoints/sshnp_entrypoint.sh
@@ -19,6 +19,7 @@ run_test()
     echo "ssh -p command: $(cat sshcommand.txt)"
     echo "./test.sh " | eval "$(cat sshcommand.txt)"
     sleep 2 # time for ssh connection to properly exit
+    return 0
 }
 
 main()
@@ -32,6 +33,7 @@ main()
         fi
         sleep 5
     done
+    exit 1
 }
 
 main


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Here - https://github.com/atsign-foundation/sshnoports/actions/runs/6225957657, the "Test" step is passing even though it should not be, when an RVD times out. This PR hopefully alleviates that.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->