### PR TITLE
refactor: wrap all dart:io calls

### DIFF
--- a/packages/noports_core/lib/src/common/default_args.dart
+++ b/packages/noports_core/lib/src/common/default_args.dart
@@ -1,5 +1,4 @@
-import 'dart:io';
-
+import 'package:noports_core/src/common/io_types.dart';
 import 'package:noports_core/src/common/types.dart';
 import 'package:noports_core/sshrv.dart';
 

--- a/packages/noports_core/lib/src/common/file_system_utils.dart
+++ b/packages/noports_core/lib/src/common/file_system_utils.dart
@@ -1,4 +1,4 @@
-import 'dart:io';
+import 'package:noports_core/src/common/io_types.dart';
 import 'package:path/path.dart' as path;
 
 /// Get the home directory or null if unknown.

--- a/packages/noports_core/lib/src/common/io_types.dart
+++ b/packages/noports_core/lib/src/common/io_types.dart
@@ -1,0 +1,23 @@
+/// This file contains all of the dart:io calls in noports_core
+/// All io used should be wrapped for the sake of testing and compatibilty
+import 'dart:io' show Process, ProcessResult, ProcessStartMode;
+import 'package:meta/meta.dart';
+
+export 'dart:io' show Platform, Process, ProcessStartMode, ServerSocket, InternetAddress;
+export 'package:file/file.dart';
+export 'package:file/local.dart' show LocalFileSystem;
+
+@internal
+typedef ProcessRunner = Future<ProcessResult> Function(
+  String executable,
+  List<String> arguments, {
+  String? workingDirectory,
+});
+
+@internal
+typedef ProcessStarter = Future<Process> Function(
+  String executable,
+  List<String> arguments, {
+  bool runInShell,
+  ProcessStartMode mode,
+});

--- a/packages/noports_core/lib/src/common/openssh_binary_path.dart
+++ b/packages/noports_core/lib/src/common/openssh_binary_path.dart
@@ -1,4 +1,4 @@
-import 'dart:io';
+import 'package:noports_core/src/common/io_types.dart';
 
 const String _windowsOpensshPath = r'C:\Windows\System32\OpenSSH\ssh.exe';
 const String _unixOpensshPath = '/usr/bin/ssh';

--- a/packages/noports_core/lib/src/sshnp/impl/sshnp_unsigned_impl.dart
+++ b/packages/noports_core/lib/src/sshnp/impl/sshnp_unsigned_impl.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:at_client/at_client.dart';
+import 'package:noports_core/src/common/io_types.dart';
 import 'package:noports_core/sshnp_foundation.dart';
 
 class SshnpUnsignedImpl extends SshnpCore with SshnpLocalSshKeyHandler {

--- a/packages/noports_core/lib/src/sshnp/models/sshnp_result.dart
+++ b/packages/noports_core/lib/src/sshnp/models/sshnp_result.dart
@@ -1,6 +1,5 @@
-import 'dart:io';
-
 import 'package:meta/meta.dart';
+import 'package:noports_core/src/common/io_types.dart';
 import 'package:socket_connector/socket_connector.dart';
 
 abstract class SshnpResult {}

--- a/packages/noports_core/lib/src/sshnp/sshnp_core.dart
+++ b/packages/noports_core/lib/src/sshnp/sshnp_core.dart
@@ -1,9 +1,6 @@
 import 'dart:async';
 
-import 'dart:io';
-
 import 'package:at_client/at_client.dart' hide StringBuffer;
-
 import 'package:at_utils/at_logger.dart';
 import 'package:meta/meta.dart';
 import 'package:noports_core/src/common/mixins/async_completion.dart';
@@ -86,9 +83,6 @@ abstract class SshnpCore
     /// Set the remote username to use for the ssh session
     remoteUsername = await sshnpdChannel.resolveRemoteUsername();
 
-    /// Find a spare local port if required
-    await findLocalPortIfRequired();
-
     /// Shares the public key if required
     await sshnpdChannel.sharePublicKeyIfRequired(identityKeyPair);
 
@@ -99,26 +93,6 @@ abstract class SshnpCore
   @override
   Future<void> dispose() async {
     completeDisposal();
-  }
-
-  @visibleForTesting
-  Future<void> findLocalPortIfRequired() async {
-    // TODO investigate if this is a problem on mobile
-    // find a spare local port
-    if (localPort == 0) {
-      logger.info('Finding a spare local port');
-      try {
-        ServerSocket serverSocket =
-            await ServerSocket.bind(InternetAddress.loopbackIPv4, 0)
-                .catchError((e) => throw e);
-        localPort = serverSocket.port;
-        await serverSocket.close().catchError((e) => throw e);
-      } catch (e, s) {
-        logger.info('Unable to find a spare local port');
-        throw SshnpError('Unable to find a spare local port',
-            error: e, stackTrace: s);
-      }
-    }
   }
 
   @override

--- a/packages/noports_core/lib/src/sshnp/util/sshnp_initial_tunnel_handler/sshnp_dart_initial_tunnel_handler.dart
+++ b/packages/noports_core/lib/src/sshnp/util/sshnp_initial_tunnel_handler/sshnp_dart_initial_tunnel_handler.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
-import 'dart:io';
+// Current implementation uses ServerSocket, which will be replaced with an
+// internal Dart stream at a later time
+import 'dart:io' show ServerSocket;
 
 import 'package:dartssh2/dartssh2.dart';
 import 'package:meta/meta.dart';
@@ -73,6 +75,7 @@ mixin SshnpDartInitialTunnelHandler on SshnpCore
             ' from localhost:$fLocalPort on local side'
             ' to $fRemoteHost:$fRemotePort on remote side');
 
