### PR TITLE
fix: bool fields remains the value the user selected

### DIFF
--- a/packages/dart/sshnp_flutter/lib/src/presentation/widgets/profile_screen_widgets/profile_form/profile_form_desktop_view.dart
+++ b/packages/dart/sshnp_flutter/lib/src/presentation/widgets/profile_screen_widgets/profile_form/profile_form_desktop_view.dart
@@ -52,7 +52,7 @@ class _ProfileFormState extends ConsumerState<ProfileFormDesktopView> {
   void onSubmit(SshnpParams oldConfig) async {
     if (_formkey.currentState!.validate()) {
       _formkey.currentState!.save();
-      SshnpParams config = SshnpParams.merge(SshnpParams.empty(), newConfig);
+      SshnpParams config = SshnpParams.merge(oldConfig, newConfig);
 
       // get the controller for the profile that is about to be saved. Since this profile is not saved a log will be printed stating that the profile does not exist in keystore.
       final controller = ref.read(configFamilyController(newConfig.profileName!).notifier);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Allow bool field in the profile form to reuse the user previously provide value instead of the default.
**- How I did it**
Updated the submit method to reuse the oldConfig values instead on the default SshnpParams value.
**- How to verify it**

1.  Run the app
2. Edit a profile bool fields multiple time, the value should always remain as what you selected.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
bool field in the profile form to reuse the user previously provide value instead of the default.
