### PR TITLE
fix: terminal can be closed if session is hung

### DIFF
--- a/packages/dart/sshnp_flutter/lib/src/controllers/terminal_session_controller.dart
+++ b/packages/dart/sshnp_flutter/lib/src/controllers/terminal_session_controller.dart
@@ -185,6 +185,11 @@ class TerminalSessionFamilyController extends FamilyNotifier<TerminalSession, St
       ref.read(terminalSessionProfileNameFamilyCounter(state._profileName!).notifier)._removeSession(state.sessionId);
     }
   }
+
+  void write(String data) {
+    state.terminal.write(data);
+    state.terminal.cursorNextLine(1);
+  }
 }
 
 /// Counter for the number of terminal sessions by profileName - issues and tracks the display name for each session

--- a/packages/dart/sshnp_flutter/lib/src/presentation/widgets/profile_screen_widgets/profile_actions/profile_terminal_action.dart
+++ b/packages/dart/sshnp_flutter/lib/src/presentation/widgets/profile_screen_widgets/profile_actions/profile_terminal_action.dart
@@ -1,20 +1,11 @@
-import 'dart:developer';
-
-import 'package:at_client_mobile/at_client_mobile.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:noports_core/sshnp.dart';
 import 'package:sshnp_flutter/src/controllers/navigation_controller.dart';
 import 'package:sshnp_flutter/src/controllers/navigation_rail_controller.dart';
-import 'package:sshnp_flutter/src/controllers/terminal_session_controller.dart';
 import 'package:sshnp_flutter/src/presentation/widgets/profile_screen_widgets/profile_actions/profile_action_button.dart';
-import 'package:sshnp_flutter/src/repository/private_key_manager_repository.dart';
 import 'package:sshnp_flutter/src/utility/sizes.dart';
-
-import '../../../../repository/profile_private_key_manager_repository.dart';
-import '../../utility/custom_snack_bar.dart';
 
 class ProfileTerminalAction extends ConsumerStatefulWidget {
   final SshnpParams params;
@@ -42,77 +33,9 @@ class _ProfileTerminalActionState extends ConsumerState<ProfileTerminalAction> {
   }
 
   Future<void> onPressed() async {
+    ref.read(navigationRailController.notifier).setRoute(AppRoute.terminal);
     if (mounted) {
-      showProgress('Starting Shell Session...');
-    }
-
-    /// Issue a new session id
-    final sessionId = ref.watch(terminalSessionController.notifier).createSession();
-
-    /// Create the session controller for the new session id
-    final sessionController = ref.watch(terminalSessionFamilyController(sessionId).notifier);
-
-    try {
-      AtClient atClient = AtClientManager.getInstance().atClient;
-
-      final profilePrivateKey =
-          await ProfilePrivateKeyManagerRepository.readProfilePrivateKeyManager(widget.params.profileName ?? '');
-      final privateKeyManager =
-          await PrivateKeyManagerRepository.readPrivateKeyManager(profilePrivateKey.privateKeyNickname);
-
-      final keyPair = privateKeyManager.toAtSshKeyPair();
-
-      final sshnp = Sshnp.dartPure(
-        params: SshnpParams.merge(
-          widget.params,
-          SshnpPartialParams(
-            verbose: kDebugMode,
-            idleTimeout: 30,
-          ),
-        ),
-        atClient: atClient,
-        identityKeyPair: keyPair,
-      );
-
-      final result = await sshnp.run();
-      if (result is SshnpError) {
-        throw result;
-      }
-
-      if (result is SshnpCommand) {
-        if (sshnp.canRunShell) {
-          if (mounted) {
-            context.pop();
-            showProgress('running shell session...');
-          }
-          log('running shell session...');
-
-          SshnpRemoteProcess shell = await sshnp.runShell();
-          if (mounted) {
-            context.pop();
-            showProgress('starting terminal session...');
-          }
-          log('starting terminal session');
-          sessionController.startSession(
-            shell,
-            terminalTitle: '${widget.params.sshnpdAtSign}-${widget.params.device}',
-          );
-        }
-
-        sessionController.issueDisplayName(widget.params.profileName!);
-
-        ref.read(navigationRailController.notifier).setRoute(AppRoute.terminal);
-        if (mounted) {
-          context.pushReplacementNamed(AppRoute.terminal.name);
-        }
-      }
-    } catch (e) {
-      sessionController.dispose();
-      if (mounted) {
-        log('error: ${e.toString()}');
-        context.pop();
-        CustomSnackBar.error(content: e.toString());
-      }
+      context.pushReplacementNamed(AppRoute.terminal.name, extra: {'params': widget.params, 'runShell': true});
     }
   }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
  fixes #713 
**- How I did it**
 Navigate to the terminal screen so if a hung session occurs, the user can close the terminal
**- How to verify it**
1. run the app
2. ssh into a remote device
3. reproduce a hung session
4. close the terminal

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
user can close terminal if a hung session occurs