### PR TITLE
feat: create slim version of sshnpd docker container that connects to hosts sshd

### DIFF
--- a/.github/workflows/dockerhub_sshnpd.yml
+++ b/.github/workflows/dockerhub_sshnpd.yml
@@ -18,6 +18,8 @@ jobs:
             dockerfile: ./packages/dart/sshnoports/tools/Dockerfile
           - name: activate_sshnpd
             dockerfile: ./packages/dart/sshnoports/tools/Dockerfile.activate
+          - name: sshnpd-slim
+            dockerfile: ./packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnp-slim
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnp-slim
@@ -1,0 +1,45 @@
+FROM dart:3.2.5@sha256:66e45c56249e3c0666c100d29e95c7d14cd0807bee9bda3513e8e4d5efc4f047 AS buildimage
+ENV PACKAGEDIR=packages/dart/sshnoports
+ENV BINARYDIR=/usr/local/at
+ENV HOMEDIR=/atsign
+ENV USER_ID=1024
+ENV GROUP_ID=1024
+SHELL ["/bin/bash", "-c"]
+WORKDIR /app
+COPY . .
+RUN \
+  set -eux ; \
+  mkdir -p $HOMEDIR/storage ; \
+  mkdir -p $HOMEDIR/config ; \
+  mkdir -p /etc/cacert ; \
+  mkdir -p ${BINARYDIR} ; \
+  #cp cacert/cacert.pem /etc/cacert ; \
+  cp ssh-keygen/ssh-keygen ${BINARYDIR} ; \
+  #mkdir -p /archive ; \
+  addgroup --gid $GROUP_ID atsign ; \
+  useradd --system --uid $USER_ID --gid $GROUP_ID --shell /bin/bash \
+    --home $HOMEDIR atsign ; \
+  chown -R atsign:atsign $HOMEDIR ; \
+  cd ${PACKAGEDIR}; \
+  dart pub get ; \
+  dart pub update ; \
+  dart compile exe bin/sshnpd.dart -o ${BINARYDIR}/sshnpd ; \
+  dart compile exe bin/srv.dart -o ${BINARYDIR}/srv
+
+
+# Second stage of build FROM scratch
+FROM scratch
+ENV PATH=/usr/local/at
+ENV USER=atsign
+COPY --from=buildimage /atsign /atsign/
+COPY --from=buildimage /runtime/ /
+COPY --from=buildimage /lib/ /
+COPY --from=buildimage /etc/passwd /etc/passwd
+COPY --from=buildimage /etc/group /etc/group
+COPY --from=buildimage /etc/cacert /etc/cacert
+WORKDIR /usr/local/at
+COPY --from=buildimage  /usr/local/at/sshnpd /usr/local/at/
+COPY --from=buildimage  /usr/local/at/srv /usr/local/at/
+COPY --from=buildimage  /usr/local/at/ssh-keygen /usr/local/at/
+USER atsign
+ENTRYPOINT ["/usr/local/at/sshnpd"]

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
@@ -15,18 +15,18 @@ RUN \
   mkdir -p $HOMEDIR/config ; \
   mkdir -p /etc/cacert ; \
   mkdir -p ${BINARYDIR} ; \
-  #cp cacert/cacert.pem /etc/cacert ; \
-  #cp ssh-keygen/ssh-keygen ${BINARYDIR} ; \
-  #mkdir -p /archive ; \
+  # create atsign account
   addgroup --gid $GROUP_ID atsign ; \
   useradd --system --uid $USER_ID --gid $GROUP_ID --shell /bin/bash \
     --home $HOMEDIR atsign ; \
   chown -R atsign:atsign $HOMEDIR ; \
-  # create static ssh-keygen
+  # build static ssh-keygen
   apt update && apt install -y curl gcc make autoconf ; \
   cd ${OPENSSH} ; \
   ./static-openssh.sh ; \
   cp build/openssh-portable*/ssh-keygen ${BINARYDIR}/ ; \ 
+  chmod 755 ${BINARYDIR}/ssh-keygen ; \
+  # build sshnpd
   cd ${WORKDIR}/${PACKAGEDIR}; \
   dart pub get ; \
   dart pub update ; \
@@ -40,7 +40,6 @@ ENV PATH=/usr/local/at
 ENV USER=atsign
 COPY --from=buildimage /atsign /atsign/
 COPY --from=buildimage /runtime/ /
-#COPY --from=buildimage /lib/ /
 COPY --from=buildimage /etc/ssl/certs/ /etc/ssl/certs/
 COPY --from=buildimage /etc/passwd /etc/passwd
 COPY --from=buildimage /etc/group /etc/group

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
@@ -5,8 +5,8 @@
 
 # Note dart:beta needs to be used when using M1 mac as known bug causes
 # crash dump otherwise, can move back to standard builds if on Linux/Windows
