### PR TITLE
fix: profiles are refreshed when first sync after onboarding is completed

### DIFF
--- a/packages/dart/sshnp_flutter/lib/main.dart
+++ b/packages/dart/sshnp_flutter/lib/main.dart
@@ -6,6 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:sshnp_flutter/src/utility/platform_utility/platform_utililty.dart';
 
+import '../src/repository/authentication_repository.dart';
+
 final AtSignLogger _logger = AtSignLogger(AtEnv.appNamespace);
 
 Future<void> main() async {
@@ -16,6 +18,7 @@ Future<void> main() async {
   } catch (e) {
     _logger.finer('Environment failed to load from .env: ', e);
   }
+  await AuthenticationRepository().checkKeyChainFirstRun();
 
   PlatformUtility platformUtility = PlatformUtility.current();
   await platformUtility.configurePlatform();

--- a/packages/dart/sshnp_flutter/lib/src/presentation/screens/onboarding_screen.dart
+++ b/packages/dart/sshnp_flutter/lib/src/presentation/screens/onboarding_screen.dart
@@ -9,6 +9,7 @@ import 'package:path_provider/path_provider.dart' show getApplicationSupportDire
 import 'package:sshnp_flutter/src/controllers/navigation_controller.dart';
 import 'package:sshnp_flutter/src/utility/sizes.dart';
 
+import '../../repository/authentication_repository.dart';
 import '../../utility/constants.dart';
 
 class OnboardingScreen extends StatefulWidget {
@@ -106,12 +107,15 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                                   ),
                                 ),
                               );