+        // TODO remove local dependency on ServerSockets
         /// Do the port forwarding for sshd
         final serverSocket = await ServerSocket.bind('localhost', fLocalPort);
 

--- a/packages/noports_core/lib/src/sshnp/util/sshnp_initial_tunnel_handler/sshnp_openssh_initial_tunnel_handler.dart
+++ b/packages/noports_core/lib/src/sshnp/util/sshnp_initial_tunnel_handler/sshnp_openssh_initial_tunnel_handler.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
+import 'package:noports_core/src/common/io_types.dart';
 import 'package:noports_core/src/common/openssh_binary_path.dart';
 import 'package:noports_core/sshnp_foundation.dart';
 

--- a/packages/noports_core/lib/src/sshnp/util/sshnp_ssh_key_handler.dart
+++ b/packages/noports_core/lib/src/sshnp/util/sshnp_ssh_key_handler.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:meta/meta.dart';
+import 'package:noports_core/src/common/io_types.dart';
 import 'package:noports_core/src/sshnp/sshnp_core.dart';
 import 'package:noports_core/src/sshnp/models/sshnp_result.dart';
 import 'package:noports_core/utils.dart';

--- a/packages/noports_core/lib/src/sshnp/util/sshnpd_channel/sshnpd_default_channel.dart
+++ b/packages/noports_core/lib/src/sshnp/util/sshnpd_channel/sshnpd_default_channel.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:at_client/at_client.dart';
 import 'package:meta/meta.dart';
-import 'package:noports_core/src/sshnp/util/sshnp_ssh_key_handler.dart';
+import 'package:noports_core/src/common/io_types.dart';
 import 'package:noports_core/src/sshnp/util/sshnpd_channel/sshnpd_channel.dart';
 import 'package:noports_core/utils.dart';
 
