### PR TITLE
fix: Handle problems caused by the tmux function in install.sh masking the tmux binary itself

### DIFF
--- a/packages/dart/sshnoports/bundles/shell/install.sh
+++ b/packages/dart/sshnoports/bundles/shell/install.sh
@@ -91,12 +91,12 @@ install_single_binary() {
     dest="$user_bin_dir"
   fi
   mkdir -p "$dest"
-  cp "$script_dir/$1" "$dest/$1"
-  echo "Installed $1 to $dest"
+  cp -f "$script_dir/$1" "$dest/$1"
+  echo "=> Installed $1 to $dest"
   if is_root & ! [ -f "$user_bin_dir/$1" ] ; then
     mkdir -p "$user_bin_dir"
     ln -sf "$dest/$1" "$user_bin_dir/$1"
-    echo "Linked $user_bin_dir/$1 to $dest"
+    echo "=> Linked $user_bin_dir/$1 to $dest"
   fi
 }
 
@@ -116,7 +116,7 @@ install_debug_binary() {
   fi
   mkdir -p "$dest"
   cp "$script_dir/debug/$1" "$bin_dir/debug_$1"
-  echo "Installed debug_$1 to $dest"
+  echo "=> Installed debug_$1 to $dest"
 }
 
 install_debug_binaries() {
@@ -218,13 +218,13 @@ install_headless_job() {
   crontab_contents=$(crontab -l 2>/dev/null)
 
   if echo "$crontab_contents" | grep -Fxq "$cron_entry"; then
-    echo "cron job already installed, killing any old $job_name.sh processes"
+    echo "=> cron job already installed, killing any old $job_name.sh processes"
     pids=$(pgrep "$command")
     if [ -n "$pids" ]; then
      echo "$pids" | xargs kill
     fi
   else
-     echo "Installing cron job: $cron_entry"
+     echo "=> Installing cron job: $cron_entry"
     (echo "$crontab_contents"; echo "$cron_entry") | crontab -;
   fi
 
@@ -249,7 +249,7 @@ headless() {
     sshnpd) install_headless_sshnpd;;
     srvd) install_headless_srvd;;
     *)
-      echo "Unknown headless job: $1";
+      echo "Error: Unknown headless job: $1";
       usage;
       exit 1;
   esac
@@ -276,6 +276,8 @@ install_tmux_service() {
   mkdir -p "$user_bin_dir"
 
   dest="$user_bin_dir/$service_name.sh"
+
+  # Only copy the "$service_name".sh script if it's not already there
   if ! [ -f "$dest" ]; then
     if is_root; then
       cp "$script_dir/headless/root_$service_name.sh" "$dest"
@@ -289,11 +291,16 @@ install_tmux_service() {
   crontab_contents=$(crontab -l 2>/dev/null)
 
   if echo "$crontab_contents" | grep -Fxq "$cron_entry"; then
-    echo "cron job already installed, killing old tmux session"
-    tmux kill-session -t "$service_name"
+    echo "=> Cron job already installed, will not re-install"
   else
-    echo "Installing cron job: $cron_entry"
+    echo "=> Installing cron job: $cron_entry"
     (echo "$crontab_contents"; echo "$cron_entry") | crontab -;
+  fi
+
+  if (command tmux has-session -t "$service_name" 2> /dev/null); then
+    echo "=> Found existing tmux session for $service_name - will kill and restart it"
+    command tmux kill-session -t "$service_name"
+    command tmux new-session -d -s "$service_name" && command tmux send-keys -t "$service_name" "$dest" C-m
   fi
 
   echo ""

--- a/packages/dart/sshnoports/bundles/shell/install.sh
+++ b/packages/dart/sshnoports/bundles/shell/install.sh
@@ -91,7 +91,14 @@ install_single_binary() {
     dest="$user_bin_dir"
   fi
   mkdir -p "$dest"
+  if test -f "$dest/$1"; then
+    if test -f "$dest/$1.old"; then
+      rm -f "$dest/$1.old" || echo "Failed to remove $dest/$1.old - aborting" && exit 1
+    fi
+    mv "$dest/$1" "$dest/$1.old" || echo "Failed to rename $dest/$1 to $dest/$1.old - aborting" && exit 1
+  fi
   cp -f "$script_dir/$1" "$dest/$1"
+
   echo "=> Installed $1 to $dest"
   if is_root & ! [ -f "$user_bin_dir/$1" ] ; then
     mkdir -p "$user_bin_dir"


### PR DESCRIPTION
Fixes #761 

**- What I did**
- fix: install.sh: Handle problems caused by the tmux function masking the tmux binary itself
- fix: install.sh:
  - When copying binaries during installation, rename existing binaries as they may be in use (which is a problem in, for example, Windows)
  - Exit the install script if either the rename of existing or the copying of new binaries fails
- fix: install.sh: for installs using tmux, separate the handling of crontab installation from the handling of tmux process killing
- feat: install.sh: If the installation killed a process running as a tmux session, then also restart it

**- How I did it**
- See file diff
- Note that I didn't rename the `tmux` function but instead used `command tmux` whenever needing to use the tmux command itself
- While mulling over all of this, I came to the opinion that just killing an existing tmux session might be unhelpful and that it would be more helpful to restart the tmux session if there was one there to kill. However I preserve the current behaviour of not starting the tmux session if it is not already running.