### PR TITLE
ci: ensure that dependencies are being properly kept up to date

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -53,7 +53,7 @@ jobs:
       - if: ${{ matrix.os != 'windows-latest' }}
         run: mkdir sshnp/debug
       # compile binaries
-      - run: dart pub get
+      - run: dart pub get --enforce-lockfile
       - run: dart run build_runner build --delete-conflicting-outputs
       - run: dart compile exe bin/activate_cli.dart -v -o sshnp/at_activate${{ matrix.ext }}
       - run: dart compile exe bin/sshnp.dart -v -o sshnp/sshnp${{ matrix.ext }}

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.0.3';
+const packageVersion = '5.2.0';

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -18,13 +18,13 @@ packages:
     source: hosted
     version: "6.4.1"
   archive:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: archive
-      sha256: e0902a06f0e00414e4e3438a084580161279f137aeb862274710f29ec10cf01e
+      sha256: "22600aa1e926be775fa5fe7e6894e7fb3df9efda8891c73f70fb3262399a432d"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.9"
+    version: "3.4.10"
   args:
     dependency: "direct main"
     description:
@@ -35,13 +35,13 @@ packages:
     source: git
     version: "2.4.2"
   asn1lib:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: asn1lib
-      sha256: b74e3842a52c61f8819a1ec8444b4de5419b41a7465e69d4aa681445377398b0
+      sha256: "21afe4333076c02877d14f4a89df111e658a6d466cbfc802eb705eb91bd5adfd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.5.0"
   async:
     dependency: transitive
     description:
@@ -75,7 +75,7 @@ packages:
     source: hosted
     version: "2.0.0"
   at_client:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: at_client
       sha256: "65fefc2c217376bdcdff1b7b5b30c476bc5bf8ca4146863aa4a28ce5401d3600"
@@ -99,7 +99,7 @@ packages:
     source: hosted
     version: "1.0.3"
   at_lookup:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: at_lookup
       sha256: "31d4a6f0a3495aa3ed81ffec7d4d2995221aaaa73a35e17962a6a07c67dfba0c"
@@ -323,13 +323,13 @@ packages:
     source: hosted
     version: "2.7.0"
   crypton:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: crypton
-      sha256: "886462e83bf642ba10f5382002654d27da8c2e6e1f42d928f12764cfa204f124"
+      sha256: "17b6631fbf89e389d421b46629132287ed37d601b2ad1357445826ab85022271"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.1"
   dart_periphery:
     dependency: transitive
     description:
@@ -371,13 +371,13 @@ packages:
     source: hosted
     version: "0.3.10"
   encrypt:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: encrypt
-      sha256: "4fd4e4fdc21b9d7d4141823e1e6515cd94e7b8d84749504c232999fba25d9bbb"
+      sha256: "62d9aa4670cc2a8798bab89b39fc71b6dfbacf615de6cf5001fb39f7e4a996a2"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.1"
+    version: "5.0.3"
   ffi:
     dependency: transitive
     description:
@@ -507,7 +507,7 @@ packages:
     source: hosted
     version: "3.0.0"
   logging:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: logging
       sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
@@ -523,13 +523,13 @@ packages:
     source: hosted
     version: "0.12.16+1"
   meta:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -745,14 +745,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
-  ssh_key:
-    dependency: "direct overridden"
-    description:
-      name: ssh_key
-      sha256: ded1af84f2c34748c000101940e7b9a63a077c9a136aaab85dbf54a6e9d19ec8
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.8.0"
   stack_trace:
     dependency: transitive
     description:
@@ -825,14 +817,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
-  tuple:
-    dependency: transitive
-    description:
-      name: tuple
-      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.2"
   typed_data:
     dependency: transitive
     description:
@@ -842,7 +826,7 @@ packages:
     source: hosted
     version: "1.3.2"
   uuid:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: uuid
       sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
@@ -850,7 +834,7 @@ packages:
     source: hosted
     version: "3.0.7"
   version:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: version
       sha256: "3d4140128e6ea10d83da32fef2fa4003fccbf6852217bb854845802f04191f94"

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -74,14 +74,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  at_cli_commons:
-    dependency: "direct overridden"
-    description:
-      name: at_cli_commons
-      sha256: "9165a0547ee36024f5d013cbb455197ef6f1f8a2c93620b1c49cb2eeead92157"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.4"
   at_client:
     dependency: "direct overridden"
     description:
@@ -94,10 +86,10 @@ packages:
     dependency: transitive
     description:
       name: at_commons
-      sha256: c689910d6de33e60b440fe60dbdea0eb09506d9ca25439a26e6aeb95882d2675
+      sha256: bbbead97be9888ae34c3cddcfe3d47ab09240a49c27efb5e2e7549bf01e72aef
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.3"
   at_demo_data:
     dependency: transitive
     description:
