### PR TITLE
fix: sshnpd/rvd installer tweaks

### DIFF
--- a/packages/sshnoports/bundles/shell/headless/sshnpd.sh
+++ b/packages/sshnoports/bundles/shell/headless/sshnpd.sh
@@ -2,6 +2,11 @@
 # disable "var is referenced but not assigned" warning for template
 # shellcheck disable=SC2154
 
+# Uncomment the following lines to specify your own values, or modify them inline below
+# device_atsign="@example_device"
+# manager_atsign="@example_client"
+# device_name="default"
+
 sleep 10; # allow machine to bring up network
 export USER="$user"
 while true; do

--- a/packages/sshnoports/bundles/shell/headless/sshrvd.sh
+++ b/packages/sshnoports/bundles/shell/headless/sshrvd.sh
@@ -2,6 +2,10 @@
 # disable "var is referenced but not assigned" warning for template
 # shellcheck disable=SC2154
 
+# Uncomment the following lines to specify your own values, or modify them inline below
+# atsign="@my_rvd"
+# internet_address="127.0.0.1"
+
 sleep 10; # allow machine to bring up network
 export USER="$user"
 while true; do

--- a/packages/sshnoports/bundles/shell/systemd/sshnpd.service
+++ b/packages/sshnoports/bundles/shell/systemd/sshnpd.service
@@ -2,8 +2,8 @@
 Description=Ssh No Ports Daemon
 After=network-online.target
 
-# Uncomment the following line to make this unit fail if sshd isn't started
-# Requisite=sshd.service
+# Make this unit fail if sshd isn't started first
+Requisite=sshd.service
 
 # Uncomment the following line to make this unit auto-start sshd if it isn't started
 # Requires=sshd.service
@@ -13,7 +13,6 @@ User=<username>
 Type=simple
 Restart=always
 RestartSec=3
-ExecStartPre=/bin/sleep 10
 ExecStart=/usr/local/bin/sshnpd -a <@device_atsign> -m <@manager_atsign> -d <device_name> -v
 
 [Install]

--- a/packages/sshnoports/bundles/shell/systemd/sshnpd.service
+++ b/packages/sshnoports/bundles/shell/systemd/sshnpd.service
@@ -9,10 +9,16 @@ Requisite=sshd.service
 # Requires=sshd.service
 
 [Service]
+# TODO : set username
 User=<username>
 Type=simple
 Restart=always
 RestartSec=3
+
+# Uncomment the following line to sleep for 10 seconds before starting up the service
+# ExecStartPre=/bin/sleep 10
+
+# TODO : set device_atsign, manager_atsign, device_name
 ExecStart=/usr/local/bin/sshnpd -a <@device_atsign> -m <@manager_atsign> -d <device_name> -v
 
 [Install]

--- a/packages/sshnoports/bundles/shell/systemd/sshrvd.service
+++ b/packages/sshnoports/bundles/shell/systemd/sshrvd.service
@@ -7,7 +7,6 @@ User=<username>
 Type=simple
 Restart=always
 RestartSec=3
-ExecStartPre=/bin/sleep 10
 ExecStart=/usr/local/bin/sshrvd -a <@atsign> -i <internet_address>
 
 [Install]

--- a/packages/sshnoports/bundles/shell/systemd/sshrvd.service
+++ b/packages/sshnoports/bundles/shell/systemd/sshrvd.service
@@ -3,10 +3,16 @@ Description=Ssh No Ports Rendezvous Daemon
 After=network-online.target
 
 [Service]
+# TODO : set username
 User=<username>
 Type=simple
 Restart=always
 RestartSec=3
+
+# Uncomment the following line to sleep for 10 seconds before starting up the service
+# ExecStartPre=/bin/sleep 10
+
+# TODO : set atsign, internet_address
 ExecStart=/usr/local/bin/sshrvd -a <@atsign> -i <internet_address>
 
 [Install]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Fixes home path to always be of the non-root user even when elevating privileges using sudo
- Added helper comments to the headless scripts
- Minor tweaks to systemd units' default settings / comments to aid with configuring

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: sshnpd/rvd installer tweaks
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
