### PR TITLE
build: update socket_connector dependency to published version 2.1.0

### DIFF
--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -29,10 +29,6 @@ dependency_overrides:
     git:
       ref: gkc/show-aliases-in-usage
       url: https://github.com/gkc/args
-  socket_connector:
-    git:
-      ref: feat/multi
-      url: https://github.com/atsign-foundation/socket_connector
 
 dev_dependencies:
   build_runner: ^2.4.6

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -724,11 +724,10 @@ packages:
   socket_connector:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "feat/multi"
-      resolved-ref: "458086671c01cd57423b4c88b298f0e4ec4d2993"
-      url: "https://github.com/atsign-foundation/socket_connector"
-    source: git
+      name: socket_connector
+      sha256: a614741652395393bc8e06987a0569bac116b2112645cc846015949dcf66aebd
+      url: "https://pub.dev"
+    source: hosted
     version: "2.1.0"
   source_map_stack_trace:
     dependency: transitive

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -17,10 +17,6 @@ dependencies:
 dependency_overrides:
   noports_core:
     path: "../noports_core"
-  socket_connector:
-    git:
-      ref: feat/multi
-      url: https://github.com/atsign-foundation/socket_connector
   # Pin the dependencies of noports_core
   archive: 3.3.9
   args:

--- a/packages/dart/sshnp_flutter/pubspec.lock
+++ b/packages/dart/sshnp_flutter/pubspec.lock
@@ -1125,11 +1125,10 @@ packages:
   socket_connector:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "feat/multi"
-      resolved-ref: "5f0374b804e83c69923c708ab4130fe903f06799"
-      url: "https://github.com/atsign-foundation/socket_connector"
-    source: git
+      name: socket_connector
+      sha256: a614741652395393bc8e06987a0569bac116b2112645cc846015949dcf66aebd
+      url: "https://pub.dev"
+    source: hosted
     version: "2.1.0"
   source_span:
     dependency: transitive

--- a/packages/dart/sshnp_flutter/pubspec.yaml
+++ b/packages/dart/sshnp_flutter/pubspec.yaml
@@ -15,10 +15,6 @@ dependency_overrides:
       url: https://github.com/atsign-foundation/at_client_sdk
       ref: issue_1232
       path: packages/at_client_mobile
-  socket_connector:
-    git:
-      ref: feat/multi
-      url: https://github.com/atsign-foundation/socket_connector
   # file_picker: ^6.0.0
   # at_onboarding_flutter: 6.1.3
   intl: ^0.17.0-nullsafety.2


### PR DESCRIPTION
**- What I did**
build: update socket_connector dependency to published version 2.1.0

**- How I did it**
Removed dependency overrides

**- How to verify it**
workflow build steps succeed