@@ -21,8 +20,9 @@ class SshnpdDefaultChannel extends SshnpdChannel
 mixin SshnpdDefaultPayloadHandler on SshnpdChannel {
   late final String ephemeralPrivateKey;
 
-  @protected
-  bool get useLocalFileStorage => (this is SshnpLocalSshKeyHandler);
+  @visibleForTesting
+  // disable publickey cache on windows
+  FileSystem? fs = Platform.isWindows ? null : LocalFileSystem();
 
   @override
   Future<void> initialize() async {
@@ -56,8 +56,7 @@ mixin SshnpdDefaultPayloadHandler on SshnpdChannel {
           params.sshnpdAtSign,
           logger,
           envelope,
-          useFileStorage: useLocalFileStorage &&
-              !Platform.isWindows, // disable publickey cache on windows
+          fs: fs,
         );
       } catch (e) {
         logger.shout(

--- a/packages/noports_core/pubspec.yaml
+++ b/packages/noports_core/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   at_utils: ^3.0.15
   cryptography: ^2.7.0
   dartssh2: ^2.8.2
+  file: ^6.0.0
   logging: ^1.2.0
   meta: ^1.9.1
   openssh_ed25519: ^1.1.0

--- a/packages/noports_core/test/sshnp/sshnp_core_mocks.dart
+++ b/packages/noports_core/test/sshnp/sshnp_core_mocks.dart
@@ -22,14 +22,6 @@ class MockSshrvdChannel extends Mock implements SshrvdChannel {}
 
 /// Stubbed [SshnpCore] (minimum viable implementation of [SshnpCore])
 class StubbedSshnpCore extends SshnpCore with StubbedAsyncInitializationMixin {
-  FunctionStub? _stubbedFindLocalPortIfRequired;
-
-  void stubFindLocalPortIfRequired(
-    FunctionStub stubbedFindLocalPortIfRequired,
-  ) {
-    _stubbedFindLocalPortIfRequired = stubbedFindLocalPortIfRequired;
-  }
-
   StubbedSshnpCore({
     required super.atClient,
     required super.params,
@@ -64,12 +56,6 @@ class StubbedSshnpCore extends SshnpCore with StubbedAsyncInitializationMixin {
   SshrvdChannel get sshrvdChannel =>
       _sshrvdChannel ?? (throw UnimplementedError());
   final SshrvdChannel? _sshrvdChannel;
-
-  @override
-  Future<void> findLocalPortIfRequired() {
-    _stubbedFindLocalPortIfRequired?.call();
-    return super.findLocalPortIfRequired();
-  }
 }
 
 /// Stubbed mixin wrapper

--- a/packages/noports_core/test/sshnp/sshnp_core_test.dart
+++ b/packages/noports_core/test/sshnp/sshnp_core_test.dart
@@ -19,7 +19,6 @@ void main() {
     late FunctionStub stubbedCallInitialization;
     late FunctionStub stubbedInitialize;
     late FunctionStub stubbedCompleteInitialization;
-    late FunctionStub stubbedFindLocalPortIfRequired;
 
     setUp(() {
       /// Creation
@@ -33,7 +32,6 @@ void main() {
       stubbedCallInitialization = FunctionStub();
       stubbedInitialize = FunctionStub();
       stubbedCompleteInitialization = FunctionStub();
-      stubbedFindLocalPortIfRequired = FunctionStub();
     });
 
     /// When declaration setup for the constructor of [StubbedSshnpCore]
@@ -50,7 +48,6 @@ void main() {
       when(() => stubbedCallInitialization.call()).thenAnswer((_) async {});
       when(() => stubbedInitialize.call()).thenAnswer((_) async {});
       when(() => stubbedCompleteInitialization.call()).thenReturn(null);
-      when(() => stubbedFindLocalPortIfRequired.call()).thenReturn(null);
 
       when(() => mockSshnpdChannel.callInitialization())
           .thenAnswer((_) async {});
@@ -115,15 +112,11 @@ void main() {
           mockInitialize: stubbedInitialize,
         );
 
-        /// Setup stub for [SshnpCore.findLocalPortIfRequired()]
-        sshnpCore.stubFindLocalPortIfRequired(stubbedFindLocalPortIfRequired);
-
         whenInitialization(identityKeyPair: sshnpCore.identityKeyPair);
 
         verifyNever(() => stubbedCallInitialization.call());
         verifyNever(() => stubbedInitialize.call());
         verifyNever(() => stubbedCompleteInitialization.call());
-        verifyNever(() => stubbedFindLocalPortIfRequired.call());
 
         await expectLater(sshnpCore.callInitialization(), completes);
 
@@ -135,7 +128,6 @@ void main() {
           () => stubbedInitialize.call(),
           () => mockSshnpdChannel.callInitialization(),
           () => mockSshnpdChannel.resolveRemoteUsername(),
-          () => stubbedFindLocalPortIfRequired.call(),
           () => mockSshnpdChannel
               .sharePublicKeyIfRequired(sshnpCore.identityKeyPair),
           () => mockSshrvdChannel.callInitialization(),
@@ -147,7 +139,6 @@ void main() {
         verifyNever(() => stubbedInitialize.call());
         verifyNever(() => mockSshnpdChannel.callInitialization());
         verifyNever(() => mockSshnpdChannel.resolveRemoteUsername());
-        verifyNever(() => stubbedFindLocalPortIfRequired.call());
         verifyNever(() => mockSshnpdChannel
             .sharePublicKeyIfRequired(sshnpCore.identityKeyPair));
         verifyNever(() => mockSshrvdChannel.callInitialization());
@@ -159,7 +150,6 @@ void main() {
         verify(() => stubbedCallInitialization.call()).called(1);
         verifyNever(() => stubbedInitialize.call());
         verifyNever(() => stubbedCompleteInitialization.call());
-        verifyNever(() => stubbedFindLocalPortIfRequired.call());
         verifyNever(() => mockSshrvdChannel.callInitialization());
       });
     }); // group Initialization


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Wrapped all io calls:
- Processes have typedefs which can be replaced with a mocked function
- File system calls are now using the file package which allows for the use of LocalFileSystem by default, but a MemoryFileSystem (i.e. an in memory file system) for testing purposes
- Platform is exported from the io_types file to ensure that it's easy to catch any leakage of dart:io into the rest of the library

Note: I left the dart:io call in `SshnpDartInitialTunnelHandler` since that code needs some discussion before it can be properly addressed. (I'd like to remove all io calls from that tunnel handler altogether, which means changing some of the overall functionality)

- Moved findLocalPortIfRequired from SshnpCore to SshnpOpensshLocalImpl since it depends on SecureSockets, if we find a need to expose this to other implementations later, we can move it to a mixin or something later.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
refactor: wrap all dart:io calls
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->