+
                               switch (onboardingResult.status) {
                                 case AtOnboardingResultStatus.success:
                                   await initializeContactsService(rootDomain: AtEnv.rootDomain);
                                   if (context.mounted) {
                                     context.replaceNamed(AppRoute.home.name);
                                   }
+                                  await AuthenticationRepository().setFirstRun(true);
+
                                   break;
                                 case AtOnboardingResultStatus.error:
                                   if (context.mounted) {

--- a/packages/dart/sshnp_flutter/lib/src/presentation/widgets/home_screen_widgets/home_screen_core.dart
+++ b/packages/dart/sshnp_flutter/lib/src/presentation/widgets/home_screen_widgets/home_screen_core.dart
@@ -1,10 +1,16 @@
+import 'dart:developer';
+
+import 'package:at_onboarding_flutter/at_onboarding_flutter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../controllers/config_controller.dart';
+import '../../../repository/authentication_repository.dart';
+import '../../../utility/my_sync_progress_listener.dart';
 import '../../../utility/sizes.dart';
 import '../profile_screen_widgets/profile_bar/profile_bar.dart';
+import '../utility/custom_snack_bar.dart';
 
 class HomeScreenCore extends ConsumerStatefulWidget {
   const HomeScreenCore({super.key});
@@ -14,6 +20,25 @@ class HomeScreenCore extends ConsumerStatefulWidget {
 }
 
 class _HomeScreenCoreState extends ConsumerState<HomeScreenCore> {
+  @override
+  void initState() {
+    // TODO: implement initState
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) async {
+        AtClientManager.getInstance().atClient.syncService.addProgressListener(MySyncProgressListener(ref));
+        final isFirstRun = await AuthenticationRepository().checkFirstRun();
+        log(isFirstRun.toString());
+        if (isFirstRun) {
+          CustomSnackBar.notification(
+            content: 'Syncing profiles...',
+            duration: const Duration(seconds: 3),
+          );
+        }
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final strings = AppLocalizations.of(context)!;

--- a/packages/dart/sshnp_flutter/lib/src/repository/authentication_repository.dart
+++ b/packages/dart/sshnp_flutter/lib/src/repository/authentication_repository.dart
@@ -31,14 +31,31 @@ class AuthenticationRepository {
   static var atContactService = ContactService();
 
   /// This function will clear the keychain if the app installed newly again.
-  Future<void> checkFirstRun() async {
+  Future<void> checkKeyChainFirstRun() async {
     _logger.finer('Checking for keychain entries to clear');
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    if (prefs.getBool('first_run') ?? true) {
+    if (prefs.getBool('keyChainFirstRun') ?? true) {
       _logger.finer('First run detected. Clearing keychain');
       await clearKeychainEntries();
-      await prefs.setBool('first_run', false);
+      await prefs.setBool('keyChainFirstRun', false);
     }
+  }
+
+  /// This function will check for first run.
+  Future<bool> checkFirstRun() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    if (prefs.getBool('firstRun') ?? true) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /// This function will set first run.
+  /// setting first run to false will prevent the app from firstRun sync.
+  Future<void> setFirstRun(bool status) async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('firstRun', status);
   }
 
   Future<void> clearKeychainEntries() async {

--- a/packages/dart/sshnp_flutter/lib/src/utility/extensions/go_router_extensions.dart
+++ b/packages/dart/sshnp_flutter/lib/src/utility/extensions/go_router_extensions.dart
@@ -1,0 +1,11 @@
+import 'package:go_router/go_router.dart';
+
+extension GoRouterExtension on GoRouter {
+  String get location {
+    final RouteMatch lastMatch = routerDelegate.currentConfiguration.last;
+    final RouteMatchList matchList =
+        lastMatch is ImperativeRouteMatch ? lastMatch.matches : routerDelegate.currentConfiguration;
+    final String location = matchList.uri.toString();
+    return location;
+  }
+}

--- a/packages/dart/sshnp_flutter/lib/src/utility/my_sync_progress_listener.dart
+++ b/packages/dart/sshnp_flutter/lib/src/utility/my_sync_progress_listener.dart
@@ -1,0 +1,42 @@
+import 'dart:developer';
+
+import 'package:at_onboarding_flutter/at_onboarding_flutter.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:sshnp_flutter/src/presentation/widgets/utility/custom_snack_bar.dart';
+import 'package:sshnp_flutter/src/utility/extensions/go_router_extensions.dart';
+
+import '../controllers/config_controller.dart';
+import '../controllers/navigation_controller.dart';
+import '../repository/authentication_repository.dart';
+import '../repository/navigation_repository.dart';
+
+class MySyncProgressListener extends SyncProgressListener {
+  final WidgetRef ref;
+
+  MySyncProgressListener(this.ref);
+  @override
+  void onSyncProgressEvent(SyncProgress syncProgress) async {
+    final context = NavigationRepository.navKey.currentContext!;
+    final currentRoute = GoRouter.of(context).location;
+    log(currentRoute);
+
+    final isSyncStatusSuccess = syncProgress.syncStatus == SyncStatus.success;
+    final isSyncStatusFailure = syncProgress.syncStatus == SyncStatus.failure;
+    final isCurrentRouteHome = currentRoute == '/${AppRoute.home.name}';
+
+    final isFirstRun = await AuthenticationRepository().checkFirstRun();
+
+    if (isSyncStatusSuccess && isCurrentRouteHome && isFirstRun) {
+      await ref.read(configListController.notifier).refresh();
+      CustomSnackBar.notification(content: 'Sync Completed');
+      await AuthenticationRepository().setFirstRun(false);
+      log('Initial Sync completed');
+    } else if (isSyncStatusFailure && isCurrentRouteHome && isFirstRun) {
+      await ref.read(configListController.notifier).refresh();
+      CustomSnackBar.notification(content: 'Sync failed... Retrying');
+
+      log('Initial Sync failed');
+    }
+  }
+}


### PR DESCRIPTION
…eted

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
    Fixes #754 
    Clear KeyChain the first time the app is run
**- How I did it**
   Add a progress listener that refreshes the profiles controller when sync is completed, this is only done after onboarding when the user is on the Home Screen.
**- How to verify it**

1. Run the app, 
2. Onboard 
3. A snackbar will be show stating if sync failed, in progress or completed

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Profiles are refreshed when the first sync after onboarding is completed