### PR TITLE
chore: remove latest from deprecation message in legacy install scripts

### DIFF
--- a/scripts/install_sshnp
+++ b/scripts/install_sshnp
@@ -194,7 +194,7 @@ parse_requirements() {
   REQ_SSH=$(command -v ssh)
   REQ_SSHD=$(command -v sshd)
   REQ_SSH=$(command -v ssh)
-  if [ -f "/usr/sbin/sshd" ]; then 
+  if [ -f "/usr/sbin/sshd" ]; then
     REQ_SSHD=true
   fi
   #REQ_SSH0=$(ssh -o "StrictHostKeyChecking no" -o "PasswordAuthentication no" 0 exit 2>/dev/null; echo $?)
@@ -411,8 +411,7 @@ do_update() {
 
 deprecation_msg() {
   case "$SSHNP_VERSION" in
-    # TODO remove latest to signify deprecation on the launch of v4.0.0
-    latest|1.*|2.*|3.*|4.0.0-test.*|4.0.0-rc.*)
+    1.*|2.*|3.*|4.0.0-test.*|4.0.0-rc.*)
       # no message, this group is expected to use this script
     ;;
     *)

--- a/scripts/install_sshnpd
+++ b/scripts/install_sshnpd
@@ -642,8 +642,7 @@ do_rename() {
 
 deprecation_msg() {
   case "$SSHNP_VERSION" in
-    # TODO remove latest to signify deprecation on the launch of v4.0.0
-    latest|1.*|2.*|3.*|4.0.0-test.*|4.0.0-rc.*)
+    1.*|2.*|3.*|4.0.0-test.*|4.0.0-rc.*)
       # no message, this group is expected to use this script
     ;;
     *)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Print the deprecation message when using the old installer to install latest
- intended for when 4.0.0 becomes the latest release

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: remove latest from deprecation message in legacy install scripts
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->