### PR TITLE
build(deps): Bump poetry to 1.7.1

### DIFF
--- a/.github/workflows/update_python_requirements.yaml
+++ b/.github/workflows/update_python_requirements.yaml
@@ -31,7 +31,7 @@ jobs:
       if: ${{ github.actor == 'dependabot[bot]' }}
       uses: abatilo/actions-poetry@192395c0d10c082a7c62294ab5d9a9de40e48974 # v2.3.0
       with:
-        poetry-version: '1.6.1'
+        poetry-version: '1.7.1'
 
     - name: Bump Python dependencies
       if: ${{ github.actor == 'dependabot[bot]' }}


### PR DESCRIPTION
New poetry minor release

**- What I did**

Bump poetry version used in workflow to 1.7.1

**- How I did it**

```sh
git checkout trunk
git pull
git checkout -b cpswan-bump-poetry-1.7.1
sed -i s/1.6.1/1.7.1/ .github/workflows/update_python_requirements.yaml
git diff
git add .
git commit -m 'build(deps): Bump poetry to 1.7.1'
git push
```

**- How to verify it**

Workflow will run on next bump to Python dependencies

**- Description for the changelog**

build(deps): Bump poetry to 1.7.1