### PR TITLE
feat: remove paramiko and use openssh binary

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
   // Use IntelliSense to learn about possible attributes.
   // Hover to view descriptions of existing attributes.
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-  "version": "0.3.0",
+  "version": "0.4.2",
   "configurations": [
     {
       // Since there are python tools in the repo, this allows you to run them faster in vscode

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
   // Use IntelliSense to learn about possible attributes.
   // Hover to view descriptions of existing attributes.
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-  "version": "0.2.0",
+  "version": "0.3.0",
   "configurations": [
     {
       // Since there are python tools in the repo, this allows you to run them faster in vscode
@@ -17,8 +17,8 @@
       "name": "Python: SSHNPD",
       "type": "python",
       "request": "launch",
-      "cwd": "",
-      "program": "packages/sshnpdpy/sshnpd.py",
+      "cwd": "packages/python/sshnpd/",
+      "program": "sshnpd.py",
       "console": "integratedTerminal",
       "justMyCode": true,
       "envFile": "${workspaceFolder}/.env",

--- a/packages/python/sshnpd/README.md
+++ b/packages/python/sshnpd/README.md
@@ -43,8 +43,3 @@ pip install .
 ```sh
 sshnpd -m @{clientAtsign} -a @{deviceAtsign} -d {deviceName}
 ```
-
-## No Ports SDK Python (experimental)
-
-There is a simple python SDK which allows you to create scripts for common
-administrative patterns via SSH No Ports.

--- a/packages/python/sshnpd/pyproject.toml
+++ b/packages/python/sshnpd/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sshnpd"
-version = "0.4.1"
+version = "0.4.2"
 description = "Python implementation of SSH No Ports daemon"
 authors = ["Xavier Lin <xavier.lin@atsign.com >"]
 maintainers = ["Chris Swan <chris@atsign.com>"]
@@ -16,7 +16,6 @@ atsdk = "^0.1.0"
 bcrypt = "^4.0.1"
 cffi = "^1.15.1"
 cryptography = "^41.0.3"
-paramiko = "3.4.0"
 pycparser = "^2.21"
 PyNaCl = "^1.5.0"
 setuptools = "^69.0.0"

--- a/packages/python/sshnpd/requirements.txt
+++ b/packages/python/sshnpd/requirements.txt
@@ -203,9 +203,6 @@ cryptography==41.0.7 ; python_version >= "3.10" and python_version < "4.0" \
 idna==3.6 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca \
     --hash=sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
-paramiko==3.4.0 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:43f0b51115a896f9c00f59618023484cb3a14b98bbceab43394a39c6739b7ee7 \
-    --hash=sha256:aac08f26a31dc4dffd92821527d1682d99d52f9ef6851968114a8728f3c274d3
 pycparser==2.21 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9 \
     --hash=sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206


### PR DESCRIPTION
**- What I did**
 Removed paramiko which was used for reverse ssh in order to address this [code scanning alert](https://github.com/atsign-foundation/sshnoports/security/code-scanning/16)

**- How I did it**
Removed paramiko and used the binary.

**- How to verify it**
 Use a sshnp command like the following 
 `sshnp -f {atsign} -t {atsign} -h {host} -d {device} --legacy-daemon`

**- Description for the changelog**
feat: remove paramiko and use openssh binary
