### PR TITLE
ci: no snooping rvd build + windows build configuration

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d # v1.6.0
       - run: mkdir sshnp
       - run: mkdir tarball
-      - if: ${{ matrix.os === 'windows-latest' }
+      - if: ${{ matrix.os === 'windows-latest' }}
         run: mkdir sshnp/debug
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
@@ -45,11 +45,11 @@ jobs:
       - run: dart compile exe bin/sshnp.dart -v -o sshnp/sshnp${{ matrix.ext }}
       - if: ${{ matrix.os != 'windows-latest' }}
         run: dart compile exe bin/sshnpd.dart -v -o sshnp/sshnpd${{ matrix.ext }}
-      - if: ${{ matrix.os != 'windows-latest' }
+      - if: ${{ matrix.os != 'windows-latest' }}
         run: dart compile exe bin/sshrv.dart -v -o sshnp/sshrv${{ matrix.ext }}
-      - if: ${{ matrix.os != 'windows-latest' }
+      - if: ${{ matrix.os != 'windows-latest' }}
         run: dart compile exe bin/sshrvd.dart -v -o sshnp/sshrvd${{ matrix.ext }}
-      - if: ${{ matrix.os != 'windows-latest' }
+      - if: ${{ matrix.os != 'windows-latest' }}
         run: dart compile exe bin/sshrvd.dart -D ENABLE_SNOOP=true -v -o sshnp/debug/sshrvd${{ matrix.ext }}
       - run: cp -r templates sshnp/templates
       - run: cp LICENSE sshnp

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -37,15 +37,20 @@ jobs:
       - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d # v1.6.0
       - run: mkdir sshnp
       - run: mkdir tarball
-      - run: mkdir sshnp/debug
+      - if: ${{ matrix.os === 'windows-latest' }
+        run: mkdir sshnp/debug
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
       - run: dart compile exe bin/activate_cli.dart -v -o sshnp/at_activate${{ matrix.ext }}
       - run: dart compile exe bin/sshnp.dart -v -o sshnp/sshnp${{ matrix.ext }}
-      - run: dart compile exe bin/sshnpd.dart -v -o sshnp/sshnpd${{ matrix.ext }}
-      - run: dart compile exe bin/sshrv.dart -v -o sshnp/sshrv${{ matrix.ext }}
-      - run: dart compile exe bin/sshrvd.dart -v -o sshnp/sshrvd${{ matrix.ext }}
-      - run: dart compile exe bin/sshrvd.dart -D ENABLE_SNOOP=true -v -o sshnp/debug/sshrvd-debug${{ matrix.ext }}
+      - if: ${{ matrix.os != 'windows-latest' }}
+        run: dart compile exe bin/sshnpd.dart -v -o sshnp/sshnpd${{ matrix.ext }}
+      - if: ${{ matrix.os != 'windows-latest' }
+        run: dart compile exe bin/sshrv.dart -v -o sshnp/sshrv${{ matrix.ext }}
+      - if: ${{ matrix.os != 'windows-latest' }
+        run: dart compile exe bin/sshrvd.dart -v -o sshnp/sshrvd${{ matrix.ext }}
+      - if: ${{ matrix.os != 'windows-latest' }
+        run: dart compile exe bin/sshrvd.dart -D ENABLE_SNOOP=true -v -o sshnp/debug/sshrvd${{ matrix.ext }}
       - run: cp -r templates sshnp/templates
       - run: cp LICENSE sshnp
       - run: tar -cvzf tarball/${{ matrix.output-name }}.tgz sshnp

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d # v1.6.0
       - run: mkdir sshnp
       - run: mkdir tarball
-      - if: ${{ matrix.os == 'windows-latest' }}
+      - if: ${{ matrix.os != 'windows-latest' }}
         run: mkdir sshnp/debug
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -24,10 +24,13 @@ jobs:
         include:
           - os: ubuntu-latest
             output-name: sshnp-linux-x64
+            ext: ''
           - os: macOS-latest
             output-name: sshnp-macos-x64
+            ext: ''
           - os: windows-latest
             output-name: sshnp-windows-x64
+            ext: '.exe'
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -36,11 +39,11 @@ jobs:
       - run: mkdir tarball
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
-      - run: dart compile exe bin/activate_cli.dart -v -o sshnp/at_activate
-      - run: dart compile exe bin/sshnp.dart -v -o sshnp/sshnp
-      - run: dart compile exe bin/sshnpd.dart -v -o sshnp/sshnpd
-      - run: dart compile exe bin/sshrv.dart -v -o sshnp/sshrv
-      - run: dart compile exe bin/sshrvd.dart -v -o sshnp/sshrvd
+      - run: dart compile exe bin/activate_cli.dart -v -o sshnp/at_activate${{ matrix.ext }}
+      - run: dart compile exe bin/sshnp.dart -v -o sshnp/sshnp${{ matrix.ext }}
+      - run: dart compile exe bin/sshnpd.dart -v -o sshnp/sshnpd${{ matrix.ext }}
+      - run: dart compile exe bin/sshrv.dart -v -o sshnp/sshrv${{ matrix.ext }}
+      - run: dart compile exe bin/sshrvd.dart -v -o sshnp/sshrvd${{ matrix.ext }}
       - run: cp -r templates sshnp/templates
       - run: cp LICENSE sshnp
       - run: tar -cvzf tarball/${{ matrix.output-name }}.tgz sshnp

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d # v1.6.0
       - run: mkdir sshnp
       - run: mkdir tarball
-      - if: ${{ matrix.os === 'windows-latest' }}
+      - if: ${{ matrix.os == 'windows-latest' }}
         run: mkdir sshnp/debug
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -37,6 +37,7 @@ jobs:
       - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d # v1.6.0
       - run: mkdir sshnp
       - run: mkdir tarball
+      - run: mkdir sshnp/debug
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
       - run: dart compile exe bin/activate_cli.dart -v -o sshnp/at_activate${{ matrix.ext }}
@@ -44,6 +45,7 @@ jobs:
       - run: dart compile exe bin/sshnpd.dart -v -o sshnp/sshnpd${{ matrix.ext }}
       - run: dart compile exe bin/sshrv.dart -v -o sshnp/sshrv${{ matrix.ext }}
       - run: dart compile exe bin/sshrvd.dart -v -o sshnp/sshrvd${{ matrix.ext }}
+      - run: dart compile exe bin/sshrvd.dart -D ENABLE_SNOOP=true -v -o sshnp/debug/sshrvd-debug${{ matrix.ext }}
       - run: cp -r templates sshnp/templates
       - run: cp LICENSE sshnp
       - run: tar -cvzf tarball/${{ matrix.output-name }}.tgz sshnp

--- a/packages/noports_core/lib/src/sshrvd/build_env.dart
+++ b/packages/noports_core/lib/src/sshrvd/build_env.dart
@@ -1,0 +1,4 @@
+class BuildEnv {
+  static final bool enableSnoop =
+      bool.fromEnvironment('ENABLE_SNOOP', defaultValue: false);
+}

--- a/packages/noports_core/lib/src/sshrvd/sshrvd_impl.dart
+++ b/packages/noports_core/lib/src/sshrvd/sshrvd_impl.dart
@@ -6,6 +6,7 @@ import 'package:at_client/at_client.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
+import 'package:noports_core/src/sshrvd/build_env.dart';
 import 'package:noports_core/src/sshrvd/socket_connector.dart';
 import 'package:noports_core/src/sshrvd/sshrvd.dart';
 import 'package:noports_core/src/sshrvd/sshrvd_params.dart';
@@ -168,8 +169,14 @@ class SshrvdImpl implements Sshrvd {
     /// Spawn an isolate and wait for it to send back the issued port numbers
     ReceivePort receivePort = ReceivePort(session);
 
-    ConnectorParams parameters =
-        (receivePort.sendPort, portA, portB, session, forAtsign, snoop);
+    ConnectorParams parameters = (
+      receivePort.sendPort,
+      portA,
+      portB,
+      session,
+      forAtsign,
+      BuildEnv.enableSnoop && snoop,
+    );
 
     logger
         .info("Spawning socket connector isolate with parameters $parameters");

--- a/packages/noports_core/lib/src/sshrvd/sshrvd_params.dart
+++ b/packages/noports_core/lib/src/sshrvd/sshrvd_params.dart
@@ -1,5 +1,6 @@
 import 'package:args/args.dart';
 import 'package:noports_core/src/common/file_system_utils.dart';
+import 'package:noports_core/src/sshrvd/build_env.dart';
 
 class SshrvdParams {
   final String username;
@@ -43,7 +44,7 @@ class SshrvdParams {
       managerAtsign: r['manager'],
       ipAddress: r['ip'],
       verbose: r['verbose'],
-      snoop: r['snoop'],
+      snoop: BuildEnv.enableSnoop && r['snoop'],
       rootDomain: r['root-domain'],
     );
   }
@@ -84,12 +85,14 @@ class SshrvdParams {
       abbr: 'v',
       help: 'More logging',
     );
-    parser.addFlag(
-      'snoop',
-      abbr: 's',
-      defaultsTo: false,
-      help: 'Snoop on traffic passing through service',
-    );
+    if (BuildEnv.enableSnoop) {
+      parser.addFlag(
+        'snoop',
+        abbr: 's',
+        defaultsTo: false,
+        help: 'Snoop on traffic passing through service',
+      );
+    }
     parser.addOption(
       'root-domain',
       mandatory: false,

--- a/packages/sshnoports/tools/Dockerfile.package
+++ b/packages/sshnoports/tools/Dockerfile.package
@@ -9,7 +9,7 @@ RUN set -eux; \
         arm64) ARCH="arm64";; \
         riscv64) ARCH="riscv64";; \
     esac; \
-    mkdir sshnp; \
+    mkdir -p sshnp/debug; \
     mkdir tarball; \
     dart pub get; \
     dart run build_runner build --delete-conflicting-outputs; \
@@ -18,6 +18,7 @@ RUN set -eux; \
     dart compile exe bin/sshnpd.dart -v -o sshnp/sshnpd; \
     dart compile exe bin/sshrv.dart -v -o sshnp/sshrv; \
     dart compile exe bin/sshrvd.dart -v -o sshnp/sshrvd; \
+    dart compile exe bin/sshrvd.dart -D ENABLE_SNOOP=true -v -o sshnp/debug/sshrvd \
     cp -r templates sshnp/templates; \
     cp LICENSE sshnp/; \
     tar -cvzf tarball/sshnp-linux-${ARCH}.tgz sshnp

--- a/packages/sshnoports/tools/Dockerfile.package
+++ b/packages/sshnoports/tools/Dockerfile.package
@@ -18,7 +18,7 @@ RUN set -eux; \
     dart compile exe bin/sshnpd.dart -v -o sshnp/sshnpd; \
     dart compile exe bin/sshrv.dart -v -o sshnp/sshrv; \
     dart compile exe bin/sshrvd.dart -v -o sshnp/sshrvd; \
-    dart compile exe bin/sshrvd.dart -D ENABLE_SNOOP=true -v -o sshnp/debug/sshrvd \
+    dart compile exe bin/sshrvd.dart -D ENABLE_SNOOP=true -v -o sshnp/debug/sshrvd; \
     cp -r templates sshnp/templates; \
     cp LICENSE sshnp/; \
     tar -cvzf tarball/sshnp-linux-${ARCH}.tgz sshnp


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

closes #520 

**- What I did**

rvd stuff:

- Added a compile time `ENABLE_SNOOP` boolean flag to enable snooping and disabled it by default
  - Removes the parameter from the parser / usage info by default
  - Hard disables it where the snoop boolean is passed into the SocketConnector constructor by default
- Added a new debug folder + sshrvd_debug binary in the multibuild

Windows stuff:

- Added `.exe` extension to windows binaries
- Removed sshrvd, sshnpd binaries from windows release

**- How I did it**

**- How to verify it**

See https://github.com/atsign-foundation/sshnoports/actions/runs/7048957823

**- Description for the changelog**
ci: no snooping rvd build + windows build configuration
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->