### PR TITLE
fix: properly bind ephemeral port to localPort variable for unsigned …

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -1,4 +1,4 @@
-name: sshnoports
+name: noports
 
 packages:
   - packages/dart/noports_core

--- a/packages/dart/noports_core/CHANGELOG.md
+++ b/packages/dart/noports_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.0.4
+
+- refactor: move the `findLocalPortIfRequired` function to `EphemeralPortBinder`, a mixin on `SshnpCore`
+- fix: call `callFindLocalPortIfRequired` during the initialization of the unsigned sshnp client
+
 # 5.0.3
 - feat: Add `--storage-path` option to sshnpd to allow users to specify where 
   it keeps any locally stored data

--- a/packages/dart/noports_core/lib/src/sshnp/impl/sshnp_openssh_local_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/impl/sshnp_openssh_local_impl.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
 
 import 'package:at_client/at_client.dart';
-import 'package:meta/meta.dart';
 import 'package:noports_core/src/common/io_types.dart';
+import 'package:noports_core/src/sshnp/util/ephemeral_port_binder.dart';
 import 'package:noports_core/sshnp_foundation.dart';
 
 class SshnpOpensshLocalImpl extends SshnpCore
-    with SshnpLocalSshKeyHandler, OpensshSshSessionHandler {
+    with SshnpLocalSshKeyHandler, OpensshSshSessionHandler, EphemeralPortBinder {
   SshnpOpensshLocalImpl({
     required super.atClient,
     required super.params,
@@ -39,26 +39,6 @@ class SshnpOpensshLocalImpl extends SshnpCore
     await super.initialize();
     completeInitialization();
   }
-
-  @visibleForTesting
-  Future<void> findLocalPortIfRequired() async {
-    // find a spare local port
-    if (localPort == 0) {
-      logger.info('Finding a spare local port');
-      try {
-        ServerSocket serverSocket =
-            await ServerSocket.bind(InternetAddress.loopbackIPv4, 0)
-                .catchError((e) => throw e);
-        localPort = serverSocket.port;
-        await serverSocket.close().catchError((e) => throw e);
-      } catch (e, s) {
-        logger.info('Unable to find a spare local port');
-        throw SshnpError('Unable to find a spare local port',
-            error: e, stackTrace: s);
-      }
-    }
-  }
-
   @override
   Future<SshnpResult> run() async {
     /// Ensure that sshnp is initialized

--- a/packages/dart/noports_core/lib/src/sshnp/impl/sshnp_unsigned_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/impl/sshnp_unsigned_impl.dart
@@ -2,9 +2,11 @@ import 'dart:async';
 
 import 'package:at_client/at_client.dart';
 import 'package:noports_core/src/common/io_types.dart';
+import 'package:noports_core/src/sshnp/util/ephemeral_port_binder.dart';
 import 'package:noports_core/sshnp_foundation.dart';
 
-class SshnpUnsignedImpl extends SshnpCore with SshnpLocalSshKeyHandler {
+class SshnpUnsignedImpl extends SshnpCore
+    with SshnpLocalSshKeyHandler, EphemeralPortBinder {
   SshnpUnsignedImpl({
     required super.atClient,
     required super.params,
@@ -38,6 +40,7 @@ class SshnpUnsignedImpl extends SshnpCore with SshnpLocalSshKeyHandler {
   @override
   Future<void> initialize() async {
     if (!isSafeToInitialize) return;
+    await findLocalPortIfRequired();
     await super.initialize();
 
     /// Generate an ephemeral key pair for this session

--- a/packages/dart/noports_core/lib/src/sshnp/util/ephemeral_port_binder.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/ephemeral_port_binder.dart
@@ -1,0 +1,25 @@
+import 'package:meta/meta.dart';
+import 'package:noports_core/sshnp_foundation.dart';
+import 'package:noports_core/src/common/io_types.dart';
+
+mixin EphemeralPortBinder on SshnpCore {
+  @visibleForTesting
+  @protected
+  Future<void> findLocalPortIfRequired() async {
+    // find a spare local port
+    if (localPort == 0) {
+      logger.info('Finding a spare local port');
+      try {
+        ServerSocket serverSocket =
+            await ServerSocket.bind(InternetAddress.loopbackIPv4, 0)
+                .catchError((e) => throw e);
+        localPort = serverSocket.port;
+        await serverSocket.close().catchError((e) => throw e);
+      } catch (e, s) {
+        logger.info('Unable to find a spare local port');
+        throw SshnpError('Unable to find a spare local port',
+            error: e, stackTrace: s);
+      }
+    }
+  }
+}

--- a/packages/dart/noports_core/lib/src/version.dart
+++ b/packages/dart/noports_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.0.3';
+const packageVersion = '5.0.4';

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: noports_core
 description: Core library code for sshnoports
 homepage: https://docs.atsign.com/
 
-version: 5.0.3
+version: 5.0.4
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -575,7 +575,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "5.0.3"
+    version: "5.0.4"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  noports_core: 5.0.3
+  noports_core: 5.0.4
   at_onboarding_cli: 1.4.1
 
 dependency_overrides:

--- a/packages/dart/sshnp_gui/pubspec.lock
+++ b/packages/dart/sshnp_gui/pubspec.lock
@@ -699,7 +699,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "5.0.2"
+    version: "5.0.4"
   openssh_ed25519:
     dependency: transitive
     description:


### PR DESCRIPTION
…client

fixes #671 

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Refactored the findLocalPortIfRequired function (in the openssh client) to a mixin which can be used by both openssh and unsigned clients.
- Uptook the use of the new mixin in both client implementations

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: properly bind ephemeral port to localPort variable for unsigned client
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
