### PR TITLE
fix: sometimes check if error is SshnpError before treating it like one

### DIFF
--- a/packages/sshnoports/bin/sshnp.dart
+++ b/packages/sshnoports/bin/sshnp.dart
@@ -66,7 +66,7 @@ void main(List<String> args) async {
         sshClient:
             SupportedSshClient.fromString(argResults['ssh-client'] as String),
       ).catchError((e) {
-        if (e.stackTrace != null) {
+        if (e is SshnpError && e.stackTrace != null) {
           Error.throwWithStackTrace(e, e.stackTrace!);
         }
         throw e;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Sometimes the code will throw an AtException when onboarding (namely if a .atKeys file is in place), which does not have a `.stackTrace` member, so I added a guard against that.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: sometimes check if error is SshnpError before treating it like one
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->