### PR TITLE
fix: Uptake notify ephemeral changes

### DIFF
--- a/packages/noports_core/lib/src/sshnp/forward_direction/sshnp_forward.dart
+++ b/packages/noports_core/lib/src/sshnp/forward_direction/sshnp_forward.dart
@@ -19,6 +19,7 @@ abstract class SSHNPForward extends SSHNPCore {
 
   @override
   int get sshrvdPort => _sshrvdPort;
+
   @override
   set sshrvdPort(int? port) => _sshrvdPort = port!;
 
@@ -32,9 +33,7 @@ abstract class SSHNPForward extends SSHNPCore {
         ..namespace = this.namespace
         ..sharedBy = clientAtSign
         ..sharedWith = sshnpdAtSign
-        ..metadata = (Metadata()
-          ..ttr = -1
-          ..ttl = 10000),
+        ..metadata = (Metadata()..ttl = 10000),
       signAndWrapAndJsonEncode(
         atClient,
         {

--- a/packages/noports_core/lib/src/sshnp/reverse_direction/sshnp_legacy_impl.dart
+++ b/packages/noports_core/lib/src/sshnp/reverse_direction/sshnp_legacy_impl.dart
@@ -31,9 +31,7 @@ class SSHNPLegacyImpl extends SSHNPReverse with LegacySSHNPDPayloadHandler {
       ..sharedBy = clientAtSign
       ..sharedWith = sshnpdAtSign
       ..namespace = this.namespace
-      ..metadata = (Metadata()
-        ..ttr = -1
-        ..ttl = 10000);
+      ..metadata = (Metadata()..ttl = 10000);
     await notify(
         sendOurPrivateKeyToSshnpd, ephemeralKeyPair.privateKeyContents);
 
@@ -62,9 +60,7 @@ class SSHNPLegacyImpl extends SSHNPReverse with LegacySSHNPDPayloadHandler {
         ..namespace = this.namespace
         ..sharedBy = clientAtSign
         ..sharedWith = sshnpdAtSign
-        ..metadata = (Metadata()
-          ..ttr = -1
-          ..ttl = 10000),
+        ..metadata = (Metadata()..ttl = 10000),
       '$localPort $port $localUsername $host $sessionId',
     );
 

--- a/packages/noports_core/lib/src/sshnp/reverse_direction/sshnp_reverse_impl.dart
+++ b/packages/noports_core/lib/src/sshnp/reverse_direction/sshnp_reverse_impl.dart
@@ -49,7 +49,6 @@ class SSHNPReverseImpl extends SSHNPReverse with DefaultSSHNPDPayloadHandler {
         ..sharedBy = clientAtSign
         ..sharedWith = sshnpdAtSign
         ..metadata = (Metadata()
-          ..ttr = -1
           ..ttl = 10000),
       signAndWrapAndJsonEncode(
         atClient,

--- a/packages/noports_core/lib/src/sshnp/sshnp_core.dart
+++ b/packages/noports_core/lib/src/sshnp/sshnp_core.dart
@@ -73,14 +73,17 @@ abstract class SSHNPCore implements SSHNP {
 
   @protected
   final Completer<void> doneCompleter = Completer<void>();
+
   @override
   Future<void> get done => doneCompleter.future;
 
   bool _initializeStarted = false;
+
   @protected
   bool get initializeStarted => _initializeStarted;
   @protected
   final Completer<void> initializedCompleter = Completer<void>();
+
   @override
   Future<void> get initialized => initializedCompleter.future;
 
@@ -105,9 +108,11 @@ abstract class SSHNPCore implements SSHNP {
   // ====================================================================
 
   String get clientAtSign => atClient.getCurrentAtSign()!;
+
   String get sshnpdAtSign => params.sshnpdAtSign;
 
   static String getNamespace(String device) => '$device.sshnp';
+
   String get namespace => getNamespace(params.device);
 
   FutureOr<AtSSHKeyPair?> identityKeyPair;
@@ -333,7 +338,6 @@ abstract class SSHNPCore implements SSHNP {
         // as we are sending a notification to the sshrvd namespace,
         // we don't want to append our namespace
         ..namespaceAware = false
-        ..ttr = -1
         ..ttl = 10000);
     logger.info('Sending notification to sshrvd: $ourSshrvdIdKey');
     await notify(ourSshrvdIdKey, sessionId);
@@ -378,9 +382,7 @@ abstract class SSHNPCore implements SSHNP {
         ..key = 'sshpublickey'
         ..sharedBy = clientAtSign
         ..sharedWith = sshnpdAtSign
-        ..metadata = (Metadata()
-          ..ttr = -1
-          ..ttl = 10000);
+        ..metadata = (Metadata()..ttl = 10000);
       await notify(sendOurPublicKeyToSshnpd, publicKeyContents);
     } catch (e, s) {
       throw SSHNPError(
@@ -491,7 +493,6 @@ abstract class SSHNPCore implements SSHNP {
       var metaData = Metadata()
         ..isPublic = false
         ..isEncrypted = true
-        ..ttr = -1
         ..namespaceAware = true;
 
       var pingKey = AtKey()

--- a/packages/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -151,7 +151,6 @@ class SSHNPDImpl implements SSHNPD {
       var metaData = Metadata()
         ..isPublic = false
         ..isEncrypted = true
-        ..ttr = -1
         ..namespaceAware = true;
 
       var atKey = AtKey()
@@ -293,7 +292,6 @@ class SSHNPDImpl implements SSHNPD {
       ..metadata = (Metadata()
         ..isPublic = false
         ..isEncrypted = true
-        ..ttr = -1
         ..ttl = 10000 // allow only ten seconds before this record expires
         ..namespaceAware = true);
 
@@ -625,7 +623,6 @@ class SSHNPDImpl implements SSHNPD {
         ..isPublic = false
         ..isEncrypted = true
         ..namespaceAware = true
-        ..ttr = -1
         ..ttl = 10000);
     return atKey;
   }
@@ -859,7 +856,6 @@ class SSHNPDImpl implements SSHNPD {
     var metaData = Metadata()
       ..isPublic = false
       ..isEncrypted = true
-      ..ttr = -1
       ..ttl = ttl
       ..updatedAt = DateTime.now()
       ..namespaceAware = true;

--- a/packages/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -151,6 +151,7 @@ class SSHNPDImpl implements SSHNPD {
       var metaData = Metadata()
         ..isPublic = false
         ..isEncrypted = true
+        ..ttr = -1 // we want this to be cacheable by managerAtsign
         ..namespaceAware = true;
 
       var atKey = AtKey()
@@ -856,7 +857,8 @@ class SSHNPDImpl implements SSHNPD {
     var metaData = Metadata()
       ..isPublic = false
       ..isEncrypted = true
-      ..ttl = ttl
+      ..ttr = -1 // we want this to be cacheable by managerAtsign
+      ..ttl = ttl // but to expire after 30 days
       ..updatedAt = DateTime.now()
       ..namespaceAware = true;
 

--- a/packages/noports_core/lib/src/sshrvd/sshrvd_impl.dart
+++ b/packages/noports_core/lib/src/sshrvd/sshrvd_impl.dart
@@ -132,7 +132,6 @@ class SSHRVDImpl implements SSHRVD {
     var metaData = Metadata()
       ..isPublic = false
       ..isEncrypted = true
-      ..ttr = -1
       ..ttl = 10000
       ..namespaceAware = true;
 

--- a/packages/sshnoports/pubspec.lock
+++ b/packages/sshnoports/pubspec.lock
@@ -556,10 +556,9 @@ packages:
   noports_core:
     dependency: "direct main"
     description:
-      name: noports_core
-      sha256: "02331701ef45e985a637d17319e9969deaa6d53b9b171bb234d47e9c60aee94e"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../noports_core"
+      relative: true
+    source: path
     version: "4.0.0-dev.3"
   openssh_ed25519:
     dependency: transitive

--- a/packages/sshnp_gui/pubspec.lock
+++ b/packages/sshnp_gui/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: at_commons
-      sha256: "091ca795288910f7d426ab4534e5e0e6e1fae3a12e2c65a578f1244d1f3d67bc"
+      sha256: a3b5c171c0a7a7cbfd334302df7670f831f00b9b701d8bec9ebbc1765e69f489
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.55"
+    version: "3.0.57"
   at_contact:
     dependency: "direct main"
     description:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Uptake the notify ephemeral changes which enables having the value in the notification without having to cache in the keyStore on the recipient's atServer
- Removed code which sets "TTR" to -1 in the metadata
  - Except in SSHNPImpl for the `username.$device` and `device_info.$device` keys which need to be cacheable

