### PR TITLE
chore: bump melos to v4 and disable parallel pub gets

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -7,5 +7,6 @@ packages:
 
 command:
   bootstrap:
+    runPubGetInParallel: false
     hooks:
       post: dart run melos exec --scope="noports_core" --scope="sshnoports" -- "dart run build_runner build --delete-conflicting-outputs"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,4 +4,4 @@ environment:
   sdk: ">=2.12.0 <4.0.0"
 
 dev_dependencies:
-  melos: ^3.1.1
+  melos: ^4.0.0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- bumped melos to v4
- disabled melos from running pub get in parallel when bootstrapping (fix for git dependency overrides)

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: bump melos to v4 and disable parallel pub gets
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
