### PR TITLE
fix: ephemeral key management plus a few other fixes

### DIFF
--- a/packages/dart/noports_core/lib/src/common/at_ssh_key_util/local_ssh_key_util.dart
+++ b/packages/dart/noports_core/lib/src/common/at_ssh_key_util/local_ssh_key_util.dart
@@ -54,8 +54,11 @@ class LocalSshKeyUtil implements AtSshKeyUtil {
     await Future.wait([
       files[0].create(recursive: true),
       files[1].create(recursive: true),
-      files[0].writeAsString(keyPair.privateKeyContents),
-      files[1].writeAsString(keyPair.publicKeyContents),
+    ]).catchError((e) => throw e);
+
+    await Future.wait([
+    files[0].writeAsString(keyPair.privateKeyContents),
+    files[1].writeAsString(keyPair.publicKeyContents),
     ]).catchError((e) => throw e);
 
     if (!Platform.isWindows) {

--- a/packages/dart/noports_core/lib/src/common/at_ssh_key_util/local_ssh_key_util.dart
+++ b/packages/dart/noports_core/lib/src/common/at_ssh_key_util/local_ssh_key_util.dart
@@ -52,6 +52,8 @@ class LocalSshKeyUtil implements AtSshKeyUtil {
     var files =
         _filesFromIdentifier(identifier: identifier ?? keyPair.identifier);
     await Future.wait([
+      files[0].create(recursive: true),
+      files[1].create(recursive: true),
       files[0].writeAsString(keyPair.privateKeyContents),
       files[1].writeAsString(keyPair.publicKeyContents),
     ]).catchError((e) => throw e);
@@ -115,7 +117,7 @@ class LocalSshKeyUtil implements AtSshKeyUtil {
     return AtSshKeyPair.fromPem(
       pemText,
       passphrase: passphrase,
-      directory: directory,
+      directory: workingDirectory,
       identifier: identifier,
     );
   }

--- a/packages/dart/noports_core/lib/src/common/file_system_utils.dart
+++ b/packages/dart/noports_core/lib/src/common/file_system_utils.dart
@@ -4,21 +4,27 @@ import 'package:path/path.dart' as path;
 /// Get the home directory or null if unknown.
 String? getHomeDirectory({bool throwIfNull = false}) {
   String? homeDir;
+  String envVarName = '';
   switch (Platform.operatingSystem) {
     case 'linux':
     case 'macos':
-      homeDir = Platform.environment['HOME'];
+      envVarName = 'HOME';
+      homeDir = Platform.environment[envVarName];
       break;
     case 'windows':
-      homeDir = Platform.environment['USERPROFILE'];
+      envVarName = 'USERPROFILE';
+      homeDir = Platform.environment[envVarName];
       break;
     default:
       // ios and fuchsia to use the ApplicationSupportDirectory
       homeDir = null;
+      if (throwIfNull) {
+        throw ('Unable to determine home directory on platform ${Platform.operatingSystem}');
+      }
       break;
   }
   if (throwIfNull && homeDir == null) {
-    throw ('Unable to determine your username: please set environment variable');
+    throw ('Unable to determine your home directory: please set $envVarName environment variable');
   }
   return homeDir;
 }
@@ -27,20 +33,26 @@ String? getHomeDirectory({bool throwIfNull = false}) {
 String? getUserName({bool throwIfNull = false}) {
   Map<String, String> envVars = Platform.environment;
   String? userName;
+  String envVarName = '';
   switch (Platform.operatingSystem) {
     case 'linux':
     case 'macos':
-      userName = envVars['USER'];
+      envVarName = 'USER';
+      userName = envVars[envVarName];
       break;
     case 'windows':
-      userName = envVars['USERNAME'];
+      envVarName = 'USERNAME';
+      userName = envVars[envVarName];
       break;
     default:
       userName = null;
+      if (throwIfNull) {
+        throw ('Unable to determine username on platform ${Platform.operatingSystem}');
+      }
       break;
   }
   if (throwIfNull && userName == null) {
-    throw ('Unable to determine your username: please set environment variable');
+    throw ('Unable to determine your username: please set environment variable $envVarName');
   }
   return userName;
 }

--- a/packages/dart/noports_core/lib/src/sshnp/impl/sshnp_dart_pure_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/impl/sshnp_dart_pure_impl.dart
@@ -115,15 +115,21 @@ class SshnpDartPureImpl extends SshnpCore
       sessionIVString: sshnpdChannel.sessionIVString,
     );
 
-    /// Start the initial tunnel
-    sendProgress('Starting tunnel session');
-    tunnelSshClient = await startInitialTunnelSession(
-      ephemeralKeyPairIdentifier: ephemeralKeyPair.identifier,
-      sshSocket: sshSocket,
-    );
-
-    /// Remove the key pair from the key utility
-    await keyUtil.deleteKeyPair(identifier: ephemeralKeyPair.identifier);
+    try {
+      /// Start the initial tunnel
+      sendProgress('Starting tunnel session');
+      tunnelSshClient = await startInitialTunnelSession(
+        ephemeralKeyPairIdentifier: ephemeralKeyPair.identifier,
+        sshSocket: sshSocket,
+      );
+    } finally {
+      /// Remove the key pair from the key utility
+      try {
+        await keyUtil.deleteKeyPair(identifier: ephemeralKeyPair.identifier);
+      } catch (e) {
+        logger.shout('Failed to delete ephemeral keyPair: $e');
+      }
+    }
 
     /// Ensure that we clean up after ourselves
     await callDisposal();

--- a/packages/dart/noports_core/lib/src/sshnp/impl/sshnp_openssh_local_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/impl/sshnp_openssh_local_impl.dart
@@ -119,15 +119,22 @@ class SshnpOpensshLocalImpl extends SshnpCore
     /// Add the key pair to the key utility
     await keyUtil.addKeyPair(keyPair: ephemeralKeyPair);
 
-    /// Start the initial tunnel
-    sendProgress('Starting tunnel session');
-    Process? bean = await startInitialTunnelSession(
-      ephemeralKeyPairIdentifier: ephemeralKeyPair.identifier,
-      localRvPort: localRvPort,
-    );
-
-    /// Remove the key pair from the key utility
-    await keyUtil.deleteKeyPair(identifier: ephemeralKeyPair.identifier);
+    Process? bean;
+    try {
+      /// Start the initial tunnel
+      sendProgress('Starting tunnel session');
+      bean = await startInitialTunnelSession(
+        ephemeralKeyPairIdentifier: ephemeralKeyPair.identifier,
+        localRvPort: localRvPort,
+      );
+    } finally {
+      /// Remove the key pair from the key utility.
+      try {
+        await keyUtil.deleteKeyPair(identifier: ephemeralKeyPair.identifier);
+      } catch (e) {
+        logger.shout('Failed to delete ephemeral keyPair: $e');
+      }
+    }
 
     /// Ensure that we clean up after ourselves
     await callDisposal();

--- a/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/srvd_channel.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/srvd_channel.dart
@@ -212,7 +212,7 @@ abstract class SrvdChannel<T> with AsyncInitialization, AtClientBindings {
       counter++;
       if (counter > 150) {
         logger.warning('Timed out waiting for srvd response');
-        throw ('Connection timeout to srvd $host service');
+        throw SshnpError('Connection timeout to srvd $host service');
       }
     }
   }

--- a/packages/dart/noports_core/lib/src/sshnp/util/ssh_session_handler/openssh_ssh_session_handler.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/ssh_session_handler/openssh_ssh_session_handler.dart
@@ -8,7 +8,8 @@ import 'package:noports_core/src/common/io_types.dart';
 import 'package:noports_core/src/common/openssh_binary_path.dart';
 import 'package:noports_core/sshnp_foundation.dart';
 
-mixin OpensshSshSessionHandler on SshnpCore implements SshSessionHandler<Process?> {
+mixin OpensshSshSessionHandler on SshnpCore
+    implements SshSessionHandler<Process?> {
   @override
   Future<Process?> startInitialTunnelSession({
     required String ephemeralKeyPairIdentifier,

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -604,15 +604,24 @@ class SshnpdImpl implements Sshnpd {
 
       LocalSshKeyUtil keyUtil = LocalSshKeyUtil();
 
-      AtSshKeyPair keyPair = await keyUtil.generateKeyPair(
+      /// Generate the ephemeral key pair which the client will use for the
+      /// initial tunnel ssh session
+      AtSshKeyPair tunnelKeyPair = await keyUtil.generateKeyPair(
           algorithm: sshAlgorithm, identifier: 'ephemeral_$sessionId');
 
       await keyUtil.authorizePublicKey(
-        sshPublicKey: keyPair.publicKeyContents,
+        sshPublicKey: tunnelKeyPair.publicKeyContents,
         localSshdPort: localSshdPort,
         sessionId: sessionId,
         permissions: ephemeralPermissions,
       );
+
+      /// Remove the ephemeral keypair from persistent storage
+      try {
+        await keyUtil.deleteKeyPair(identifier: tunnelKeyPair.identifier);
+      } catch (e) {
+        logger.shout('Failed to delete ephemeral keyPair: $e');
+      }
 
       /// - Send response message to the sshnp client which includes the
       ///   ephemeral private key
@@ -622,7 +631,7 @@ class SshnpdImpl implements Sshnpd {
         value: signAndWrapAndJsonEncode(atClient, {
           'status': 'connected',
           'sessionId': sessionId,
-          'ephemeralPrivateKey': keyPair.privateKeyContents,
+          'ephemeralPrivateKey': tunnelKeyPair.privateKeyContents,
           'sessionAESKey': sessionAESKeyEncrypted,
           'sessionIV': sessionIVEncrypted,
         }),

--- a/packages/dart/sshnoports/bin/sshnp.dart
+++ b/packages/dart/sshnoports/bin/sshnp.dart
@@ -60,6 +60,7 @@ void main(List<String> args) async {
     if (!Platform.isWindows) {
       if (storageDir != null) {
         if (storageDir!.existsSync()) {
+          // stderr.writeln('${DateTime.now()} : Cleaning up temporary files');
           storageDir!.deleteSync(recursive: true);
         }
       }
@@ -125,11 +126,13 @@ void main(List<String> args) async {
         atClientGenerator: (SshnpParams params) => createAtClientCli(
           homeDirectory: homeDirectory,
           atsign: params.clientAtSign,
-          atKeysFilePath: params.atKeysFilePath ?? getDefaultAtKeysFilePath(homeDirectory, params.clientAtSign),
+          atKeysFilePath: params.atKeysFilePath ??
+              getDefaultAtKeysFilePath(homeDirectory, params.clientAtSign),
           rootDomain: params.rootDomain,
           storagePath: storageDir!.path,
         ),
-        sshClient: SupportedSshClient.fromString(argResults['ssh-client'] as String),
+        sshClient:
+            SupportedSshClient.fromString(argResults['ssh-client'] as String),
       ).catchError((e) {
         if (e is SshnpError && e.stackTrace != null) {
           Error.throwWithStackTrace(e, e.stackTrace!);

--- a/packages/dart/sshnoports/bin/sshnp.dart
+++ b/packages/dart/sshnoports/bin/sshnp.dart
@@ -222,8 +222,8 @@ void main(List<String> args) async {
       exitProgram(exitCode: 1);
     }
   }, (Object error, StackTrace stackTrace) async {
-    if (error is SSHError) {
-      stderr.writeln('\n\nError: $error');
+    if (error is SSHError || error is SshnpError) {
+      stderr.writeln('\nError: $error');
     } else {
       stderr.writeln('\nError: $error');
       stderr.writeln('\nStack Trace: $stackTrace');


### PR DESCRIPTION
Fixes #750 

**- What I did**
- fix: make LocalSshKeyUtil.addKeyPair ensure that the full path to the temporary file location exists
- fix: make LocalSshKeyUtil.generateKeyPair set the correct directory in the created AtSshKeyPair
- fix: Make the openssh and dart sshnp impls remove the ssh ephemeralKeyPair as soon as it is no longer needed once the tunnel session has been created
- fix: Ensure SshnpdImpl removes the ephemeral tunnel ssh keyPairs that it generates
- chore: Clean up exception messages in file_system_utils.dart
- fix: If we got a timeout from the srvd, throw an SshnpError so that the the CLI client doesn't log a stack trace
- chore(style): run dart format

**- How I did it**
- See commits - Each change above is in its own commit
