### PR TITLE
fix: windows initial ssh connection timeout code

### DIFF
--- a/packages/dart/noports_core/lib/src/sshnp/util/ssh_session_handler/openssh_ssh_session_handler.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/ssh_session_handler/openssh_ssh_session_handler.dart
@@ -69,6 +69,7 @@ mixin OpensshSshSessionHandler on SshnpCore implements SshSessionHandler<Process
         int counter = 0;
         while (waiter == 0) {
           Socket? sock;
+          await Future.delayed(Duration(milliseconds: 500));
           try {
             sock = await Socket.connect('localhost', localPort);
           } catch (e) {
@@ -80,7 +81,6 @@ mixin OpensshSshSessionHandler on SshnpCore implements SshSessionHandler<Process
             await sock?.close();
             waiter = 1;
           }
-          await Future.delayed(Duration(milliseconds: 200));
           if (counter > 5) {
             throw SshnpError(
               'SSHNP failed to start the initial ssh tunnel',

--- a/packages/dart/noports_core/lib/src/sshnp/util/ssh_session_handler/openssh_ssh_session_handler.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/ssh_session_handler/openssh_ssh_session_handler.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:convert';
 
 import 'package:dartssh2/dartssh2.dart';
@@ -7,8 +8,7 @@ import 'package:noports_core/src/common/io_types.dart';
 import 'package:noports_core/src/common/openssh_binary_path.dart';
 import 'package:noports_core/sshnp_foundation.dart';
 
-mixin OpensshSshSessionHandler on SshnpCore
-    implements SshSessionHandler<Process?> {
+mixin OpensshSshSessionHandler on SshnpCore implements SshSessionHandler<Process?> {
   @override
   Future<Process?> startInitialTunnelSession({
     required String ephemeralKeyPairIdentifier,
@@ -64,8 +64,29 @@ mixin OpensshSshSessionHandler on SshnpCore
           runInShell: true,
           mode: ProcessStartMode.detachedWithStdio,
         ));
-        // Delay to allow the detached session to pick up the keys
-        await Future.delayed(Duration(seconds: 3));
+        // Delay to allow the initial connection to get in place
+        int waiter = 0;
+        int counter = 0;
+        while (waiter == 0) {
+          Socket? sock;
+          try {
+            sock = await Socket.connect('localhost', localPort);
+          } catch (e) {
+            logger.info("waiting for initial ssh tunnel");
+            await sock?.close();
+            counter++;
+          }
+          if (sock?.remotePort == localPort) {
+            await sock?.close();
+            waiter = 1;
+          }
+          await Future.delayed(Duration(milliseconds: 200));
+          if (counter > 5) {
+            throw SshnpError(
+              'SSHNP failed to start the initial ssh tunnel',
+            );
+          }
+        }
       } else {
         process = await startProcess(opensshBinaryPath, args);
         process.stdout.transform(Utf8Decoder()).listen((String s) {

--- a/packages/dart/noports_core/lib/src/sshnp/util/ssh_session_handler/openssh_ssh_session_handler.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/ssh_session_handler/openssh_ssh_session_handler.dart
@@ -55,14 +55,12 @@ mixin OpensshSshSessionHandler on SshnpCore implements SshSessionHandler<Process
         // the process since there is a physical window the user can close to
         // end the session
         unawaited(startProcess(
-          'powershell.exe',
+          opensshBinaryPath,
           [
-            '-command',
-            opensshBinaryPath,
             ...args,
           ],
           runInShell: true,
-          mode: ProcessStartMode.detachedWithStdio,
+          mode: ProcessStartMode.normal,
         ));
         // Delay to allow the initial connection to get in place
         int waiter = 0;


### PR DESCRIPTION
Windows code was breaking due to a wait statement and a variable amount of time for teh initial ssh to be established

**- What I did**
Made a check to see if the initial ssh was up and if not timeout after 5 retries
**- How I did it**
checked socket to see if remote ssh was TCP reachable
**- How to verify it**
chaneg the code to a random port and see the connection fail
**- Description for the changelog**
removes dependency on time/wait for initial ssh connection on windows