-# crash still hapens on arm build so remove that build on M1 too
-# 02/05/2024
+# crash still happens on arm build so remove that build on M1 too
+# as of 5th Feb 2024 - Will check state as 3.3 Stable is released
 #FROM dart:beta-sdk AS buildimage
 
 FROM dart:3.2.6@sha256:63cccf40dda6d2481a3d347f4e23081bd8bac707506fde9d6913de4a513533cd  AS buildimage
@@ -53,7 +53,6 @@ ENV PATH=/usr/local/at
 ENV USER=atsign
 COPY --from=buildimage /atsign /atsign/
 COPY --from=buildimage /runtime/ /
-COPY --from=buildimage /etc/ssl/certs/ /etc/ssl/certs/
 COPY --from=buildimage /etc/passwd /etc/passwd
 COPY --from=buildimage /etc/group /etc/group
 COPY --from=buildimage /etc/cacert /etc/cacert

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
@@ -30,7 +30,6 @@ RUN \
   cd ${WORKDIR}/${PACKAGEDIR}; \
   dart pub get ; \
   dart pub update ; \
-  dart pub upgrade : \
   dart compile exe bin/sshnpd.dart -o ${BINARYDIR}/sshnpd ; \
   dart compile exe bin/srv.dart -o ${BINARYDIR}/srv ; \
   # create atsign account

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
@@ -1,14 +1,15 @@
 # To build using docker buildx
 # docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v7 \
-# --tag cconstab/sshnpd-colin-slim-multi:latest  \
+# --tag <YOUR DOCKERHUB ID>/sshnpd-slim-multi:latest  \
 # -f packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim .
 
 # Note dart:beta needs to be used when using M1 mac as known bug causes
 # crash dump otherwise, can move back to standard builds if on Linux/Windows
-# crash still hapens on arm build 
+# crash still hapens on arm build so remove that build on M1 too
 # 02/05/2024
+#FROM dart:beta-sdk AS buildimage
 
-FROM dart:beta-sdk AS buildimage
+FROM dart:3.2.5@sha256:66e45c56249e3c0666c100d29e95c7d14cd0807bee9bda3513e8e4d5efc4f047
 ENV PACKAGEDIR=packages/dart/sshnoports
 ENV OPENSSH=tools/static-openssh
 ENV BINARYDIR=/usr/local/at
@@ -30,7 +31,7 @@ RUN \
   useradd --system --uid $USER_ID --gid $GROUP_ID --shell /bin/bash \
     --home $HOMEDIR atsign ; \
   chown -R atsign:atsign $HOMEDIR ; \
-  # build static ssh-keygen
+  # build static openssh binaries
   apt update && apt install -y curl gcc make autoconf ; \
   cd ${OPENSSH} ; \
   ./static-openssh.sh ; \

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
@@ -25,6 +25,7 @@ RUN \
   cd ${OPENSSH} ; \
   ./static-openssh.sh ; \
   cp build/openssh-portable*/ssh-keygen ${BINARYDIR}/ ; \ 
+  cp build/openssh-portable*/ssh ${BINARYDIR}/ ; \
   chmod 755 ${BINARYDIR}/ssh-keygen ; \
   chmod 755 ${BINARYDIR}/ssh ; \
   # build sshnpd

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
@@ -1,6 +1,6 @@
 # To build using docker buildx
-# docker buildx build --push --platform linux/amd64,linux/arm64 \
-# --tag cconstab/sshnpd-colin-slim-multi:mac  \
+# docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v7 \
+# --tag cconstab/sshnpd-colin-slim-multi:latest  \
 # -f packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim .
 
 # Note dart:beta needs to be used when using M1 mac as known bug causes

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
@@ -9,7 +9,7 @@
 # 02/05/2024
 #FROM dart:beta-sdk AS buildimage
 
-FROM dart:3.2.5@sha256:66e45c56249e3c0666c100d29e95c7d14cd0807bee9bda3513e8e4d5efc4f047
+FROM dart:3.2.5@sha256:66e45c56249e3c0666c100d29e95c7d14cd0807bee9bda3513e8e4d5efc4f047 AS buildimage
 ENV PACKAGEDIR=packages/dart/sshnoports
 ENV OPENSSH=tools/static-openssh
 ENV BINARYDIR=/usr/local/at

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
@@ -26,6 +26,13 @@ RUN \
   mkdir -p $HOMEDIR/config ; \
   mkdir -p /etc/cacert ; \
   mkdir -p ${BINARYDIR} ; \
