### PR TITLE
fix: Correct handling of mixed-case device names

### DIFF
--- a/docs/ssh-no-ports/guides/installation-guide/device-installation-sshnpd/headless.md
+++ b/docs/ssh-no-ports/guides/installation-guide/device-installation-sshnpd/headless.md
@@ -68,7 +68,13 @@ Replace `$device_atsign` with the [device address](#user-content-fn-2)[^2]
 
 Replace `$manager_atsign` with the [client address](#user-content-fn-3)[^3]
 
-Replace `$device_name` with your own [custom **unique** identifier](#user-content-fn-4)[^4] for this device, you will need this value later so don't forget it.
+Replace `$device_name` with your own [custom **unique
+** identifier](#user-content-fn-4)[^4] for this device. You will need this 
+value later, so don't forget it.
+{% hint style="info" %}
+`$device_name` must be alphanumeric snake case, max length 30 - e.g. dev_abc1
+{% endhint %}
+
 
 Add any additional config to the end of the line where sshnpd is run, some useful flags you should consider adding:
 

--- a/docs/ssh-no-ports/guides/installation-guide/device-installation-sshnpd/systemd-unit.md
+++ b/docs/ssh-no-ports/guides/installation-guide/device-installation-sshnpd/systemd-unit.md
@@ -42,7 +42,12 @@ Replace `<@device_atsign>` with the [device address](#user-content-fn-2)[^2]
 
 Replace `<@manager_atsign>` with the [client address](#user-content-fn-3)[^3]
 
-Replace `<device_name>` with your own [custom **unique** identifier](#user-content-fn-4)[^4] for this device, you will need this value later so don't forget it.
+Replace `<device_name>` with your own [custom **unique
+** identifier](#user-content-fn-4)[^4] for this device. You will need this
+value later, so don't forget it.
+{% hint style="info" %}
+`<device_name>` must be alphanumeric snake case, max length 30 - e.g. dev_abc1
+{% endhint %}
 
 Add any additional config to the end of the line where sshnpd is run, some useful flags you should consider adding:
 

--- a/docs/ssh-no-ports/guides/installation-guide/device-installation-sshnpd/tmux-session.md
+++ b/docs/ssh-no-ports/guides/installation-guide/device-installation-sshnpd/tmux-session.md
@@ -84,7 +84,12 @@ Replace `$device_atsign` with the [device address](#user-content-fn-2)[^2]
 
 Replace `$manager_atsign` with the [client address](#user-content-fn-3)[^3]
 
-Replace `$device_name` with your own [custom **unique** identifier](#user-content-fn-4)[^4] for this device, you will need this value later so don't forget it.
+Replace `$device_name` with your own [custom **unique
+** identifier](#user-content-fn-4)[^4] for this device. You will need this
+value later, so don't forget it.
+{% hint style="info" %}
+`$device_name` must be alphanumeric snake case, max length 30 - e.g. dev_abc1
+{% endhint %}
 
 Add any additional config to the end of the line where sshnpd is run, some useful flags you should consider adding:
 

--- a/packages/dart/noports_core/CHANGELOG.md
+++ b/packages/dart/noports_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.0.5
+- fix: Strict validation of device name as alphanumeric snake case
+- feat: Increase device name max length from 15 to 36
+
 # 6.0.4
 - build: upgrade at_chops dependency to ^2.0.0
 

--- a/packages/dart/noports_core/lib/src/common/validation_utils.dart
+++ b/packages/dart/noports_core/lib/src/common/validation_utils.dart
@@ -8,9 +8,12 @@ import 'package:noports_core/src/common/file_system_utils.dart';
 import 'package:noports_core/src/common/io_types.dart';
 import 'package:path/path.dart' as path;
 
-const String sshnpDeviceNameRegex = r'[a-zA-Z0-9_]{0,15}';
+const String sshnpDeviceNameRegex = r'[a-z0-9_]{1,30}';
+const String invalidDeviceNameMsg = 'Device name must be alphanumeric'
+    ' snake case, max length 30';
+const String deviceNameFormatHelp = 'Alphanumeric snake case, max length 30.';
 
-bool checkNonAscii(String test) {
+bool invalidDeviceName(String test) {
   return RegExp(sshnpDeviceNameRegex).allMatches(test).first.group(0) != test;
 }
 

--- a/packages/dart/noports_core/lib/src/common/validation_utils.dart
+++ b/packages/dart/noports_core/lib/src/common/validation_utils.dart
@@ -8,10 +8,10 @@ import 'package:noports_core/src/common/file_system_utils.dart';
 import 'package:noports_core/src/common/io_types.dart';
 import 'package:path/path.dart' as path;
 
-const String sshnpDeviceNameRegex = r'[a-z0-9_]{1,30}';
+const String sshnpDeviceNameRegex = r'[a-z0-9_]{1,36}';
 const String invalidDeviceNameMsg = 'Device name must be alphanumeric'
-    ' snake case, max length 30';
-const String deviceNameFormatHelp = 'Alphanumeric snake case, max length 30.';
+    ' snake case, max length 36';
+const String deviceNameFormatHelp = 'Alphanumeric snake case, max length 36.';
 
 bool invalidDeviceName(String test) {
   return RegExp(sshnpDeviceNameRegex).allMatches(test).first.group(0) != test;

--- a/packages/dart/noports_core/lib/src/sshnp/models/sshnp_arg.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/models/sshnp_arg.dart
@@ -1,7 +1,6 @@
 import 'package:args/args.dart';
 
-import 'package:noports_core/src/common/default_args.dart';
-import 'package:noports_core/src/common/types.dart';
+import 'package:noports_core/utils.dart';
 
 enum ArgFormat {
   option,
@@ -224,7 +223,7 @@ class SshnpArg {
   static const deviceArg = SshnpArg(
     name: 'device',
     abbr: 'd',
-    help: 'Receiving device name',
+    help: 'Receiving device name. $deviceNameFormatHelp',
     defaultsTo: DefaultSshnpArgs.device,
   );
   static const srvdArg = SshnpArg(

--- a/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
@@ -92,14 +92,14 @@ abstract class ClientParamsBase implements ClientParams {
     required this.sshnpdAtSign,
     required this.srvdAtSign,
     this.localPort = DefaultSshnpArgs.localPort,
-    this.device = DefaultSshnpArgs.device,
+    String device = DefaultSshnpArgs.device,
     this.verbose = DefaultArgs.verbose,
     this.atKeysFilePath,
     this.rootDomain = DefaultArgs.rootDomain,
     this.authenticateClientToRvd = DefaultArgs.authenticateClientToRvd,
     this.authenticateDeviceToRvd = DefaultArgs.authenticateDeviceToRvd,
     this.encryptRvdTraffic = DefaultArgs.encryptRvdTraffic,
-  });
+  }) : device = device.toLowerCase();
 }
 
 abstract interface class SrvdChannelParams implements ClientParams {}

--- a/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
@@ -91,14 +91,14 @@ abstract class ClientParamsBase implements ClientParams {
     required this.sshnpdAtSign,
     required this.srvdAtSign,
     this.localPort = DefaultSshnpArgs.localPort,
-    String device = DefaultSshnpArgs.device,
+    this.device = DefaultSshnpArgs.device,
     this.verbose = DefaultArgs.verbose,
     this.atKeysFilePath,
     this.rootDomain = DefaultArgs.rootDomain,
     this.authenticateClientToRvd = DefaultArgs.authenticateClientToRvd,
     this.authenticateDeviceToRvd = DefaultArgs.authenticateDeviceToRvd,
     this.encryptRvdTraffic = DefaultArgs.encryptRvdTraffic,
-  }) : device = device.toLowerCase() {
+  }) {
     if (invalidDeviceName(device)) {
       throw ArgumentError(invalidDeviceNameMsg);
     }

--- a/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
@@ -4,8 +4,7 @@ import 'package:at_chops/at_chops.dart';
 import 'package:at_utils/at_utils.dart';
 import 'package:noports_core/src/sshnp/models/config_file_repository.dart';
 import 'package:noports_core/src/sshnp/models/sshnp_arg.dart';
-import 'package:noports_core/src/common/default_args.dart';
-import 'package:noports_core/sshnp.dart';
+import 'package:noports_core/utils.dart';
 
 abstract interface class ClientParams {
   bool get verbose;
@@ -99,7 +98,11 @@ abstract class ClientParamsBase implements ClientParams {
     this.authenticateClientToRvd = DefaultArgs.authenticateClientToRvd,
     this.authenticateDeviceToRvd = DefaultArgs.authenticateDeviceToRvd,
     this.encryptRvdTraffic = DefaultArgs.encryptRvdTraffic,
-  }) : device = device.toLowerCase();
+  }) : device = device.toLowerCase() {
+    if (invalidDeviceName(device)) {
+      throw ArgumentError(invalidDeviceNameMsg);
+    }
+  }
 }
 
 abstract interface class SrvdChannelParams implements ClientParams {}

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -91,6 +91,9 @@ class SshnpdImpl implements Sshnpd {
     required this.version,
     required this.permitOpen,
   }) : device = device.toLowerCase() {
+    if (invalidDeviceName(device)) {
+      throw ArgumentError(invalidDeviceNameMsg);
+    }
     logger.hierarchicalLoggingEnabled = true;
     logger.logger.level = Level.SHOUT;
 

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -80,7 +80,7 @@ class SshnpdImpl implements Sshnpd {
     required this.atClient,
     required this.username,
     required this.homeDirectory,
-    required String device,
+    required this.device,
     required this.managerAtsigns,
     required this.sshClient,
     this.makeDeviceInfoVisible = false,
@@ -90,7 +90,7 @@ class SshnpdImpl implements Sshnpd {
     required this.sshAlgorithm,
     required this.version,
     required this.permitOpen,
-  }) : device = device.toLowerCase() {
+  }) {
     if (invalidDeviceName(device)) {
       throw ArgumentError(invalidDeviceNameMsg);
     }

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -80,7 +80,7 @@ class SshnpdImpl implements Sshnpd {
     required this.atClient,
     required this.username,
     required this.homeDirectory,
-    required this.device,
+    required String device,
     required this.managerAtsigns,
     required this.sshClient,
     this.makeDeviceInfoVisible = false,
@@ -90,7 +90,7 @@ class SshnpdImpl implements Sshnpd {
     required this.sshAlgorithm,
     required this.version,
     required this.permitOpen,
-  }) {
+  }) : device = device.toLowerCase() {
     logger.hierarchicalLoggingEnabled = true;
     logger.logger.level = Level.SHOUT;
 

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
@@ -66,8 +66,8 @@ class SshnpdParams {
         orElse: () => DefaultSshnpdArgs.sshClient);
 
     // Do we have an ASCII ?
-    if (checkNonAscii(device)) {
-      throw ('\nDevice name can only contain alphanumeric characters with a max length of 15');
+    if (invalidDeviceName(device)) {
+      throw ('\n$invalidDeviceNameMsg');
     }
 
     return SshnpdParams(
@@ -126,7 +126,8 @@ class SshnpdParams {
       mandatory: false,
       defaultsTo: "default",
       help: 'This daemon will operate with this device name;'
-          ' allows multiple devices to share an atSign',
+          ' allows multiple devices to share an atSign.'
+          ' $deviceNameFormatHelp',
     );
 
     parser.addFlag(

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
@@ -28,7 +28,7 @@ class SshnpdParams {
   static final ArgParser parser = _createArgParser();
 
   SshnpdParams({
-    required this.device,
+    required String device,
     required this.username,
     required this.homeDirectory,
     required this.managerAtsigns,
@@ -44,7 +44,7 @@ class SshnpdParams {
     required this.sshAlgorithm,
     required this.storagePath,
     required this.permitOpen,
-  });
+  }) : device = device.toLowerCase();
 
   static Future<SshnpdParams> fromArgs(List<String> args) async {
     // Arg check

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
@@ -71,7 +71,7 @@ class SshnpdParams {
 
     // Do we have an ASCII ?
     if (invalidDeviceName(device)) {
-      throw ('\n$invalidDeviceNameMsg');
+      throw ArgumentError(invalidDeviceNameMsg);
     }
 
     return SshnpdParams(

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
@@ -28,7 +28,7 @@ class SshnpdParams {
   static final ArgParser parser = _createArgParser();
 
   SshnpdParams({
-    required String device,
+    required this.device,
     required this.username,
     required this.homeDirectory,
     required this.managerAtsigns,
@@ -44,7 +44,11 @@ class SshnpdParams {
     required this.sshAlgorithm,
     required this.storagePath,
     required this.permitOpen,
-  }) : device = device.toLowerCase();
+  }) {
+    if (invalidDeviceName(device)) {
+      throw ArgumentError(invalidDeviceNameMsg);
+    }
+  }
 
   static Future<SshnpdParams> fromArgs(List<String> args) async {
     // Arg check

--- a/packages/dart/noports_core/lib/src/version.dart
+++ b/packages/dart/noports_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '6.0.4';
+const packageVersion = '6.0.5';

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: noports_core
 description: Core library code for sshnoports
 homepage: https://docs.atsign.com/
 
-version: 6.0.4
+version: 6.0.5
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/dart/noports_core/test/sshnp/models/sshnp_params_test.dart
+++ b/packages/dart/noports_core/test/sshnp/models/sshnp_params_test.dart
@@ -54,7 +54,7 @@ void main() {
             sshnpdAtSign: '',
             srvdAtSign: '',
             device: 'myDeviceName');
-        expect(params.device, equals('myDeviceName'));
+        expect(params.device, equals('myDeviceName'.toLowerCase()));
       });
       test('SshnpParams.localPort test', () {
         final params = SshnpParams(
@@ -230,7 +230,7 @@ void main() {
         expect(params.clientAtSign, equals('@myClientAtSign'));
         expect(params.sshnpdAtSign, equals('@mySshnpdAtSign'));
         expect(params.srvdAtSign, equals('@mySrvdAtSign'));
-        expect(params.device, equals('myDeviceName'));
+        expect(params.device, equals('myDeviceName'.toLowerCase()));
         expect(params.localPort, equals(2345));
         expect(params.identityFile, equals('.ssh/id_ed25519'));
         expect(params.identityPassphrase, equals('myPassphrase'));
@@ -301,7 +301,7 @@ void main() {
         expect(params.clientAtSign, equals('@myClientAtSign'.toLowerCase()));
         expect(params.sshnpdAtSign, equals('@mySshnpdAtSign'.toLowerCase()));
         expect(params.srvdAtSign, equals('@mySrvdAtSign'));
-        expect(params.device, equals('myDeviceName'));
+        expect(params.device, equals('myDeviceName'.toLowerCase()));
         expect(params.localPort, equals(2345));
         expect(params.identityFile, equals('.ssh/id_ed25519'));
         expect(params.identityPassphrase, equals('myPassphrase'));
@@ -357,7 +357,7 @@ void main() {
         expect(params.clientAtSign, equals('@myClientAtSign'.toLowerCase()));
         expect(params.sshnpdAtSign, equals('@mySshnpdAtSign'.toLowerCase()));
         expect(params.srvdAtSign, equals('@mySrvdAtSign'));
-        expect(params.device, equals('myDeviceName'));
+        expect(params.device, equals('myDeviceName'.toLowerCase()));
         expect(params.localPort, equals(2345));
         expect(params.sendSshPublicKey, equals(true));
         expect(
@@ -406,7 +406,7 @@ void main() {
         expect(
             parsedParams.sshnpdAtSign, equals('@mySshnpdAtSign'.toLowerCase()));
         expect(parsedParams.srvdAtSign, equals('@mySrvdAtSign'));
-        expect(parsedParams.device, equals('myDeviceName'));
+        expect(parsedParams.device, equals('myDeviceName'.toLowerCase()));
         expect(parsedParams.localPort, equals(2345));
         expect(parsedParams.sendSshPublicKey, equals(true));
         expect(parsedParams.localSshOptions,
@@ -443,7 +443,7 @@ void main() {
         expect(argMap[SshnpArg.fromArg.name], equals('@myClientAtSign'));
         expect(argMap[SshnpArg.toArg.name], equals('@mySshnpdAtSign'));
         expect(argMap[SshnpArg.srvdArg.name], equals('@mySrvdAtSign'));
-        expect(argMap[SshnpArg.deviceArg.name], equals('myDeviceName'));
+        expect(argMap[SshnpArg.deviceArg.name], equals('myDeviceName'.toLowerCase()));
         expect(argMap[SshnpArg.localPortArg.name], equals(2345));
         expect(
             argMap[SshnpArg.identityFileArg.name], equals('.ssh/id_ed25519'));
@@ -490,7 +490,7 @@ void main() {
         expect(
             parsedParams.sshnpdAtSign, equals('@mySshnpdAtSign'.toLowerCase()));
         expect(parsedParams.srvdAtSign, equals('@mySrvdAtSign'));
-        expect(parsedParams.device, equals('myDeviceName'));
+        expect(parsedParams.device, equals('myDeviceName'.toLowerCase()));
         expect(parsedParams.localPort, equals(2345));
         expect(parsedParams.identityFile, equals('.ssh/id_ed25519'));
         expect(parsedParams.identityPassphrase, equals('myPassphrase'));
@@ -772,7 +772,7 @@ void main() {
         expect(
             parsedParams.sshnpdAtSign, equals('@mySshnpdAtSign'.toLowerCase()));
         expect(parsedParams.srvdAtSign, equals('@mySrvdAtSign'));
-        expect(parsedParams.device, equals('myDeviceName'));
+        expect(parsedParams.device, equals('myDeviceName'.toLowerCase()));
         expect(parsedParams.localPort, equals(2345));
         expect(parsedParams.sendSshPublicKey, equals(true));
         expect(parsedParams.localSshOptions,

--- a/packages/dart/noports_core/test/sshnp/models/sshnp_params_test.dart
+++ b/packages/dart/noports_core/test/sshnp/models/sshnp_params_test.dart
@@ -443,7 +443,8 @@ void main() {
         expect(argMap[SshnpArg.fromArg.name], equals('@myClientAtSign'));
         expect(argMap[SshnpArg.toArg.name], equals('@mySshnpdAtSign'));
         expect(argMap[SshnpArg.srvdArg.name], equals('@mySrvdAtSign'));
-        expect(argMap[SshnpArg.deviceArg.name], equals('myDeviceName'.toLowerCase()));
+        expect(argMap[SshnpArg.deviceArg.name],
+            equals('myDeviceName'.toLowerCase()));
         expect(argMap[SshnpArg.localPortArg.name], equals(2345));
         expect(
             argMap[SshnpArg.identityFileArg.name], equals('.ssh/id_ed25519'));

--- a/packages/dart/noports_core/test/sshnp/models/sshnp_params_test.dart
+++ b/packages/dart/noports_core/test/sshnp/models/sshnp_params_test.dart
@@ -48,13 +48,41 @@ void main() {
             clientAtSign: '', sshnpdAtSign: '', srvdAtSign: '@my_srvd');
         expect(params.srvdAtSign, equals('@my_srvd'));
       });
+      test('SshnpParams.device invalid with uppercase test', () {
+        expect(
+            () => SshnpParams(
+                clientAtSign: '',
+                sshnpdAtSign: '',
+                srvdAtSign: '',
+                device: 'myDeviceName'),
+            throwsA(TypeMatcher<ArgumentError>()));
+      });
+      test('SshnpParams.device invalid with disallowed chars test', () {
+        expect(
+            () => SshnpParams(
+                clientAtSign: '',
+                sshnpdAtSign: '',
+                srvdAtSign: '',
+                device: 'my-device-name'),
+            throwsA(TypeMatcher<ArgumentError>()));
+      });
+      test('SshnpParams.device invalid too long test', () {
+        expect(
+            () => SshnpParams(
+                clientAtSign: '',
+                sshnpdAtSign: '',
+                srvdAtSign: '',
+                device: 'abcde_12345_abcde_12345_abcde_1'),
+            throwsA(TypeMatcher<ArgumentError>()));
+      });
       test('SshnpParams.device test', () {
+        String deviceName = 'my_device_name_12345';
         final params = SshnpParams(
             clientAtSign: '',
             sshnpdAtSign: '',
             srvdAtSign: '',
-            device: 'myDeviceName');
-        expect(params.device, equals('myDeviceName'.toLowerCase()));
+            device: deviceName);
+        expect(params.device, equals(deviceName));
       });
       test('SshnpParams.localPort test', () {
         final params = SshnpParams(
@@ -210,7 +238,7 @@ void main() {
             clientAtSign: '@myClientAtSign',
             sshnpdAtSign: '@mySshnpdAtSign',
             srvdAtSign: '@mySrvdAtSign',
-            device: 'myDeviceName',
+            device: 'my_device_name_12345',
             localPort: 2345,
             identityFile: '.ssh/id_ed25519',
             identityPassphrase: 'myPassphrase',
@@ -230,7 +258,7 @@ void main() {
         expect(params.clientAtSign, equals('@myClientAtSign'));
         expect(params.sshnpdAtSign, equals('@mySshnpdAtSign'));
         expect(params.srvdAtSign, equals('@mySrvdAtSign'));
-        expect(params.device, equals('myDeviceName'.toLowerCase()));
+        expect(params.device, equals('my_device_name_12345'));
         expect(params.localPort, equals(2345));
         expect(params.identityFile, equals('.ssh/id_ed25519'));
         expect(params.identityPassphrase, equals('myPassphrase'));
@@ -279,7 +307,7 @@ void main() {
             '"${SshnpArg.fromArg.name}": "@myClientAtSign",'
             '"${SshnpArg.toArg.name}": "@mySshnpdAtSign",'
             '"${SshnpArg.srvdArg.name}": "@mySrvdAtSign",'
-            '"${SshnpArg.deviceArg.name}": "myDeviceName",'
+            '"${SshnpArg.deviceArg.name}": "my_device_name_12345",'
             '"${SshnpArg.localPortArg.name}": 2345,'
             '"${SshnpArg.identityFileArg.name}": ".ssh/id_ed25519",'
             '"${SshnpArg.identityPassphraseArg.name}": "myPassphrase",'
@@ -301,7 +329,7 @@ void main() {
         expect(params.clientAtSign, equals('@myClientAtSign'.toLowerCase()));
         expect(params.sshnpdAtSign, equals('@mySshnpdAtSign'.toLowerCase()));
         expect(params.srvdAtSign, equals('@mySrvdAtSign'));
-        expect(params.device, equals('myDeviceName'.toLowerCase()));
+        expect(params.device, equals('my_device_name_12345'));
         expect(params.localPort, equals(2345));
         expect(params.identityFile, equals('.ssh/id_ed25519'));
         expect(params.identityPassphrase, equals('myPassphrase'));
@@ -334,7 +362,7 @@ void main() {
           '${SshnpArg.fromArg.bashName} = @myClientAtSign',
           '${SshnpArg.toArg.bashName} = @mySshnpdAtSign',
           '${SshnpArg.srvdArg.bashName} = @mySrvdAtSign',
-          '${SshnpArg.deviceArg.bashName} = myDeviceName',
+          '${SshnpArg.deviceArg.bashName} = my_device_name_12345',
           '${SshnpArg.localPortArg.bashName} = 2345',
           '${SshnpArg.identityFileArg.bashName} = .ssh/id_ed25519',
           '${SshnpArg.identityPassphraseArg.bashName} = myPassphrase',
@@ -357,7 +385,7 @@ void main() {
         expect(params.clientAtSign, equals('@myClientAtSign'.toLowerCase()));
         expect(params.sshnpdAtSign, equals('@mySshnpdAtSign'.toLowerCase()));
         expect(params.srvdAtSign, equals('@mySrvdAtSign'));
-        expect(params.device, equals('myDeviceName'.toLowerCase()));
+        expect(params.device, equals('my_device_name_12345'));
         expect(params.localPort, equals(2345));
         expect(params.sendSshPublicKey, equals(true));
         expect(
@@ -377,7 +405,7 @@ void main() {
           clientAtSign: '@myClientAtSign',
           sshnpdAtSign: '@mySshnpdAtSign',
           srvdAtSign: '@mySrvdAtSign',
-          device: 'myDeviceName',
+          device: 'my_device_name_12345',
           localPort: 2345,
           identityFile: '.ssh/id_ed25519',
           identityPassphrase: 'myPassphrase',
@@ -406,7 +434,7 @@ void main() {
         expect(
             parsedParams.sshnpdAtSign, equals('@mySshnpdAtSign'.toLowerCase()));
         expect(parsedParams.srvdAtSign, equals('@mySrvdAtSign'));
-        expect(parsedParams.device, equals('myDeviceName'.toLowerCase()));
+        expect(parsedParams.device, equals('my_device_name_12345'));
         expect(parsedParams.localPort, equals(2345));
         expect(parsedParams.sendSshPublicKey, equals(true));
         expect(parsedParams.localSshOptions,
@@ -424,7 +452,7 @@ void main() {
           clientAtSign: '@myClientAtSign',
           sshnpdAtSign: '@mySshnpdAtSign',
           srvdAtSign: '@mySrvdAtSign',
-          device: 'myDeviceName',
+          device: 'my_device_name_12345',
           localPort: 2345,
           identityFile: '.ssh/id_ed25519',
           identityPassphrase: 'myPassphrase',
@@ -443,8 +471,7 @@ void main() {
         expect(argMap[SshnpArg.fromArg.name], equals('@myClientAtSign'));
         expect(argMap[SshnpArg.toArg.name], equals('@mySshnpdAtSign'));
         expect(argMap[SshnpArg.srvdArg.name], equals('@mySrvdAtSign'));
-        expect(argMap[SshnpArg.deviceArg.name],
-            equals('myDeviceName'.toLowerCase()));
+        expect(argMap[SshnpArg.deviceArg.name], equals('my_device_name_12345'));
         expect(argMap[SshnpArg.localPortArg.name], equals(2345));
         expect(
             argMap[SshnpArg.identityFileArg.name], equals('.ssh/id_ed25519'));
@@ -469,7 +496,7 @@ void main() {
           clientAtSign: '@myClientAtSign',
           sshnpdAtSign: '@mySshnpdAtSign',
           srvdAtSign: '@mySrvdAtSign',
-          device: 'myDeviceName',
+          device: 'my_device_name_12345',
           localPort: 2345,
           identityFile: '.ssh/id_ed25519',
           identityPassphrase: 'myPassphrase',
@@ -491,7 +518,7 @@ void main() {
         expect(
             parsedParams.sshnpdAtSign, equals('@mySshnpdAtSign'.toLowerCase()));
         expect(parsedParams.srvdAtSign, equals('@mySrvdAtSign'));
-        expect(parsedParams.device, equals('myDeviceName'.toLowerCase()));
+        expect(parsedParams.device, equals('my_device_name_12345'));
         expect(parsedParams.localPort, equals(2345));
         expect(parsedParams.identityFile, equals('.ssh/id_ed25519'));
         expect(parsedParams.identityPassphrase, equals('myPassphrase'));
@@ -551,8 +578,8 @@ void main() {
         expect(params.srvdAtSign, equals('@mySrvdAtSign'));
       });
       test('SshnpPartialParams.device test', () {
-        final params = SshnpPartialParams(device: 'myDeviceName');
-        expect(params.device, equals('myDeviceName'));
+        final params = SshnpPartialParams(device: 'my_device_name_12345');
+        expect(params.device, equals('my_device_name_12345'));
       });
       test('SshnpPartialParams.localPort test', () {
         final params = SshnpPartialParams(localPort: 2345);
@@ -655,7 +682,7 @@ void main() {
             clientAtSign: '@myClientAtSign',
             sshnpdAtSign: '@mySshnpdAtSign',
             srvdAtSign: '@mySrvdAtSign',
-            device: 'myDeviceName',
+            device: 'my_device_name_12345',
             localPort: 2345,
             identityFile: '.ssh/id_ed25519',
             identityPassphrase: 'myPassphrase',
@@ -675,7 +702,7 @@ void main() {
         expect(params.clientAtSign, equals('@myClientAtSign'));
         expect(params.sshnpdAtSign, equals('@mySshnpdAtSign'));
         expect(params.srvdAtSign, equals('@mySrvdAtSign'));
-        expect(params.device, equals('myDeviceName'));
+        expect(params.device, equals('my_device_name_12345'));
         expect(params.localPort, equals(2345));
         expect(params.identityFile, equals('.ssh/id_ed25519'));
         expect(params.identityPassphrase, equals('myPassphrase'));
@@ -699,7 +726,7 @@ void main() {
             clientAtSign: '@myClientAtSign',
             sshnpdAtSign: '@mySshnpdAtSign',
             srvdAtSign: '@mySrvdAtSign',
-            device: 'myDeviceName',
+            device: 'my_device_name_12345',
             localPort: 2345,
             identityFile: '.ssh/id_ed25519',
             identityPassphrase: 'myPassphrase',
@@ -720,7 +747,7 @@ void main() {
         expect(params.clientAtSign, equals('@myClientAtSign'));
         expect(params.sshnpdAtSign, equals('@mySshnpdAtSign'));
         expect(params.srvdAtSign, equals('@mySrvdAtSign'));
-        expect(params.device, equals('myDeviceName'));
+        expect(params.device, equals('my_device_name_12345'));
         expect(params.localPort, equals(2345));
         expect(params.identityFile, equals('.ssh/id_ed25519'));
         expect(params.identityPassphrase, equals('myPassphrase'));
@@ -744,7 +771,7 @@ void main() {
           clientAtSign: '@myClientAtSign',
           sshnpdAtSign: '@mySshnpdAtSign',
           srvdAtSign: '@mySrvdAtSign',
-          device: 'myDeviceName',
+          device: 'my_device_name_12345',
           localPort: 2345,
           identityFile: '.ssh/id_ed25519',
           identityPassphrase: 'myPassphrase',
@@ -773,7 +800,7 @@ void main() {
         expect(
             parsedParams.sshnpdAtSign, equals('@mySshnpdAtSign'.toLowerCase()));
         expect(parsedParams.srvdAtSign, equals('@mySrvdAtSign'));
-        expect(parsedParams.device, equals('myDeviceName'.toLowerCase()));
+        expect(parsedParams.device, equals('my_device_name_12345'));
         expect(parsedParams.localPort, equals(2345));
         expect(parsedParams.sendSshPublicKey, equals(true));
         expect(parsedParams.localSshOptions,
@@ -792,7 +819,7 @@ void main() {
             '"${SshnpArg.fromArg.name}": "@myClientAtSign",'
             '"${SshnpArg.toArg.name}": "@mySshnpdAtSign",'
             '"${SshnpArg.srvdArg.name}": "@mySrvdAtSign",'
-            '"${SshnpArg.deviceArg.name}": "myDeviceName",'
+            '"${SshnpArg.deviceArg.name}": "my_device_name_12345",'
             '"${SshnpArg.localPortArg.name}": 2345,'
             '"${SshnpArg.identityFileArg.name}": ".ssh/id_ed25519",'
             '"${SshnpArg.identityPassphraseArg.name}": "myPassphrase",'
@@ -814,7 +841,7 @@ void main() {
         expect(params.clientAtSign, equals('@myClientAtSign'.toLowerCase()));
         expect(params.sshnpdAtSign, equals('@mySshnpdAtSign'.toLowerCase()));
         expect(params.srvdAtSign, equals('@mySrvdAtSign'));
-        expect(params.device, equals('myDeviceName'));
+        expect(params.device, equals('my_device_name_12345'));
         expect(params.localPort, equals(2345));
         expect(params.identityFile, equals('.ssh/id_ed25519'));
         expect(params.identityPassphrase, equals('myPassphrase'));
@@ -838,7 +865,7 @@ void main() {
           SshnpArg.fromArg.name: '@myClientAtSign',
           SshnpArg.toArg.name: '@mySshnpdAtSign',
           SshnpArg.srvdArg.name: '@mySrvdAtSign',
-          SshnpArg.deviceArg.name: 'myDeviceName',
+          SshnpArg.deviceArg.name: 'my_device_name_12345',
           SshnpArg.localPortArg.name: 2345,
           SshnpArg.identityFileArg.name: '.ssh/id_ed25519',
           SshnpArg.identityPassphraseArg.name: 'myPassphrase',
@@ -858,7 +885,7 @@ void main() {
         expect(params.clientAtSign, equals('@myClientAtSign'.toLowerCase()));
         expect(params.sshnpdAtSign, equals('@mySshnpdAtSign'.toLowerCase()));
         expect(params.srvdAtSign, equals('@mySrvdAtSign'));
-        expect(params.device, equals('myDeviceName'));
+        expect(params.device, equals('my_device_name_12345'));
         expect(params.localPort, equals(2345));
         expect(params.identityFile, equals('.ssh/id_ed25519'));
         expect(params.identityPassphrase, equals('myPassphrase'));
@@ -887,7 +914,7 @@ void main() {
           '--${SshnpArg.srvdArg.name}',
           '@mySrvdAtSign',
           '--${SshnpArg.deviceArg.name}',
-          'myDeviceName',
+          'my_device_name_12345',
           '--${SshnpArg.localPortArg.name}',
           '2345',
           '--${SshnpArg.identityFileArg.name}',
@@ -922,7 +949,7 @@ void main() {
         expect(params.clientAtSign, equals('@myClientAtSign'.toLowerCase()));
         expect(params.sshnpdAtSign, equals('@mySshnpdAtSign'.toLowerCase()));
         expect(params.srvdAtSign, equals('@mySrvdAtSign'));
-        expect(params.device, equals('myDeviceName'));
+        expect(params.device, equals('my_device_name_12345'));
         expect(params.localPort, equals(2345));
         expect(params.identityFile, equals('.ssh/id_ed25519'));
         expect(params.identityPassphrase, equals('myPassphrase'));

--- a/packages/dart/noports_core/test/sshnp/models/sshnp_params_test.dart
+++ b/packages/dart/noports_core/test/sshnp/models/sshnp_params_test.dart
@@ -72,7 +72,7 @@ void main() {
                 clientAtSign: '',
                 sshnpdAtSign: '',
                 srvdAtSign: '',
-                device: 'abcde_12345_abcde_12345_abcde_1'),
+                device: 'abcde_12345_abcde_12345_abcde_12345_X'),
             throwsA(TypeMatcher<ArgumentError>()));
       });
       test('SshnpParams.device test', () {

--- a/packages/dart/sshnoports/bin/npt.dart
+++ b/packages/dart/sshnoports/bin/npt.dart
@@ -84,9 +84,7 @@ void main(List<String> args) async {
         'device',
         abbr: 'd',
         mandatory: true,
-        help: 'The device name'
-            ' The same atSign may be used to run daemons on many devices,'
-            ' therefore each one must run with its own unique device name',
+        help: 'Receiving device name. $deviceNameFormatHelp',
       );
       parser.addOption(
         'local-port',

--- a/packages/dart/sshnoports/bin/npt.dart
+++ b/packages/dart/sshnoports/bin/npt.dart
@@ -207,6 +207,19 @@ void main(List<String> args) async {
         });
       }
 
+      NptParams params = NptParams(
+        clientAtSign: clientAtSign,
+        sshnpdAtSign: daemonAtSign,
+        srvdAtSign: srvdAtSign,
+        remoteHost: remoteHost,
+        remotePort: remotePort,
+        device: device,
+        localPort: localPort,
+        verbose: verbose,
+        rootDomain: parsedArgs['root-domain'],
+        inline: inline,
+      );
+
       cli.CLIBase cliBase = cli.CLIBase(
           atSign: clientAtSign,
           atKeysFilePath: parsedArgs['key-file'],
@@ -220,18 +233,7 @@ void main(List<String> args) async {
       await cliBase.init();
 
       final npt = Npt.create(
-        params: NptParams(
-          clientAtSign: clientAtSign,
-          sshnpdAtSign: daemonAtSign,
-          srvdAtSign: srvdAtSign,
-          remoteHost: remoteHost,
-          remotePort: remotePort,
-          device: device,
-          localPort: localPort,
-          verbose: verbose,
-          rootDomain: parsedArgs['root-domain'],
-          inline: inline,
-        ),
+        params: params,
         atClient: cliBase.atClient,
       );
 

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -584,7 +584,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.0.4"
+    version: "6.0.5"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,13 +1,13 @@
 name: sshnoports
 publish_to: none
 
-version: 5.0.3
+version: 5.1.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  noports_core: 6.0.4
+  noports_core: 6.0.5
   at_onboarding_cli: 1.4.3
   args: 2.4.2
   socket_connector: ^2.1.0

--- a/packages/dart/sshnp_flutter/pubspec.lock
+++ b/packages/dart/sshnp_flutter/pubspec.lock
@@ -772,7 +772,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.0.4"
+    version: "6.0.5"
   openssh_ed25519:
     dependency: transitive
     description:


### PR DESCRIPTION
**- What I did**
- fix: Updated device name validation : now require alphanumeric snake case
- feat: Increased max length of device name to 36
- feat: Use the same device name validation in all relevant constructors
- docs: Updated docs to include device_name constraints (alphanumeric snake case, max length 36)
- resolves #839 

**- How I did it**
- modified regex in validation_utils.dart to be alphanumeric snake case, max length 36
- modified various programs' args parsing to validate device names using the same validation function
- modified various programs' args help to use the same language for describing the device name format
- Added unit tests for invalid device names
- Modified other unit tests to use valid device names

**- How to verify it**
Tests pass

