### PR TITLE
776 onboarding widget too large for the minimum desktop size

### DIFF
--- a/packages/dart/sshnp_flutter/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/dart/sshnp_flutter/macos/Runner.xcodeproj/project.pbxproj
@@ -574,7 +574,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 5XUSS6C2DF;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "SSH No Ports Desktop";
@@ -711,7 +711,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 5XUSS6C2DF;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "SSH No Ports Desktop";
@@ -740,7 +740,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 5XUSS6C2DF;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "SSH No Ports Desktop";

--- a/packages/dart/sshnp_flutter/macos/Runner/Base.lproj/MainMenu.xib
+++ b/packages/dart/sshnp_flutter/macos/Runner/Base.lproj/MainMenu.xib
@@ -334,7 +334,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <rect key="contentRect" x="335" y="390" width="800" height="600"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
-            <value key="minSize" type="size" width="671" height="467"/>
+            <value key="minSize" type="size" width="671" height="505"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="800" height="600"/>
                 <autoresizingMask key="autoresizingMask"/>

--- a/packages/dart/sshnp_flutter/pubspec.yaml
+++ b/packages/dart/sshnp_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sshnp_flutter
 description: ssh to any remove device using atsign
-version: 1.0.0+2
+version: 1.0.0+3
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Updated Minimum Desktop Size
- Updated build number

**- How I did it**
Updated pubspec.yaml and the macOS directory files in Xcode

**- How to verify it**

1. Run the app
2. Press the reset button
3. Reduce the app to the minimum size
4. Onboard and all of the onboarding widget should be visible on the screen.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

- Updated Minimum Desktop Size
- Updated build number