+  # build sshnpd
+  cd ${WORKDIR}/${PACKAGEDIR}; \
+  dart pub get ; \
+  dart pub update ; \
+  dart pub upgrade : \
+  dart compile exe bin/sshnpd.dart -o ${BINARYDIR}/sshnpd ; \
+  dart compile exe bin/srv.dart -o ${BINARYDIR}/srv ; \
   # create atsign account
   addgroup --gid $GROUP_ID atsign ; \
   useradd --system --uid $USER_ID --gid $GROUP_ID --shell /bin/bash \
@@ -38,13 +45,7 @@ RUN \
   cp build/openssh-portable*/ssh-keygen ${BINARYDIR}/ ; \ 
   cp build/openssh-portable*/ssh ${BINARYDIR}/ ; \
   chmod 755 ${BINARYDIR}/ssh-keygen ; \
-  chmod 755 ${BINARYDIR}/ssh ; \
-  # build sshnpd
-  cd ${WORKDIR}/${PACKAGEDIR}; \
-  dart pub get ; \
-  dart pub update ; \
-  dart compile exe bin/sshnpd.dart -o ${BINARYDIR}/sshnpd ; \
-  dart compile exe bin/srv.dart -o ${BINARYDIR}/srv
+  chmod 755 ${BINARYDIR}/ssh 
 
 
 # Second stage of build FROM scratch

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
@@ -9,7 +9,7 @@
 # 02/05/2024
 #FROM dart:beta-sdk AS buildimage
 
-FROM dart:3.2.5@sha256:66e45c56249e3c0666c100d29e95c7d14cd0807bee9bda3513e8e4d5efc4f047 AS buildimage
+FROM dart:3.2.6@sha256:63cccf40dda6d2481a3d347f4e23081bd8bac707506fde9d6913de4a513533cd  AS buildimage
 ENV PACKAGEDIR=packages/dart/sshnoports
 ENV OPENSSH=tools/static-openssh
 ENV BINARYDIR=/usr/local/at

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
@@ -5,6 +5,7 @@
 
 # Note dart:beta needs to be used when using M1 mac as known bug causes
 # crash dump otherwise, can move back to standard builds if on Linux/Windows
+# crash still hapens on arm build 
 # 02/05/2024
 
 FROM dart:beta-sdk AS buildimage

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
@@ -1,7 +1,9 @@
 FROM dart:3.2.5@sha256:66e45c56249e3c0666c100d29e95c7d14cd0807bee9bda3513e8e4d5efc4f047 AS buildimage
 ENV PACKAGEDIR=packages/dart/sshnoports
+ENV OPENSSH=tools/static-openssh
 ENV BINARYDIR=/usr/local/at
 ENV HOMEDIR=/atsign
+ENV WORKDIR=/app
 ENV USER_ID=1024
 ENV GROUP_ID=1024
 SHELL ["/bin/bash", "-c"]
@@ -14,13 +16,18 @@ RUN \
   mkdir -p /etc/cacert ; \
   mkdir -p ${BINARYDIR} ; \
   #cp cacert/cacert.pem /etc/cacert ; \
-  cp ssh-keygen/ssh-keygen ${BINARYDIR} ; \
+  #cp ssh-keygen/ssh-keygen ${BINARYDIR} ; \
   #mkdir -p /archive ; \
   addgroup --gid $GROUP_ID atsign ; \
   useradd --system --uid $USER_ID --gid $GROUP_ID --shell /bin/bash \
     --home $HOMEDIR atsign ; \
   chown -R atsign:atsign $HOMEDIR ; \
-  cd ${PACKAGEDIR}; \
+  # create static ssh-keygen
+  apt update && apt install -y curl gcc make autoconf ; \
+  cd ${OPENSSH} ; \
+  ./static-openssh.sh ; \
+  cp build/openssh-portable*/ssh-keygen ${BINARYDIR}/ ; \ 
+  cd ${WORKDIR}/${PACKAGEDIR}; \
   dart pub get ; \
   dart pub update ; \
   dart compile exe bin/sshnpd.dart -o ${BINARYDIR}/sshnpd ; \
@@ -33,7 +40,8 @@ ENV PATH=/usr/local/at
 ENV USER=atsign
 COPY --from=buildimage /atsign /atsign/
 COPY --from=buildimage /runtime/ /
