### PR TITLE
fix: Ensure dist files are placed for upload

### DIFF
--- a/.github/workflows/python-sshnpd-build-publish.yml
+++ b/.github/workflows/python-sshnpd-build-publish.yml
@@ -33,6 +33,7 @@ jobs:
       working-directory: packages/python/sshnpd
       run: |
         poetry build
+        cp -r dist/ ${{ runner.home }}
 
     - name: Store the distribution packages
       uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0


### PR DESCRIPTION
The python-sshnpd-build-publish workflow is presently failing as the upload isn't finding the dist files from the build stage

**- What I did**

Added a line to copy the files from where they're built (in the package hierarchy) to the expected place (in the runner home).

**- How to verify it**

Merging this PR should result in a successful release to TestPyPI

**- Description for the changelog**

fix: Ensure dist files are placed for upload