### PR TITLE
feat: add usageLineLength so terminal resizes usage correctly

### DIFF
--- a/packages/dart/noports_core/lib/src/sshnp/models/sshnp_arg.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/models/sshnp_arg.dart
@@ -140,8 +140,9 @@ class SshnpArg {
     bool withDefaults = true,
     Iterable<String>? includeList,
     Iterable<String>? excludeList,
+    int? usageLineLength,
   }) {
-    var parser = ArgParser();
+    var parser = ArgParser(usageLineLength: usageLineLength);
     // Basic arguments
     for (SshnpArg arg in SshnpArg.args) {
       if (!parserType.shouldParse(arg.parseWhen)) {

--- a/packages/dart/sshnoports/bin/sshnp.dart
+++ b/packages/dart/sshnoports/bin/sshnp.dart
@@ -18,7 +18,9 @@ void main(List<String> args) async {
   AtSignLogger.root_level = 'SHOUT';
   AtSignLogger.defaultLoggingHandler = AtSignLogger.stdErrLoggingHandler;
 
-  ExtendedArgParser parser = ExtendedArgParser();
+  ExtendedArgParser parser = ExtendedArgParser(
+    usageLineLength: stdout.hasTerminal ? stdout.terminalColumns : null,
+  );
 
   // Create the printUsage closure
   void printUsage({Object? error}) {

--- a/packages/dart/sshnoports/lib/src/extended_arg_parser.dart
+++ b/packages/dart/sshnoports/lib/src/extended_arg_parser.dart
@@ -14,8 +14,11 @@ const legacyDaemonFlag = 'legacy-daemon';
 const outputExecutionCommandFlag = 'output-execution-command';
 
 class ExtendedArgParser {
-  static ArgParser createArgParser() {
-    final parser = SshnpArg.createArgParser(parserType: ParserType.commandLine);
+  static ArgParser createArgParser({int? usageLineLength}) {
+    final parser = SshnpArg.createArgParser(
+      parserType: ParserType.commandLine,
+      usageLineLength: usageLineLength,
+    );
 
     parser.addOption(
       sshClientOption,
@@ -45,7 +48,8 @@ class ExtendedArgParser {
   final ArgParser parser;
   ArgResults? results;
 
-  ExtendedArgParser() : parser = createArgParser();
+  ExtendedArgParser({int? usageLineLength})
+      : parser = createArgParser(usageLineLength: usageLineLength);
 
   ArgResults parse(Iterable<String> args) {
     return results = parser.parse(args);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Passed through the usageLineLength parameter from stdout.terminalColumns so that the usage formats the descriptions of parameters nicely. (Creates new lines and indentation instead of wrapping)

**- How I did it**

**- How to verify it**

**- Description for the changelog**
feat: add usageLineLength so terminal resizes usage correctly
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
