### PR TITLE
chore: bump version to 4.0.4

### DIFF
--- a/packages/noports_core/CHANGELOG.md
+++ b/packages/noports_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.1
+
+- fix: Add more supported ssh public key types to the send ssh public key filters.
+
 # 5.0.0
 
 - **BREAKING CHANGE** fix: changed `list-devices` arg from String option to boolean flag.

--- a/packages/noports_core/lib/src/version.dart
+++ b/packages/noports_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.0.0';
+const packageVersion = '5.0.1';

--- a/packages/noports_core/pubspec.yaml
+++ b/packages/noports_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: noports_core
 description: Core library code for sshnoports
 homepage: https://docs.atsign.com/
 
-version: 5.0.0
+version: 5.0.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/sshnoports/lib/src/version.dart
+++ b/packages/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.0.3';
+const packageVersion = '4.0.4';

--- a/packages/sshnoports/pubspec.lock
+++ b/packages/sshnoports/pubspec.lock
@@ -575,7 +575,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "5.0.0"
+    version: "5.0.1"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/sshnoports/pubspec.yaml
+++ b/packages/sshnoports/pubspec.yaml
@@ -1,13 +1,13 @@
 name: sshnoports
 publish_to: none
 
-version: 4.0.3
+version: 4.0.4
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  noports_core: 4.0.1
+  noports_core: 5.0.1
   at_onboarding_cli: 1.4.1
 
 dependency_overrides:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Bumped noports_core to 5.0.1
- Bumped sshnoports to 4.0.4

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: bump version to 4.0.4
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->