### PR TITLE
feat: sshnpd: add --storage-path option

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -64,7 +64,7 @@ jobs:
       - run: cp -r bundles/${{ matrix.bundle }}/* sshnp/
       - run: cp LICENSE sshnp
       - run: tar -cvzf tarball/${{ matrix.output-name }}.tgz sshnp
-      - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: x64_binaries
           path: ./packages/sshnoports/tarball/${{ matrix.output-name }}.tgz
@@ -96,7 +96,7 @@ jobs:
           --platform ${{ matrix.platform }} -o type=tar,dest=bins.tar .
       - run: mkdir tarballs
       - run: tar -xvf bins.tar -C tarballs
-      - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: other_binaries
           path: ./packages/sshnoports/tarballs/${{ matrix.output-name }}.tgz

--- a/packages/noports_core/CHANGELOG.md
+++ b/packages/noports_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.3
+- feat: Add `--storage-path` option to sshnpd to allow users to specify where 
+  it keeps any locally stored data
+
 # 5.0.2
 
 - fix: Add more supported ssh public key types to the send ssh public key filters for sshnpd.

--- a/packages/noports_core/lib/src/common/validation_utils.dart
+++ b/packages/noports_core/lib/src/common/validation_utils.dart
@@ -4,6 +4,7 @@ import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
 import 'package:at_utils/at_utils.dart';
 
+import 'package:noports_core/src/common/file_system_utils.dart';
 import 'package:noports_core/src/common/io_types.dart';
 import 'package:path/path.dart' as path;
 
@@ -73,13 +74,12 @@ Future<void> verifyEnvelopeSignature(
   AtSignLogger logger,
   Map envelope, {
   FileSystem? fs,
-  String? storagePath,
 }) async {
   final String signature = envelope['signature'];
   Map payload = envelope['payload'];
   final hashingAlgo = HashingAlgoType.values.byName(envelope['hashingAlgo']);
   final signingAlgo = SigningAlgoType.values.byName(envelope['signingAlgo']);
-  final pk = await getLocallyCachedPK(atClient, requestingAtsign, fs: fs, storagePath: storagePath);
+  final pk = await getLocallyCachedPK(atClient, requestingAtsign, fs: fs);
   AtSigningVerificationInput input = AtSigningVerificationInput(
       jsonEncode(payload), base64Decode(signature), pk)
     ..signingMode = AtSigningMode.data
@@ -110,11 +110,10 @@ Future<String> getLocallyCachedPK(
   AtClient atClient,
   String atSign, {
   FileSystem? fs,
-  String? storagePath,
 }) async {
   atSign = AtUtils.fixAtSign(atSign);
 
-  String? cachedPK = await _fetchFromLocalPKCache(atClient, atSign, fs: fs, storagePath: storagePath);
+  String? cachedPK = await _fetchFromLocalPKCache(atClient, atSign, fs: fs);
   if (cachedPK != null) {
     return cachedPK;
   }
@@ -125,7 +124,7 @@ Future<String> getLocallyCachedPK(
     throw AtPublicKeyNotFoundException('Failed to retrieve $s');
   }
 
-  await _storeToLocalPKCache(av.value, atClient, atSign, fs: fs, storagePath: storagePath);
+  await _storeToLocalPKCache(av.value, atClient, atSign, fs: fs);
 
   return av.value;
 }
@@ -134,11 +133,11 @@ Future<String?> _fetchFromLocalPKCache(
   AtClient atClient,
   String atSign, {
   FileSystem? fs,
-  String? storagePath,
 }) async {
   String dontAtMe = atSign.substring(1);
   if (fs != null) {
-    String fn = path.normalize('${storagePath!}/cached_pks/$dontAtMe');
+    String fn = path
+        .normalize('${getHomeDirectory()}/.atsign/sshnp/cached_pks/$dontAtMe');
     File f = fs.file(fn);
     if (await f.exists()) {
       return (await f.readAsString()).trim();
@@ -162,11 +161,11 @@ Future<bool> _storeToLocalPKCache(
   AtClient atClient,
   String atSign, {
   FileSystem? fs,
-  String? storagePath,
 }) async {
   String dontAtMe = atSign.substring(1);
   if (fs != null) {
-    String dirName = path.normalize('${storagePath!}/cached_pks');
+    String dirName =
+        path.normalize('${getHomeDirectory()}/.atsign/sshnp/cached_pks');
     String fileName = path.normalize('$dirName/$dontAtMe');
 
     File f = fs.file(fileName);

--- a/packages/noports_core/lib/src/sshnpd/sshnpd_params.dart
+++ b/packages/noports_core/lib/src/sshnpd/sshnpd_params.dart
@@ -19,6 +19,7 @@ class SshnpdParams {
   final int localSshdPort;
   final String ephemeralPermissions;
   final SupportedSshAlgorithm sshAlgorithm;
+  final String? storagePath;
 
   // Non param variables
   static final ArgParser parser = _createArgParser();
@@ -37,6 +38,7 @@ class SshnpdParams {
     required this.localSshdPort,
     required this.ephemeralPermissions,
     required this.sshAlgorithm,
+    required this.storagePath,
   });
 
   static Future<SshnpdParams> fromArgs(List<String> args) async {
@@ -76,6 +78,7 @@ class SshnpdParams {
           int.tryParse(r['local-sshd-port']) ?? DefaultArgs.localSshdPort,
       ephemeralPermissions: r['ephemeral-permissions'],
       sshAlgorithm: SupportedSshAlgorithm.fromString(r['ssh-algorithm']),
+      storagePath: r['storage-path'],
     );
   }
 
@@ -169,6 +172,12 @@ class SshnpdParams {
       defaultsTo: DefaultArgs.sshAlgorithm.toString(),
       help: 'Use RSA 4096 keys rather than the default ED25519 keys',
       allowed: SupportedSshAlgorithm.values.map((c) => c.toString()).toList(),
+    );
+
+    parser.addOption(
+      'storage-path',
+      mandatory: false,
+      help: r'Directory for local storage. Defaults to $HOME/.sshnp/${atSign}/storage',
     );
 
     return parser;

--- a/packages/noports_core/lib/src/version.dart
+++ b/packages/noports_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.0.2';
+const packageVersion = '5.0.3';

--- a/packages/noports_core/pubspec.yaml
+++ b/packages/noports_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: noports_core
 description: Core library code for sshnoports
 homepage: https://docs.atsign.com/
 
-version: 5.0.2
+version: 5.0.3
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/sshnoports/bin/sshnpd.dart
+++ b/packages/sshnoports/bin/sshnpd.dart
@@ -18,6 +18,7 @@ void main(List<String> args) async {
         atsign: p.deviceAtsign,
         atKeysFilePath: p.atKeysFilePath,
         rootDomain: p.rootDomain,
+        storagePath: p.storagePath,
       ),
       usageCallback: (e, s) {
         printVersion();

--- a/packages/sshnoports/lib/src/create_at_client_cli.dart
+++ b/packages/sshnoports/lib/src/create_at_client_cli.dart
@@ -10,6 +10,7 @@ Future<AtClient> createAtClientCli({
   required String homeDirectory,
   required String atsign,
   required String atKeysFilePath,
+  String? storagePath,
   String? pathExtension,
   String subDirectory = '.sshnp',
   String namespace = DefaultArgs.namespace,
@@ -21,12 +22,13 @@ Future<AtClient> createAtClientCli({
   if (pathExtension != null) {
     pathBase += '$pathExtension${Platform.pathSeparator}';
   }
+  storagePath ??= path.normalize('$pathBase/storage');
   AtOnboardingPreference atOnboardingConfig = AtOnboardingPreference()
-    ..hiveStoragePath = path.normalize('$pathBase/storage')
+    ..hiveStoragePath = storagePath
     ..namespace = namespace
     ..downloadPath = path.normalize('$homeDirectory/$subDirectory/files')
     ..isLocalStoreRequired = true
-    ..commitLogPath = path.normalize('$pathBase/storage/commitLog')
+    ..commitLogPath = path.normalize('$storagePath/commitLog')
     ..fetchOfflineNotifications = false
     ..atKeysFilePath = atKeysFilePath
     ..atProtocolEmitted = Version(2, 0, 0)

--- a/packages/sshnoports/lib/src/version.dart
+++ b/packages/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.0.4';
+const packageVersion = '4.0.5';

--- a/packages/sshnoports/pubspec.lock
+++ b/packages/sshnoports/pubspec.lock
@@ -572,10 +572,9 @@ packages:
   noports_core:
     dependency: "direct main"
     description:
-      name: noports_core
-      sha256: c9228de65289f6946c07f12606feb106a6c53d65ca22b69f3da10a71f3f12e0d
-      url: "https://pub.dev"
-    source: hosted
+      path: "../noports_core"
+      relative: true
+    source: path
     version: "5.0.2"
   openssh_ed25519:
     dependency: transitive

--- a/packages/sshnoports/pubspec.lock
+++ b/packages/sshnoports/pubspec.lock
@@ -572,11 +572,10 @@ packages:
   noports_core:
     dependency: "direct main"
     description:
-      name: noports_core
-      sha256: c9228de65289f6946c07f12606feb106a6c53d65ca22b69f3da10a71f3f12e0d
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.0.2"
+      path: "../noports_core"
+      relative: true
+    source: path
+    version: "5.0.3"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/sshnoports/pubspec.lock
+++ b/packages/sshnoports/pubspec.lock
@@ -572,10 +572,11 @@ packages:
   noports_core:
     dependency: "direct main"
     description:
-      path: "../noports_core"
-      relative: true
-    source: path
-    version: "5.0.3"
+      name: noports_core
+      sha256: c9228de65289f6946c07f12606feb106a6c53d65ca22b69f3da10a71f3f12e0d
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/sshnoports/pubspec.lock
+++ b/packages/sshnoports/pubspec.lock
@@ -575,7 +575,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "5.0.2"
+    version: "5.0.3"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/sshnoports/pubspec.yaml
+++ b/packages/sshnoports/pubspec.yaml
@@ -7,10 +7,12 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  noports_core: 5.0.3
+  noports_core: 5.0.3 # not yet published
   at_onboarding_cli: 1.4.1
 
 dependency_overrides:
+  noports_core:
+    path: ../noports_core
   # Pin the dependencies of noports_core
   archive: 3.3.9
   args: 2.4.2

--- a/packages/sshnoports/pubspec.yaml
+++ b/packages/sshnoports/pubspec.yaml
@@ -7,8 +7,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  noports_core:
-    path: ../noports_core # Will be version 5.0.3
+  noports_core: 5.0.2 # Will need to upgrade to 5.0.3 once 5.0.3 has been published
   at_onboarding_cli: 1.4.1
 
 dependency_overrides:

--- a/packages/sshnoports/pubspec.yaml
+++ b/packages/sshnoports/pubspec.yaml
@@ -7,12 +7,11 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  noports_core: 5.0.3 # not yet published
+  noports_core:
+    path: ../noports_core # Will be version 5.0.3
   at_onboarding_cli: 1.4.1
 
 dependency_overrides:
-  noports_core:
-    path: ../noports_core
   # Pin the dependencies of noports_core
   archive: 3.3.9
   args: 2.4.2

--- a/packages/sshnoports/pubspec.yaml
+++ b/packages/sshnoports/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  noports_core: 5.0.2 # Will need to upgrade to 5.0.3 once 5.0.3 has been published
+  noports_core: 5.0.3
   at_onboarding_cli: 1.4.1
 
 dependency_overrides:

--- a/packages/sshnoports/pubspec.yaml
+++ b/packages/sshnoports/pubspec.yaml
@@ -1,13 +1,13 @@
 name: sshnoports
 publish_to: none
 
-version: 4.0.4
+version: 4.0.5
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  noports_core: 5.0.2
+  noports_core: 5.0.3
   at_onboarding_cli: 1.4.1
 
 dependency_overrides:


### PR DESCRIPTION
**- What I did**
- Allow user to specify a path for where the sshnpd program keeps any locally stored data

**- How I did it**
- See commits

**- How to verify it**
- Automated tests pass
- Manual tests pass - verifiable by checking that the provided storage-path contains the hive boxes once the sshnpd process has started up. Manually tested successfully as follows:
  - `bin/sshnpd -a @daemonAtSign -m @clientAtSign -d mbp -v -s -u --storage-path ./sshnpd_storage/@daemonAtSign`
  - `bin/sshnp -f @clientAtSign -t @daemonAtSign -d mbp -i ~/.ssh/noports -h @rv_eu -s noports.pub -u @USER --idle-timeout 30 --ssh-client dart`

**- Description for the changelog**
feat: sshnpd: add --storage-path option
