### PR TITLE
chore: breaking arg changes to cli client

### DIFF
--- a/packages/dart/noports_core/lib/src/sshnp/models/sshnp_arg.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/models/sshnp_arg.dart
@@ -135,6 +135,11 @@ class SshnpArg {
     return 'SshnpArg{format: $format, name: $name, abbr: $abbr, help: $help, mandatory: $mandatory, defaultsTo: $defaultsTo, type: $type}';
   }
 
+  static final disabledArgs = [
+    portArg,
+    localSshdPortArg,
+  ];
+
   static ArgParser createArgParser({
     ParserType parserType = ParserType.all,
     bool withDefaults = true,
@@ -145,7 +150,8 @@ class SshnpArg {
     var parser = ArgParser(usageLineLength: usageLineLength);
     // Basic arguments
     for (SshnpArg arg in SshnpArg.args) {
-      if (!parserType.shouldParse(arg.parseWhen)) {
+      if (!parserType.shouldParse(arg.parseWhen) ||
+          disabledArgs.contains(arg)) {
         continue;
       }
 
@@ -198,6 +204,7 @@ class SshnpArg {
     defaultsTo: DefaultArgs.help,
     format: ArgFormat.flag,
     parseWhen: ParseWhen.commandLine,
+    negatable: false,
   );
   static const keyFileArg = SshnpArg(
     name: 'key-file',
@@ -263,6 +270,7 @@ class SshnpArg {
         'When true, the ssh public key will be sent to the remote host for use in the ssh session',
     defaultsTo: DefaultSshnpArgs.sendSshPublicKey,
     format: ArgFormat.flag,
+    negatable: false,
   );
   static const localSshOptionsArg = SshnpArg(
     name: 'local-ssh-options',
@@ -277,6 +285,7 @@ class SshnpArg {
     defaultsTo: DefaultArgs.verbose,
     help: 'More logging',
     format: ArgFormat.flag,
+    negatable: false,
   );
   static const remoteUserNameArg = SshnpArg(
     name: 'remote-user-name',
@@ -336,6 +345,7 @@ class SshnpArg {
     defaultsTo: DefaultArgs.addForwardsToTunnel,
     format: ArgFormat.flag,
     parseWhen: ParseWhen.commandLine,
+    negatable: false,
   );
   static const configFileArg = SshnpArg(
     name: 'config-file',
@@ -395,5 +405,6 @@ class SshnpArg {
     format: ArgFormat.flag,
     parseWhen: ParseWhen.commandLine,
     mandatory: false,
+    negatable: false,
   );
 }

--- a/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
@@ -35,7 +35,6 @@ class SshnpParams {
   final int idleTimeout;
   final bool addForwardsToTunnel;
   final String? atKeysFilePath;
-  final SupportedSshAlgorithm sshAlgorithm;
   final bool authenticateClientToRvd;
   final bool authenticateDeviceToRvd;
   final bool encryptRvdTraffic;
@@ -85,7 +84,6 @@ class SshnpParams {
     this.remoteSshdPort = DefaultArgs.remoteSshdPort,
     this.idleTimeout = DefaultArgs.idleTimeout,
     this.addForwardsToTunnel = DefaultArgs.addForwardsToTunnel,
-    this.sshAlgorithm = DefaultArgs.sshAlgorithm,
     this.authenticateClientToRvd = DefaultArgs.authenticateClientToRvd,
     this.authenticateDeviceToRvd = DefaultArgs.authenticateDeviceToRvd,
     this.encryptRvdTraffic = DefaultArgs.encryptRvdTraffic,
@@ -130,7 +128,6 @@ class SshnpParams {
       idleTimeout: params2.idleTimeout ?? params1.idleTimeout,
       addForwardsToTunnel:
           params2.addForwardsToTunnel ?? params1.addForwardsToTunnel,
-      sshAlgorithm: params2.sshAlgorithm ?? params1.sshAlgorithm,
       authenticateClientToRvd:
           params2.authenticateClientToRvd ?? params1.authenticateClientToRvd,
       authenticateDeviceToRvd:
@@ -177,7 +174,6 @@ class SshnpParams {
       idleTimeout: partial.idleTimeout ?? DefaultArgs.idleTimeout,
       addForwardsToTunnel:
           partial.addForwardsToTunnel ?? DefaultArgs.addForwardsToTunnel,
-      sshAlgorithm: partial.sshAlgorithm ?? DefaultArgs.sshAlgorithm,
       authenticateClientToRvd: partial.authenticateClientToRvd ??
           DefaultArgs.authenticateClientToRvd,
       authenticateDeviceToRvd: partial.authenticateDeviceToRvd ??
@@ -233,7 +229,6 @@ class SshnpParams {
       SshnpArg.remoteSshdPortArg.name: remoteSshdPort,
       SshnpArg.idleTimeoutArg.name: idleTimeout,
       SshnpArg.addForwardsToTunnelArg.name: addForwardsToTunnel,
-      SshnpArg.sshAlgorithmArg.name: sshAlgorithm.toString(),
       SshnpArg.authenticateClientToRvdArg.name: authenticateClientToRvd,
       SshnpArg.authenticateDeviceToRvdArg.name: authenticateDeviceToRvd,
       SshnpArg.encryptRvdTrafficArg.name: encryptRvdTraffic,

--- a/packages/dart/noports_core/test/sshnp/models/sshnp_params_test.dart
+++ b/packages/dart/noports_core/test/sshnp/models/sshnp_params_test.dart
@@ -418,7 +418,6 @@ void main() {
             parsedParams.sshnpdAtSign, equals('@mySshnpdAtSign'.toLowerCase()));
         expect(parsedParams.host, equals('@myHost'));
         expect(parsedParams.device, equals('myDeviceName'));
-        expect(parsedParams.port, equals(1234));
         expect(parsedParams.localPort, equals(2345));
         expect(parsedParams.sendSshPublicKey, equals(true));
         expect(parsedParams.localSshOptions,
@@ -477,8 +476,6 @@ void main() {
         expect(argMap[SshnpArg.addForwardsToTunnelArg.name], equals(true));
         expect(argMap[SshnpArg.keyFileArg.name],
             equals('~/.atsign/@myAtsign_keys.atKeys'));
-        expect(argMap[SshnpArg.sshAlgorithmArg.name],
-            equals(SupportedSshAlgorithm.rsa.toString()));
       });
       test('SshnpParams.toJson', () {
         final params = SshnpParams(
@@ -936,8 +933,6 @@ void main() {
           '@myHost',
           '--${SshnpArg.deviceArg.name}',
           'myDeviceName',
-          '--${SshnpArg.portArg.name}',
-          '1234',
           '--${SshnpArg.localPortArg.name}',
           '2345',
           '--${SshnpArg.identityFileArg.name}',
@@ -956,8 +951,6 @@ void main() {
           'true',
           '--${SshnpArg.rootDomainArg.name}',
           'root.atsign.wtf',
-          '--${SshnpArg.localSshdPortArg.name}',
-          '4567',
           '--${SshnpArg.remoteSshdPortArg.name}',
           '2222',
           '--${SshnpArg.idleTimeoutArg.name}',
@@ -975,7 +968,6 @@ void main() {
         expect(params.sshnpdAtSign, equals('@mySshnpdAtSign'.toLowerCase()));
         expect(params.host, equals('@myHost'));
         expect(params.device, equals('myDeviceName'));
-        expect(params.port, equals(1234));
         expect(params.localPort, equals(2345));
         expect(params.identityFile, equals('.ssh/id_ed25519'));
         expect(params.identityPassphrase, equals('myPassphrase'));
@@ -986,7 +978,6 @@ void main() {
         expect(params.tunnelUsername, equals('myTunnelUsername'));
         expect(params.verbose, equals(true));
         expect(params.rootDomain, equals('root.atsign.wtf'));
-        expect(params.localSshdPort, equals(4567));
         expect(params.remoteSshdPort, equals(2222));
         expect(params.idleTimeout, equals(120));
         expect(params.addForwardsToTunnel, equals(true));

--- a/packages/dart/noports_core/test/sshnp/models/sshnp_params_test.dart
+++ b/packages/dart/noports_core/test/sshnp/models/sshnp_params_test.dart
@@ -26,7 +26,6 @@ void main() {
       expect(params.idleTimeout, isA<int>());
       expect(params.addForwardsToTunnel, isA<bool>());
       expect(params.atKeysFilePath, isA<String?>());
-      expect(params.sshAlgorithm, isA<SupportedSshAlgorithm>());
       expect(params.profileName, isA<String?>());
       expect(params.listDevices, isA<bool>());
       expect(params.toConfigLines(), isA<List<String>>());
@@ -162,14 +161,6 @@ void main() {
         expect(
             params.atKeysFilePath, equals('~/.atsign/@myAtsign_keys.atKeys'));
       });
-      test('SshnpParams.sshAlgorithm test', () {
-        final params = SshnpParams(
-            clientAtSign: '',
-            sshnpdAtSign: '',
-            host: '',
-            sshAlgorithm: SupportedSshAlgorithm.rsa);
-        expect(params.sshAlgorithm, equals(SupportedSshAlgorithm.rsa));
-      });
       test('SshnpParams.profileName test', () {
         final params = SshnpParams(
             clientAtSign: '',
@@ -212,7 +203,6 @@ void main() {
         expect(params.idleTimeout, equals(DefaultArgs.idleTimeout));
         expect(params.addForwardsToTunnel,
             equals(DefaultArgs.addForwardsToTunnel));
-        expect(params.sshAlgorithm, equals(DefaultArgs.sshAlgorithm));
       });
       test('SshnpParams.merge() test (overrides take priority)', () {
         final params = SshnpParams.merge(
@@ -261,7 +251,6 @@ void main() {
         expect(params.addForwardsToTunnel, equals(true));
         expect(
             params.atKeysFilePath, equals('~/.atsign/@myAtsign_keys.atKeys'));
-        expect(params.sshAlgorithm, equals(SupportedSshAlgorithm.rsa));
       });
       test('SshnpParams.merge() test (null coalesce values)', () {
         final params =
@@ -290,7 +279,6 @@ void main() {
         expect(params.idleTimeout, equals(DefaultArgs.idleTimeout));
         expect(params.addForwardsToTunnel,
             equals(DefaultArgs.addForwardsToTunnel));
-        expect(params.sshAlgorithm, equals(DefaultArgs.sshAlgorithm));
       });
       test('SshnpParams.fromJson() test', () {
         String json = '{'
@@ -340,7 +328,6 @@ void main() {
         expect(params.addForwardsToTunnel, equals(true));
         expect(
             params.atKeysFilePath, equals('~/.atsign/@myAtsign_keys.atKeys'));
-        expect(params.sshAlgorithm, equals(SupportedSshAlgorithm.rsa));
       });
       test('SshnpParams.fromPartial() test', () {
         final partial = SshnpPartialParams(
@@ -417,7 +404,6 @@ void main() {
           idleTimeout: 120,
           addForwardsToTunnel: true,
           atKeysFilePath: '~/.atsign/@myAtsign_keys.atKeys',
-          sshAlgorithm: SupportedSshAlgorithm.rsa,
         );
         final configLines = params.toConfigLines();
         // Since exact formatting is in question,
@@ -465,7 +451,6 @@ void main() {
           idleTimeout: 120,
           addForwardsToTunnel: true,
           atKeysFilePath: '~/.atsign/@myAtsign_keys.atKeys',
-          sshAlgorithm: SupportedSshAlgorithm.rsa,
         );
         final argMap = params.toArgMap();
         expect(argMap[SshnpArg.fromArg.name], equals('@myClientAtSign'));
@@ -516,7 +501,6 @@ void main() {
           idleTimeout: 120,
           addForwardsToTunnel: true,
           atKeysFilePath: '~/.atsign/@myAtsign_keys.atKeys',
-          sshAlgorithm: SupportedSshAlgorithm.rsa,
         );
         final json = params.toJson();
         final parsedParams = SshnpParams.fromJson(json);
@@ -543,7 +527,6 @@ void main() {
         expect(parsedParams.addForwardsToTunnel, equals(true));
         expect(parsedParams.atKeysFilePath,
             equals('~/.atsign/@myAtsign_keys.atKeys'));
-        expect(parsedParams.sshAlgorithm, equals(SupportedSshAlgorithm.rsa));
       });
     }); // group('SshnpParams functions')
   }); // group('SshnpParams')
@@ -817,7 +800,6 @@ void main() {
           idleTimeout: 120,
           addForwardsToTunnel: true,
           atKeysFilePath: '~/.atsign/@myAtsign_keys.atKeys',
-          sshAlgorithm: SupportedSshAlgorithm.rsa,
         );
         final configLines = params.toConfigLines();
         // Since exact formatting is in question,

--- a/packages/dart/sshnoports/bin/sshnp.dart
+++ b/packages/dart/sshnoports/bin/sshnp.dart
@@ -115,7 +115,6 @@ void main(List<String> args) async {
           rootDomain: params.rootDomain,
           storagePath: storageDir!.path,
         ),
-        legacyDaemon: argResults['legacy-daemon'] as bool,
         sshClient:
             SupportedSshClient.fromString(argResults['ssh-client'] as String),
       ).catchError((e) {

--- a/packages/dart/sshnoports/lib/src/create_sshnp.dart
+++ b/packages/dart/sshnoports/lib/src/create_sshnp.dart
@@ -12,7 +12,6 @@ Future<Sshnp> createSshnp(
   AtClient? atClient,
   AtClientGenerator? atClientGenerator,
   SupportedSshClient sshClient = DefaultExtendedArgs.sshClient,
-  bool legacyDaemon = DefaultExtendedArgs.legacyDaemon,
 }) async {
   atClient ??= await atClientGenerator?.call(params);
 
@@ -22,21 +21,6 @@ Future<Sshnp> createSshnp(
   if (atClient == null) {
     throw ArgumentError(
         'atClient must be provided or atClientGenerator must be provided');
-  }
-
-  if (legacyDaemon) {
-    if (params.authenticateDeviceToRvd ||
-        params.authenticateClientToRvd ||
-        params.encryptRvdTraffic ||
-        params.discoverDaemonFeatures) {
-      throw ArgumentError('When using --legacy-daemon, you must also'
-          ' use these flags: --no-ac --no-ad --no-et --no-ddf');
-    }
-    // ignore: deprecated_member_use
-    return Sshnp.unsigned(
-      atClient: atClient,
-      params: params,
-    );
   }
 
   switch (sshClient) {

--- a/packages/dart/sshnoports/lib/src/extended_arg_parser.dart
+++ b/packages/dart/sshnoports/lib/src/extended_arg_parser.dart
@@ -5,12 +5,10 @@ const sshClients = ['openssh', 'dart'];
 
 class DefaultExtendedArgs {
   static const sshClient = SupportedSshClient.openssh;
-  static const legacyDaemon = false;
   static const outputExecutionCommand = false;
 }
 
 const sshClientOption = 'ssh-client';
-const legacyDaemonFlag = 'legacy-daemon';
 const outputExecutionCommandFlag = 'output-execution-command';
 
 class ExtendedArgParser {
@@ -25,13 +23,6 @@ class ExtendedArgParser {
       help: 'What to use for outbound ssh connections',
       allowed: SupportedSshClient.values.map((e) => e.toString()),
       defaultsTo: DefaultExtendedArgs.sshClient.toString(),
-    );
-
-    parser.addFlag(
-      legacyDaemonFlag,
-      help: 'Request is to a legacy (< 4.0.0) noports daemon',
-      defaultsTo: DefaultExtendedArgs.legacyDaemon,
-      negatable: false,
     );
 
     parser.addFlag(
@@ -80,10 +71,6 @@ class ExtendedArgParser {
         coreArgs.removeAt(i); // remove the option e.g. --ssh-client
         coreArgs.removeAt(i); // remove the value e.g. "openssh"
       }
-    }
-
-    if (results!.wasParsed('legacy-daemon')) {
-      coreArgs.removeWhere((element) => element == '--$legacyDaemonFlag');
     }
 
     if (results!.wasParsed(outputExecutionCommandFlag)) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Removed legacy-daemon, port, local-sshd-port args from the parser
- Removed params.sshAlgorithm from the client core code (completely unused by everything)
- Removed legacy-daemon from createSshnp function
- Made a bunch of flags non-negatable (i.e. no `--[no-]` in the usage) (for all the ones that are off by default)
  - help
  - verbose
  - add-forwards-to-tunnel
  - send-ssh-public-key
  - discover-daemon-features

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: breaking arg changes to cli client
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
