### PR TITLE
fix: empty session and tunnel username are treated as null.

### DIFF
--- a/packages/dart/sshnp_flutter/lib/src/presentation/widgets/profile_screen_widgets/profile_form/profile_form_desktop_view.dart
+++ b/packages/dart/sshnp_flutter/lib/src/presentation/widgets/profile_screen_widgets/profile_form/profile_form_desktop_view.dart
@@ -52,7 +52,7 @@ class _ProfileFormState extends ConsumerState<ProfileFormDesktopView> {
   void onSubmit(SshnpParams oldConfig) async {
     if (_formkey.currentState!.validate()) {
       _formkey.currentState!.save();
-      SshnpParams config = SshnpParams.merge(oldConfig, newConfig);
+      SshnpParams config = SshnpParams.merge(SshnpParams.empty(), newConfig);
 
       // get the controller for the profile that is about to be saved. Since this profile is not saved a log will be printed stating that the profile does not exist in keystore.
       final controller = ref.read(configFamilyController(newConfig.profileName!).notifier);
@@ -151,7 +151,7 @@ class _ProfileFormState extends ConsumerState<ProfileFormDesktopView> {
                       newConfig,
                       SshnpPartialParams(host: value),
                     ),
-                    validator: FormValidator.validateRequiredField,
+                    validator: FormValidator.validateAtsignField,
                   ),
                   gapH20,
                   Text(strings.connectionConfiguration, style: Theme.of(context).textTheme.bodyLarge),
@@ -159,10 +159,13 @@ class _ProfileFormState extends ConsumerState<ProfileFormDesktopView> {
                   ProfileFormCard(
                     formFields: [
                       CustomTextFormField(
-                          initialValue: oldConfig.remoteUsername ?? '',
+                          initialValue: oldConfig.remoteUsername,
                           labelText: strings.remoteUserName,
                           toolTip: strings.remoteUserNameTooltip,
                           onSaved: (value) {
+                            if (value == '') {
+                              value = null;
+                            }
                             newConfig = SshnpPartialParams.merge(
                               newConfig,
                               SshnpPartialParams(remoteUsername: value),
@@ -170,10 +173,13 @@ class _ProfileFormState extends ConsumerState<ProfileFormDesktopView> {
                           }),
                       gapH10,
                       CustomTextFormField(
-                          initialValue: oldConfig.tunnelUsername ?? '',
+                          initialValue: oldConfig.tunnelUsername,
                           labelText: strings.tunnelUserName,
                           toolTip: strings.tunnelUserNameTooltip,
                           onSaved: (value) {
+                            if (value == '') {
+                              value = null;
+                            }
                             newConfig = SshnpPartialParams.merge(
                               newConfig,
                               SshnpPartialParams(tunnelUsername: value),
@@ -184,21 +190,22 @@ class _ProfileFormState extends ConsumerState<ProfileFormDesktopView> {
                         initialValue: oldConfig.remoteSshdPort.toString(),
                         labelText: strings.remoteSshdPort,
                         toolTip: strings.remoteSshdPortTooltip,
-                        onChanged: (value) => newConfig = SshnpPartialParams.merge(
+                        onSaved: (value) => newConfig = SshnpPartialParams.merge(
                           newConfig,
-                          SshnpPartialParams(remoteSshdPort: int.tryParse(value)),
+                          SshnpPartialParams(remoteSshdPort: int.tryParse(value!)),
                         ),
-                        validator: FormValidator.validateRequiredField,
+                        validator: FormValidator.validateRequiredIntField,
                       ),
                       gapH10,
                       CustomTextFormField(
                         initialValue: oldConfig.localPort.toString(),
                         labelText: strings.localPort,
                         toolTip: strings.localPortTooltip,
-                        onChanged: (value) => newConfig = SshnpPartialParams.merge(
+                        onSaved: (value) => newConfig = SshnpPartialParams.merge(
                           newConfig,
-                          SshnpPartialParams(localPort: int.tryParse(value)),
+                          SshnpPartialParams(localPort: int.tryParse(value!)),
                         ),
+                        validator: FormValidator.validateRequiredIntField,
                       ),
                       gapH10,
                       gapH12,
@@ -288,9 +295,9 @@ class _ProfileFormState extends ConsumerState<ProfileFormDesktopView> {
                         hintText: strings.localSshOptionsHint,
                         labelText: strings.localSshOptions,
                         toolTip: strings.localSshOptionsTooltip,
-                        onChanged: (value) => newConfig = SshnpPartialParams.merge(
+                        onSaved: (value) => newConfig = SshnpPartialParams.merge(
                           newConfig,
-                          SshnpPartialParams(localSshOptions: value.split(',')),
+                          SshnpPartialParams(localSshOptions: value?.split(',')),
                         ),
                       ),
                       gapH10,
@@ -302,6 +309,7 @@ class _ProfileFormState extends ConsumerState<ProfileFormDesktopView> {
                           newConfig,
                           SshnpPartialParams(rootDomain: value),
                         ),
+                        validator: FormValidator.validateRequiredField,
                       ),
                     ],
                   ),

--- a/packages/dart/sshnp_flutter/lib/src/presentation/widgets/profile_screen_widgets/profile_form/profile_form_desktop_view.dart
+++ b/packages/dart/sshnp_flutter/lib/src/presentation/widgets/profile_screen_widgets/profile_form/profile_form_desktop_view.dart
@@ -194,7 +194,7 @@ class _ProfileFormState extends ConsumerState<ProfileFormDesktopView> {
                           newConfig,
                           SshnpPartialParams(remoteSshdPort: int.tryParse(value!)),
                         ),
-                        validator: FormValidator.validateRequiredIntField,
+                        validator: FormValidator.validateRequiredPortField,
                       ),
                       gapH10,
                       CustomTextFormField(
@@ -205,7 +205,7 @@ class _ProfileFormState extends ConsumerState<ProfileFormDesktopView> {
                           newConfig,
                           SshnpPartialParams(localPort: int.tryParse(value!)),
                         ),
-                        validator: FormValidator.validateRequiredIntField,
+                        validator: FormValidator.validateRequiredPortField,
                       ),
                       gapH10,
                       gapH12,

--- a/packages/dart/sshnp_flutter/lib/src/utility/constants.dart
+++ b/packages/dart/sshnp_flutter/lib/src/utility/constants.dart
@@ -21,6 +21,7 @@ const kEmptyFieldValidationError = 'Field cannot be left blank';
 const kAtsignFieldValidationError = 'Field must start with @';
 const kProfileNameFieldValidationError = 'Field must only use lower case alphanumeric characters spaces';
 const kPrivateKeyFieldValidationError = 'Field must only use lower case alphanumeric characters';
+const kIntFieldValidationError = 'Field must only use numbers';
 
 const kPrivateKeyDropDownOption = 'Create a new private key';
 

--- a/packages/dart/sshnp_flutter/lib/src/utility/constants.dart
+++ b/packages/dart/sshnp_flutter/lib/src/utility/constants.dart
@@ -22,6 +22,7 @@ const kAtsignFieldValidationError = 'Field must start with @';
 const kProfileNameFieldValidationError = 'Field must only use lower case alphanumeric characters spaces';
 const kPrivateKeyFieldValidationError = 'Field must only use lower case alphanumeric characters';
 const kIntFieldValidationError = 'Field must only use numbers';
+const kPortFieldValidationError = 'Field must use a valid port number';
 
 const kPrivateKeyDropDownOption = 'Create a new private key';
 

--- a/packages/dart/sshnp_flutter/lib/src/utility/form_validator.dart
+++ b/packages/dart/sshnp_flutter/lib/src/utility/form_validator.dart
@@ -10,12 +10,14 @@ class FormValidator {
     return null;
   }
 
-  static String? validateRequiredIntField(String? value) {
+  static String? validateRequiredPortField(String? value) {
     String valid = r'^[0-9]+$';
     if (value?.isEmpty ?? true) {
       return kEmptyFieldValidationError;
     } else if (!RegExp(valid).hasMatch(value!)) {
-      return kIntFieldValidationError;
+      return kPortFieldValidationError;
+    } else if (!(int.parse(value) >= 0 && int.parse(value) <= 65535)) {
+      return kPortFieldValidationError;
     }
     return null;
   }

--- a/packages/dart/sshnp_flutter/lib/src/utility/form_validator.dart
+++ b/packages/dart/sshnp_flutter/lib/src/utility/form_validator.dart
@@ -10,12 +10,23 @@ class FormValidator {
     return null;
   }
 
+  static String? validateRequiredIntField(String? value) {
+    String valid = r'^[0-9]+$';
+    if (value?.isEmpty ?? true) {
+      return kEmptyFieldValidationError;
+    } else if (!RegExp(valid).hasMatch(value!)) {
+      return kIntFieldValidationError;
+    }
+    return null;
+  }
+
   static String? validateAtsignField(String? value) {
     if (value?.isEmpty ?? true) {
       return kEmptyFieldValidationError;
     } else if (!value!.startsWith('@')) {
       return kAtsignFieldValidationError;
     }
+    validateRequiredField(value);
     return null;
   }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Replaces empty string as null when using the session and tunnel username.
- Added additional validation to SR Address, Device address, remote sshd port and local forwarding port.

**- How I did it**

**- How to verify it**

1. Run the app
2.  edit or create a profile. 
3. enter an invalid value in the form field

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Improve validation when creating profiles and empty session and tunnel username are treated as null.