@@ -126,10 +118,10 @@ packages:
     dependency: transitive
     description:
       name: at_persistence_secondary_server
-      sha256: b5736436dac6f13f80cc56e9fd5127dc7eae41ba9d3c761732f4dc0bb6db5e77
+      sha256: "5b4a07feabaa75266d92af4a2d810b045d08c229a37154e18a8dcc7cd0070916"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.60"
+    version: "3.0.61"
   at_persistence_spec:
     dependency: transitive
     description:
@@ -238,10 +230,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: a3ec2e0f967bc47f69f95009bb93db936288d61d5343b9436e378b28a2f830c6
+      sha256: fedde275e0a6b798c3296963c5cd224e3e1b55d0e478d5b7e65e6b540f363a0e
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.0"
+    version: "8.9.1"
   chalkdart:
     dependency: transitive
     description:
@@ -350,10 +342,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "40ae61a5d43feea6d24bd22c0537a6629db858963b99b4bc1c3db80676f32368"
+      sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.4"
+    version: "2.3.6"
   dartssh2:
     dependency: "direct main"
     description:
@@ -390,10 +382,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
+      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   file:
     dependency: transitive
     description:
@@ -446,10 +438,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: a2bbf9d017fcced29139daa8ed2bba4ece450ab222871df93ca9eec6f80c34ba
+      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   http_multi_server:
     dependency: transitive
     description:
@@ -869,10 +861,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: a2662fb1f114f4296cf3f5a50786a2d888268d7776cf681aa17d660ffa23b246
+      sha256: e7d5ecd604e499358c5fe35ee828c0298a320d54455e791e9dcf73486bc8d9f0
       url: "https://pub.dev"
     source: hosted
-    version: "14.0.0"
+    version: "14.1.0"
   watcher:
     dependency: transitive
     description:
@@ -885,18 +877,18 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "4188706108906f002b3a293509234588823c8c979dc83304e229ff400c996b05"
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.2"
+    version: "0.5.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "939ab60734a4f8fa95feacb55804fa278de28bdeef38e616dc08e44a84adea23"
+      sha256: "1d8e795e2a8b3730c41b8a98a2dff2e0fb57ae6f0764a1c46ec5915387d257b2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
+    version: "2.4.4"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -925,9 +917,9 @@ packages:
     dependency: transitive
     description:
       name: zxing2
-      sha256: a042961441bd400f59595f9125ef5fca4c888daf0ea59c17f41e0e151f8a12b5
+      sha256: "6cf995abd3c86f01ba882968dedffa7bc130185e382f2300239d2e857fc7912c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.3"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
+  dart: ">=3.3.0 <4.0.0"

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,13 +1,14 @@
 name: sshnoports
 publish_to: none
 
-version: 5.1.0
+version: 5.2.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  noports_core: 6.0.5
+  noports_core:
+    path: "../noports_core"
   at_onboarding_cli: 1.4.3
   args: 2.4.2
   socket_connector: ^2.1.0
@@ -15,27 +16,10 @@ dependencies:
   at_utils: 3.0.16
 
 dependency_overrides:
-  noports_core:
-    path: "../noports_core"
-  # Pin the dependencies of noports_core
-  archive: 3.3.9
   args:
     git:
       ref: gkc/show-aliases-in-usage
       url: https://github.com/gkc/args
-  at_client: 3.0.75
-  at_cli_commons: ^1.0.4
-  at_lookup: 3.0.45
-  at_utils: 3.0.16
-  asn1lib: 1.4.1
-  encrypt: 5.0.1
-  crypton: 2.1.0
-  dartssh2: 2.8.2
-  logging: 1.2.0
-  meta: 1.9.1
-  ssh_key: 0.8.0
-  uuid: 3.0.7
-  version: 3.0.2
 
 dev_dependencies:
   lints: ^3.0.0

--- a/packages/dart/sshnoports/tools/Dockerfile.package
+++ b/packages/dart/sshnoports/tools/Dockerfile.package
@@ -15,7 +15,7 @@ RUN set -eux; \
   cd sshnoports; \
   mkdir -p sshnp/debug; \
   mkdir tarball; \
-  dart pub get; \
+  dart pub get --enforce-lockfile; \
   dart run build_runner build --delete-conflicting-outputs; \
   dart compile exe bin/activate_cli.dart -v -o sshnp/at_activate; \
   dart compile exe bin/sshnp.dart -v -o sshnp/sshnp; \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Removed the dependency overrides from sshnoports
- Added `--enforce-lockfile` flag to `pub get`s in the multibuild
- This will now allow us to use pubspec.lock in sshnoports to achieve repeatable builds, instead of relying on pinned dependencies which dart doesn't have a good way of automatically updating.

**- How I did it**

**- How to verify it**

https://github.com/atsign-foundation/noports/actions/runs/8208067643

**- Description for the changelog**
ci: ensure that dependencies are being properly kept up to date
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
