### PR TITLE
fix: remove sudoer assumption in install.sh; fix bugs in remove / rename part of install_single_binary

### DIFF
--- a/packages/dart/noports_core/lib/src/common/at_ssh_key_util/local_ssh_key_util.dart
+++ b/packages/dart/noports_core/lib/src/common/at_ssh_key_util/local_ssh_key_util.dart
@@ -57,8 +57,8 @@ class LocalSshKeyUtil implements AtSshKeyUtil {
     ]).catchError((e) => throw e);
 
     await Future.wait([
-    files[0].writeAsString(keyPair.privateKeyContents),
-    files[1].writeAsString(keyPair.publicKeyContents),
+      files[0].writeAsString(keyPair.privateKeyContents),
+      files[1].writeAsString(keyPair.publicKeyContents),
     ]).catchError((e) => throw e);
 
     if (!Platform.isWindows) {

--- a/packages/dart/noports_core/lib/src/srv/srv_impl.dart
+++ b/packages/dart/noports_core/lib/src/srv/srv_impl.dart
@@ -9,6 +9,7 @@ import 'package:cryptography/dart.dart';
 import 'package:dartssh2/dartssh2.dart';
 import 'package:meta/meta.dart';
 import 'package:noports_core/srv.dart';
+import 'package:noports_core/sshnp.dart';
 import 'package:socket_connector/socket_connector.dart';
 
 @visibleForTesting
@@ -62,7 +63,7 @@ class SrvImplExec implements Srv<Process> {
     String? command = await Srv.getLocalBinaryPath();
     String postfix = Platform.isWindows ? '.exe' : '';
     if (command == null) {
-      throw Exception(
+      throw SshnpError(
         'Unable to locate srv$postfix binary.\n'
         'N.B. sshnp is expected to be compiled and run from source, not via the dart command.',
       );

--- a/packages/dart/noports_core/test/sshnp/util/sshnpd_channel/sshnpd_channel_test.dart
+++ b/packages/dart/noports_core/test/sshnp/util/sshnpd_channel/sshnpd_channel_test.dart
@@ -312,8 +312,7 @@ void main() {
         when(
           () => mockAtClient.get(
             any<AtKey>(
-              that: predicate(
-                  (AtKey key) => key.key.startsWith('username.')),
+              that: predicate((AtKey key) => key.key.startsWith('username.')),
             ),
           ),
         ).thenAnswer((i) async => AtValue()..value = 'mySharedUsername');

--- a/packages/dart/sshnoports/bundles/shell/install.sh
+++ b/packages/dart/sshnoports/bundles/shell/install.sh
@@ -14,7 +14,9 @@ define_env() {
     user="$SUDO_USER"
     if [ -z "$user" ]; then
       user="root"
-    else # we are sudo-ing
+    else
+      # we are root, but via sudo
+      # so get home directory of SUDO_USER
       user_home=$(sudo -u "$user" sh -c 'echo $HOME')
     fi
   else

--- a/packages/dart/sshnoports/bundles/shell/install.sh
+++ b/packages/dart/sshnoports/bundles/shell/install.sh
@@ -5,6 +5,7 @@ is_root() {
   [ "$(id -u)" -eq 0 ]
 }
 
+user_home=$HOME
 define_env() {
   script_dir="$(dirname -- "$( readlink -f -- "$0"; )")"
   bin_dir="/usr/local/bin"
@@ -13,11 +14,12 @@ define_env() {
     user="$SUDO_USER"
     if [ -z "$user" ]; then
       user="root"
+    else # we are sudo-ing
+      user_home=$(sudo -u "$user" sh -c 'echo $HOME')
     fi
   else
     user="$USER"
   fi
-  user_home=$(sudo -u "$user" sh -c 'echo $HOME')
   user_bin_dir="$user_home/.local/bin"
   user_sshnpd_dir="$user_home/.sshnpd"
   user_log_dir="$user_sshnpd_dir/logs"
@@ -93,9 +95,21 @@ install_single_binary() {
   mkdir -p "$dest"
   if test -f "$dest/$1"; then
     if test -f "$dest/$1.old"; then
-      rm -f "$dest/$1.old" || echo "Failed to remove $dest/$1.old - aborting" && exit 1
+      if rm -f "$dest/$1.old"
+      then
+        echo "=> Removed $dest/$1.old"
+      else
+        echo "Failed to remove $dest/$1.old - aborting"
+        exit 1
+      fi
     fi
-    mv "$dest/$1" "$dest/$1.old" || echo "Failed to rename $dest/$1 to $dest/$1.old - aborting" && exit 1
+    if mv "$dest/$1" "$dest/$1.old"
+    then
+      echo "=> Renamed existing binary $dest/$1 to $dest/$1.old"
+    else
+      echo "Failed to rename $dest/$1 to $dest/$1.old - aborting"
+      exit 1
+    fi
   fi
   cp -f "$script_dir/$1" "$dest/$1"
 
@@ -103,7 +117,7 @@ install_single_binary() {
   if is_root & ! [ -f "$user_bin_dir/$1" ] ; then
     mkdir -p "$user_bin_dir"
     ln -sf "$dest/$1" "$user_bin_dir/$1"
-    echo "=> Linked $user_bin_dir/$1 to $dest"
+    echo "=> Linked $user_bin_dir/$1 to $dest/$1"
   fi
 }
 


### PR DESCRIPTION
**- What I did**
- fix: remove assumption in install.sh that the current user is a sudoer
- fix: fix buggy code I added to install_single_binary to (1) remove $binary.old if it exists (2) rename current $binary to $binary.old
- couple of small other things
  - chore: run dart format
  - fix: srv_impl.dart: throw an SshnpError rather than an Exception if the srv binary can't be found

**- How to verify it**
- Tested on MacOS as a normal user
- Tested on an Ubuntu VM as root
- Tested on an Ubuntu VM as a normal linux user (WITHOUT sudo permission)
- Tested on an Ubuntu VM as a normal linux user (WITH sudo permission)
- For each of the above, tested the following scenarios
  - New installation - i.e.
    - no srv or sshnpd in /usr/local/bin
    - no ~/.local/bin directory
  - Repeat installation
  - Remove ~/.local/bin and repeat installation 
  - Remove /usr/local/bin/srv* and /usr/local/bin/sshnpd* and repeat installation

