### PR TITLE
fix: check ssh public keys correctly

### DIFF
--- a/packages/noports_core/lib/src/sshnp/util/sshnpd_channel/sshnpd_channel.dart
+++ b/packages/noports_core/lib/src/sshnp/util/sshnpd_channel/sshnpd_channel.dart
@@ -122,7 +122,8 @@ abstract class SshnpdChannel with AsyncInitialization, AtClientBindings {
     logger.info('Sharing public key with sshnpd');
     try {
       logger.info('sharing ssh public key: $publicKeyContents');
-      if (!publicKeyContents.startsWith('ssh-')) {
+      // Check for Supported ssh keypairs from dartssh2 package
+      if (!publicKeyContents.startsWith(RegExp(r'^(ecdsa-sha2-nistp)|(rsa-sha2-)|(ssh-rsa)|(ssh-ed25519)|(ecdsa-sha2-nistp)'))) {
         logger.severe('SSH Public Key does not look like a public key file');
         throw ('SSH Public Key does not look like a public key file');
       }


### PR DESCRIPTION
The original check worked by blind chance for ed25519 keys but now correctly checks public key file/format


**- What I did**
fixed bug in that RSA ssh keys were not seen as "valid" when using the '-s' flag on sshnp. The original code looked at the ssh public key file the code now looks at the format of the key once returned/processed by the dartssh2 package.
**- How I did it**
Check on dartssh2 package to which key formats are recognized and put in RgeEx to check those format strings
**- How to verify it**
Ran tests locally with broken rsa ssh key file which now works
**- Description for the changelog**
fixed error in ssh key checking when using the -s flag in sshnp