-COPY --from=buildimage /lib/ /
+#COPY --from=buildimage /lib/ /
+COPY --from=buildimage /etc/ssl/certs/ /etc/ssl/certs/
 COPY --from=buildimage /etc/passwd /etc/passwd
 COPY --from=buildimage /etc/group /etc/group
 COPY --from=buildimage /etc/cacert /etc/cacert

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
@@ -26,6 +26,7 @@ RUN \
   ./static-openssh.sh ; \
   cp build/openssh-portable*/ssh-keygen ${BINARYDIR}/ ; \ 
   chmod 755 ${BINARYDIR}/ssh-keygen ; \
+  chmod 755 ${BINARYDIR}/ssh ; \
   # build sshnpd
   cd ${WORKDIR}/${PACKAGEDIR}; \
   dart pub get ; \
@@ -48,5 +49,6 @@ WORKDIR /usr/local/at
 COPY --from=buildimage  /usr/local/at/sshnpd /usr/local/at/
 COPY --from=buildimage  /usr/local/at/srv /usr/local/at/
 COPY --from=buildimage  /usr/local/at/ssh-keygen /usr/local/at/
+COPY --from=buildimage  /usr/local/at/ssh /usr/local/at/
 USER atsign
 ENTRYPOINT ["/usr/local/at/sshnpd"]

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
@@ -39,7 +39,7 @@ RUN \
   chown -R atsign:atsign $HOMEDIR ; \
   # build static openssh binaries
   apt update && apt install -y curl gcc make autoconf ; \
-  cd ${OPENSSH} ; \
+  cd ${WORKDIR}/${OPENSSH} ; \
   ./static-openssh.sh ; \
   cp build/openssh-portable*/ssh-keygen ${BINARYDIR}/ ; \ 
   cp build/openssh-portable*/ssh ${BINARYDIR}/ ; \

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
@@ -1,4 +1,13 @@
-FROM dart:3.2.5@sha256:66e45c56249e3c0666c100d29e95c7d14cd0807bee9bda3513e8e4d5efc4f047 AS buildimage
+# To build using docker buildx
+# docker buildx build --push --platform linux/amd64,linux/arm64 \
+# --tag cconstab/sshnpd-colin-slim-multi:mac  \
+# -f packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim .
+
+# Note dart:beta needs to be used when using M1 mac as known bug causes
+# crash dump otherwise, can move back to standard builds if on Linux/Windows
+# 02/05/2024
+
+FROM dart:beta-sdk AS buildimage
 ENV PACKAGEDIR=packages/dart/sshnoports
 ENV OPENSSH=tools/static-openssh
 ENV BINARYDIR=/usr/local/at

--- a/tools/static-openssh/static-openssh.sh
+++ b/tools/static-openssh/static-openssh.sh
@@ -41,7 +41,7 @@ curl --output $dist/openssl-$OPENSSL_VERSION.tar.gz --location https://www.opens
 gzip -dc $dist/openssl-*.tar.gz |(cd "$build" && tar xf -)
 fi
 cd "$build"/openssl-*
-./config --prefix="$root" no-shared no-tests
+./config --prefix="$root"  no-shared no-tests
 make
 make install
 cd "$top"
@@ -64,6 +64,6 @@ sed \
 ; 
 export PATH=$root/bin:$PATH 
 autoreconf
-./configure LIBS="-lpthread" "--prefix=$root" "--exec-prefix=$root" --with-privsep-user=nobody --with-privsep-path="$prefix/var/empty" "--with-ssl-dir=$root"
+./configure LIBS="-lpthread"  "--with-ldflags=-static" "--prefix=$root" "--exec-prefix=$root" --with-privsep-user=nobody --with-privsep-path="$prefix/var/empty" "--with-ssl-dir=$root"
 make
 cd "$top"

--- a/tools/static-openssh/static-openssh.sh
+++ b/tools/static-openssh/static-openssh.sh
@@ -4,7 +4,7 @@ set -uex
 umask 0077
 
 ZLIB_VERSION=1.3.1
-OPENSSL_VERSION=3.2.0
+OPENSSL_VERSION=3.2.1
 OPENSSH_VERSION=V_9_6_P1
 
 prefix="/opt/openssh"

