### PR TITLE
fix: change list-devices back to flag type

### DIFF
--- a/packages/noports_core/lib/src/sshnp/models/sshnp_arg.dart
+++ b/packages/noports_core/lib/src/sshnp/models/sshnp_arg.dart
@@ -341,6 +341,7 @@ class SshnpArg {
     name: 'list-devices',
     help: 'List available devices',
     defaultsTo: DefaultSshnpArgs.listDevices,
+    format: ArgFormat.flag,
     aliases: ['ls'],
     negatable: false,
     parseWhen: ParseWhen.commandLine,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

fixes: #625 

**- What I did**

- Changed `--list-devices` from a string option back to a boolean flag

@gkc @cpswan this is a breaking change, but it is unbreaking something that was accidentally broken when we pushed v4.0.0. I think we should push this out as noports_core (the sdk) version 5.0.0 but sshnoports (the cli) can be a patch increase 4.0.2 -> 4.0.3.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: change list-devices back to flag type
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->