### PR TITLE
fix: added correct checks to ssh public key checks

### DIFF
--- a/packages/noports_core/lib/src/common/at_ssh_key_util/local_ssh_key_util.dart
+++ b/packages/noports_core/lib/src/common/at_ssh_key_util/local_ssh_key_util.dart
@@ -127,8 +127,9 @@ class LocalSshKeyUtil implements AtSshKeyUtil {
     String sessionId = '',
     String permissions = '',
   }) async {
-    // Check to see if the ssh public key looks like one!
-    if (!sshPublicKey.startsWith('ssh-')) {
+    // Check to see if the ssh public key is
+    // supported keys by the dartssh2 package
+    if (!sshPublicKey.startsWith(RegExp(r'^(ecdsa-sha2-nistp)|(rsa-sha2-)|(ssh-rsa)|(ssh-ed25519)|(ecdsa-sha2-nistp)'))) {
       throw ('$sshPublicKey does not look like a public key');
     }
 

--- a/packages/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -329,8 +329,9 @@ class SshnpdImpl implements Sshnpd {
           'ssh Public Key received from ${notification.from} notification id : ${notification.id}');
       sshPublicKey = notification.value!;
 
-      // Check to see if the ssh public key looks like one!
-      if (!sshPublicKey.startsWith('ssh-')) {
+    // Check to see if the ssh public key is
+    // supported keys by the dartssh2 package
+    if (!sshPublicKey.startsWith(RegExp(r'^(ecdsa-sha2-nistp)|(rsa-sha2-)|(ssh-rsa)|(ssh-ed25519)|(ecdsa-sha2-nistp)'))) {
         throw ('$sshPublicKey does not look like a public key');
       }
 


### PR DESCRIPTION
This might well be better in an extension of String or function call but as this does not change often this will solve the short term issue and we can raise an issue to clean up later


**- What I did**
Identified that sshnpd also checks the public key validity, and hence the `-s` still fails to work and so addressed the issue
**- How I did it**
I added the same RegEx checks in two different places in the code
**- How to verify it**
Really needs to built so it can be tested as there is not yet a `-s` end to end test
**- Description for the changelog**

Fixed issue where the public keys was being tested incorrectly by sshnpd when using the `-s` flag on sshnpd and sshnp