--- a/tools/static-openssh/static-openssh.sh
+++ b/tools/static-openssh/static-openssh.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -uex
+umask 0077
+
+ZLIB_VERSION=1.3.1
+OPENSSL_VERSION=3.2.0
+OPENSSH_VERSION=V_9_6_P1
+
+prefix="/opt/openssh"
+top="$(pwd)"
+root="$top/root"
+build="$top/build"
+dist="$top/dist"
+
+export "CPPFLAGS=-I$root/include -L. -fPIC"
+export "CFLAGS=-I$root/include -L. -fPIC"
+export "LDFLAGS=-L$root/lib -L$root/lib64"
+
+#COMMENT THIS for debugging the script. Each stage will cache download and build
+#rm -rf "$root" "$build" "$dist"
+mkdir -p "$root" "$build" "$dist"
+
+if [ ! -f "build/zlib-$ZLIB_VERSION/minigzip" ]; then
+echo "---- Building ZLIB -----"
+if [ ! -f "$dist/zlib-$ZLIB_VERSION.tar.gz" ]; then
+curl --output $dist/zlib-$ZLIB_VERSION.tar.gz --location https://zlib.net/zlib-$ZLIB_VERSION.tar.gz
+gzip -dc $dist/zlib-*.tar.gz |(cd "$build" && tar xf -)
+fi
+cd "$build"/zlib-*
+./configure --prefix="$root" --static
+make
+make install
+cd "$top"
+fi
+
+if [ ! -f "build/openssl-$OPENSSL_VERSION/wow" ]; then
+echo "---- Building OpenSSL -----"
+if [ ! -f "$dist/openssl-$OPENSSL_VERSION.tar.gz" ]; then
+curl --output $dist/openssl-$OPENSSL_VERSION.tar.gz --location https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
+gzip -dc $dist/openssl-*.tar.gz |(cd "$build" && tar xf -)
+fi
+cd "$build"/openssl-*
+./config --prefix="$root" no-shared no-tests
+make
+make install
+cd "$top"
+fi
+
+if [ ! -f "$dist/openssh-$OPENSSH_VERSION.tar.gz" ]; then
+curl --output $dist/openssh-$OPENSSH_VERSION.tar.gz --location https://github.com/openssh/openssh-portable/archive/refs/tags/$OPENSSH_VERSION.tar.gz
+fi
+gzip -dc $dist/openssh-*.tar.gz |(cd "$build" && tar xf -)
+cd "$build"/openssh-*
+cp -p "$root"/lib/*.a .
+[ -f sshd_config.orig ] || cp -p sshd_config sshd_config.orig
+sed \
+  -e 's/^#\(PubkeyAuthentication\) .*/\1 yes/' \
+  -e '/^# *Kerberos/d' \
+  -e '/^# *GSSAPI/d' \
+  -e 's/^#\([A-Za-z]*Authentication\) .*/\1 no/' \
+  sshd_config.orig \
+  >sshd_config \
+; 
+export PATH=$root/bin:$PATH 
+autoreconf
+./configure LIBS="-lpthread" "--prefix=$root" "--exec-prefix=$root" --with-privsep-user=nobody --with-privsep-path="$prefix/var/empty" "--with-ssl-dir=$root"
+make
+cd "$top"

--- a/tools/static-openssh/static-openssh.sh
+++ b/tools/static-openssh/static-openssh.sh
@@ -41,7 +41,13 @@ curl --output $dist/openssl-$OPENSSL_VERSION.tar.gz --location https://www.opens
 gzip -dc $dist/openssl-*.tar.gz |(cd "$build" && tar xf -)
 fi
 cd "$build"/openssl-*
-./config --prefix="$root"  no-shared no-tests
+  CPU=$(uname -m)
+  if [[ $CPU == "armv7l" ]]
+     then  
+     ./Configure linux-armv4 --prefix="$root"  no-shared no-tests
+     else
+     ./config --prefix="$root"  no-shared no-tests
+  fi
 make
 make install
 cd "$top"

--- a/tools/static-openssh/static-openssh.sh
+++ b/tools/static-openssh/static-openssh.sh
@@ -41,6 +41,7 @@ curl --output $dist/openssl-$OPENSSL_VERSION.tar.gz --location https://www.opens
 gzip -dc $dist/openssl-*.tar.gz |(cd "$build" && tar xf -)
 fi
 cd "$build"/openssl-*
+# Debian 12 / Ubuntu 20.x.x break the autoconf in ./config on armv7 devices
   CPU=$(uname -m)
   if [[ $CPU == "armv7l" ]]
      then  


### PR DESCRIPTION
**- What I did**
 Created a docker container that holds sshnpd srv and statically linked versions of ssh and ssh-keygen for x86/Arm65/ArmV7
**- How I did it**
Created Dockerfile that builds sshnpd and srv, wrote script that builds openssh and libs into static binaries.
Isolated bugs in the builds of openssh in Docker on Armv7
Added build to the existing GitHub docker build action
**- How to verify it**
Built manually and tested - to be documented on noports.com
running container using the --host and --user arguments on docker run to point the containers localhost to the hosts and mounting ~/ as /atsign in the container allows the container to provide access to the ssh daemon on the host.
**- Description for the changelog**

 slim version of sshnpd docker container that connects to hosts sshd (typically 34mb as against 300mb for full container)