### PR TITLE
fix: don't dump stack trace when printing usage

### DIFF
--- a/packages/sshnoports/bin/sshnp.dart
+++ b/packages/sshnoports/bin/sshnp.dart
@@ -21,14 +21,11 @@ void main(List<String> args) async {
   ExtendedArgParser parser = ExtendedArgParser();
 
   // Create the printUsage closure
-  void printUsage({Object? error, StackTrace? stackTrace}) {
+  void printUsage({Object? error}) {
     printVersion();
     stderr.writeln(parser.usage);
     if (error != null) {
       stderr.writeln('\n$error');
-    }
-    if (stackTrace != null) {
-      stderr.writeln('\n$stackTrace');
     }
   }
 
@@ -117,8 +114,8 @@ void main(List<String> args) async {
           exit(0);
         }
       }
-    } on ArgumentError catch (error, stackTrace) {
-      printUsage(error: error, stackTrace: stackTrace);
+    } on ArgumentError catch (error) {
+      printUsage(error: error);
       exit(1);
     } on SshnpError catch (error, stackTrace) {
       stderr.writeln(error.toString());

--- a/packages/sshnoports/lib/src/version.dart
+++ b/packages/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.0.0';
+const packageVersion = '4.0.1';

--- a/packages/sshnoports/pubspec.yaml
+++ b/packages/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 4.0.0
+version: 4.0.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**N.B.** Contains all of the changes of #606, merge that first and rebase to trunk.

**- What I did**

- Don't dump stacktrace when printing usage
- Bumped version to release as v4.0.1

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: don't dump stack trace when printing usage
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->