### PR TITLE
build(deps): Bump paramiko to 3.4.0

### DIFF
--- a/packages/python/sshnpd/pyproject.toml
+++ b/packages/python/sshnpd/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sshnpd"
-version = "0.4.0"
+version = "0.4.1"
 description = "Python implementation of SSH No Ports daemon"
 authors = ["Xavier Lin <xavier.lin@atsign.com >"]
 maintainers = ["Chris Swan <chris@atsign.com>"]
@@ -16,7 +16,7 @@ atsdk = "^0.1.0"
 bcrypt = "^4.0.1"
 cffi = "^1.15.1"
 cryptography = "^41.0.3"
-paramiko = "3.3.1"
+paramiko = "3.4.0"
 pycparser = "^2.21"
 PyNaCl = "^1.5.0"
 setuptools = "^69.0.0"

--- a/packages/python/sshnpd/requirements.txt
+++ b/packages/python/sshnpd/requirements.txt
@@ -203,9 +203,9 @@ cryptography==41.0.7 ; python_version >= "3.10" and python_version < "4.0" \
 idna==3.6 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca \
     --hash=sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
-paramiko==3.3.1 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:6a3777a961ac86dbef375c5f5b8d50014a1a96d0fd7f054a43bc880134b0ff77 \
-    --hash=sha256:b7bc5340a43de4287bbe22fe6de728aa2c22468b2a849615498dd944c2f275eb
+paramiko==3.4.0 ; python_version >= "3.10" and python_version < "4.0" \
+    --hash=sha256:43f0b51115a896f9c00f59618023484cb3a14b98bbceab43394a39c6739b7ee7 \
+    --hash=sha256:aac08f26a31dc4dffd92821527d1682d99d52f9ef6851968114a8728f3c274d3
 pycparser==2.21 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9 \
     --hash=sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206


### PR DESCRIPTION
Fixes:

https://github.com/atsign-foundation/sshnoports/security/dependabot/9
https://github.com/atsign-foundation/sshnoports/security/dependabot/10

**- What I did**

* Bump paramiko to 3.4.0 (@Xlin123 can we use `^3.4.0` instead?)
* Update requirements.txt
* Bump patch number for package

**- How to verify it**

Test locally in a virtual environment.

**- Description for the changelog**

build(deps): Bump paramiko to 3.4.0