### PR TITLE
fix: Ensure dist files are placed for upload

### DIFF
--- a/.github/workflows/python-sshnpd-build-publish.yml
+++ b/.github/workflows/python-sshnpd-build-publish.yml
@@ -33,7 +33,7 @@ jobs:
       working-directory: packages/python/sshnpd
       run: |
         poetry build
-        cp -r dist/ ${{ runner.home }}
+        cp -r dist/ $GITHUB_WORKSPACE
 
     - name: Store the distribution packages
       uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0


### PR DESCRIPTION
It turns out that ${{ runner.home }} [doesn't exist ](https://github.com/softprops/action-gh-release/issues/368#issuecomment-1795332121)🤦‍♂️ 

**- What I did**

Altered script to use `$GITHUB_WORKSPACE` instead (per [Checkout Action docs](https://github.com/actions/checkout))

**- How to verify it**

A successful run of the build-publish action on merging this PR should publish to TestPyPI

**- Description for the changelog**

fix: Ensure dist files are placed for upload
