### PR TITLE
fix: dart client authentication

### DIFF
--- a/packages/noports_core/lib/src/sshnp/util/ssh_session_handler/dart_ssh_session_handler.dart
+++ b/packages/noports_core/lib/src/sshnp/util/ssh_session_handler/dart_ssh_session_handler.dart
@@ -158,7 +158,8 @@ class SshClientHelper {
       }
 
       try {
-        await client.authenticated.catchError((e) => throw e);
+        // Ensure we are connected and authenticated correctly
+        await client.ping().catchError((e) => throw e);
       } catch (e, s) {
         throw SshnpError(
           'Failed to authenticate as $username@$host:$port : $e',


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

fixes: #619 

**- What I did**

Where we call `await client.authenticated;` we are greeted with an SSHAuthAbortError. Instead we `await client.ping();` which sends a keep alive packet to the server, in addition to awaiting authentication.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: dart client authentication
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->