### PR TITLE
build(deps): Pin to versioned tag rather than automated

### DIFF
--- a/packages/dart/sshnoports/tools/Dockerfile.package
+++ b/packages/dart/sshnoports/tools/Dockerfile.package
@@ -1,7 +1,7 @@
 # Dockerfile.package
 # A dockerfile for packaging SSH No Ports releases using docker buildx
 
-FROM atsigncompany/buildimage:automated@sha256:df2ef31dba19fa48cffe53cb2d2215148db917737e2e511a3f7f3a59ef0244fe AS build
+FROM atsigncompany/buildimage:3.2.5@sha256:df2ef31dba19fa48cffe53cb2d2215148db917737e2e511a3f7f3a59ef0244fe AS build
 # Using atsigncompany/buildimage until official dart image has RISC-V support
 WORKDIR /sshnoports
 COPY . .


### PR DESCRIPTION
The present `:automated` tag isn't very informative about what version of Dart we're getting

**- What I did**

Changed tag to the present release version `3.2.5`

**- How to verify it**

SHAs are the same:

```
$ sudo docker buildx imagetools inspect atsigncompany/buildimage:automated --format "{{json .Manifest}}" | jq -r .digest
sha256:df2ef31dba19fa48cffe53cb2d2215148db917737e2e511a3f7f3a59ef0244fe

$ sudo docker buildx imagetools inspect atsigncompany/buildimage:3.2.5 --format "{{json .Manifest}}" | jq -r .digest
sha256:df2ef31dba19fa48cffe53cb2d2215148db917737e2e511a3f7f3a59ef0244fe
```

**- Description for the changelog**

build(deps): Pin to versioned tag rather than automated