### PR TITLE
ci: Restrict token permissions in gitbook workflow

### DIFF
--- a/.github/workflows/gitbook.yaml
+++ b/.github/workflows/gitbook.yaml
@@ -2,7 +2,10 @@ name: Gitbook Review
 on:
   push:
     branches:
-     - gitbook
+      - gitbook
+
+permissions:
+  contents: read
 
 jobs:
   create-pull-request:
@@ -16,7 +19,7 @@ jobs:
 
       - name: Authenticate GitHub CLI
         run: |
-         echo -e ${{ secrets.MY_GITHUB_TOKEN }} | gh auth login --with-token 
+          echo -e ${{ secrets.MY_GITHUB_TOKEN }} | gh auth login --with-token 
 
       - name: Create Pull Request
         run: |
@@ -27,4 +30,3 @@ jobs:
             --title 'docs(automated): Update docs from Gitbook' \
             --body 'Sync Gitbook docs branch to trunk' || \
           echo "Already created?";
-


### PR DESCRIPTION
Fixes https://github.com/atsign-foundation/noports/security/code-scanning/17

Should also clear https://github.com/atsign-foundation/noports/security/code-scanning/18 which appears to be a false positive

**- What I did**

* Added section to make token permissions read only
* Tidied up some white space

**- How to verify it**

https://github.com/atsign-foundation/noports/security/code-scanning/17 should clear when merged

**- Description for the changelog**

ci: Restrict token permissions in gitbook workflow
