### PR TITLE
fix: placeholder navigation destination and empty terminal nav destination

### DIFF
--- a/packages/dart/sshnp_flutter/lib/src/presentation/widgets/navigation/app_navigation_rail.dart
+++ b/packages/dart/sshnp_flutter/lib/src/presentation/widgets/navigation/app_navigation_rail.dart
@@ -48,11 +48,13 @@ class AppNavigationRail extends ConsumerWidget {
                 destinations: controller.routes.map((AppRoute route) {
                   if (route == AppRoute.blank) {
                     return NavigationRailDestination(
+                      disabled: true,
                       icon: SizedBox(height: 116 + height - 467),
                       label: gap0,
                     );
                   } else if ((route == AppRoute.terminal && terminalList.isEmpty)) {
                     return const NavigationRailDestination(
+                      disabled: true,
                       icon: gapH46,
                       label: gap0,
                     );


### PR DESCRIPTION
…ation disabled.

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
 fixes #731 
**- How I did it**
Set disabled parameter to true for the Placeholder navigation destination and the terminal navigation destination when the terminal list is empty.
**- How to verify it**
run the app and they should be no white square when when mouse press occurs in the empty space of the navigation rail.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix buggy navigation rail