### PR TITLE
feat: npt: use different session keys for each socket pair

### DIFF
--- a/packages/dart/noports_core/lib/src/srv/srv_impl.dart
+++ b/packages/dart/noports_core/lib/src/srv/srv_impl.dart
@@ -548,7 +548,7 @@ class SrvImplDart implements Srv<SocketConnector> {
     // Authenticate the control socket
     if (rvdAuthString != null) {
       logger.info(
-          '_runClientSideMulti authenticating control socket connection to rvd');
+          '_runDaemonSideMulti authenticating control socket connection to rvd');
       sessionControlSocket.writeln(rvdAuthString);
     }
     DataTransformer controlEncrypter =

--- a/packages/dart/noports_core/lib/src/srv/srv_impl.dart
+++ b/packages/dart/noports_core/lib/src/srv/srv_impl.dart
@@ -445,12 +445,12 @@ class SrvImplDart implements Srv<SocketConnector> {
       transformAtoB: encrypter,
       transformBtoA: decrypter,
       multi: multi,
-      onConnect: (Socket sideA, Socket sideB) async {
+      beforeJoining: (Side sideA, Side sideB) async {
         // Authenticate the sideB socket (to the rvd)
         if (rvdAuthString != null) {
           logger.info(
               '_runClientSideSingle authenticating new connection to rvd');
-          sideB.writeln(rvdAuthString);
+          sideB.socket.writeln(rvdAuthString);
         }
       },
     );

--- a/packages/dart/noports_core/lib/src/srv/srv_impl.dart
+++ b/packages/dart/noports_core/lib/src/srv/srv_impl.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:at_chops/at_chops.dart';
 import 'package:at_utils/at_utils.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:cryptography/dart.dart';
@@ -348,69 +349,64 @@ class SrvImplDart implements Srv<SocketConnector> {
     }
   }
 
+  DataTransformer createEncrypter(String aesKeyBase64, String ivBase64) {
+    final DartAesCtr algorithm = DartAesCtr.with256bits(
+      macAlgorithm: Hmac.sha256(),
+    );
+    final SecretKey sessionAESKey = SecretKey(base64Decode(aesKeyBase64));
+    final List<int> sessionIV = base64Decode(ivBase64);
+
+    return (Stream<List<int>> stream) {
+      return algorithm.encryptStream(
+        stream,
+        secretKey: sessionAESKey,
+        nonce: sessionIV,
+        onMac: (mac) {},
+      );
+    };
+  }
+
+  DataTransformer createDecrypter(String aesKeyBase64, String ivBase64) {
+    final DartAesCtr algorithm = DartAesCtr.with256bits(
+      macAlgorithm: Hmac.sha256(),
+    );
+    final SecretKey sessionAESKey = SecretKey(base64Decode(aesKeyBase64));
+    final List<int> sessionIV = base64Decode(ivBase64);
+
+    return (Stream<List<int>> stream) {
+      return algorithm.decryptStream(
+        stream,
+        secretKey: sessionAESKey,
+        nonce: sessionIV,
+        mac: Mac.empty,
+      );
+    };
+  }
+
   @override
   Future<SocketConnector> run() async {
-    DataTransformer? encrypter;
-    DataTransformer? decrypter;
-
-    if (sessionAESKeyString != null && sessionIVString != null) {
-      final DartAesCtr algorithm = DartAesCtr.with256bits(
-        macAlgorithm: Hmac.sha256(),
-      );
-      final SecretKey sessionAESKey =
-          SecretKey(base64Decode(sessionAESKeyString!));
-      final List<int> sessionIV = base64Decode(sessionIVString!);
-
-      encrypter = (Stream<List<int>> stream) {
-        return algorithm.encryptStream(
-          stream,
-          secretKey: sessionAESKey,
-          nonce: sessionIV,
-          onMac: (mac) {},
-        );
-      };
-      decrypter = (Stream<List<int>> stream) {
-        return algorithm.decryptStream(
-          stream,
-          secretKey: sessionAESKey,
-          nonce: sessionIV,
-          mac: Mac.empty,
-        );
-      };
-    }
-
     try {
       var hosts = await InternetAddress.lookup(streamingHost);
 
       late SocketConnector sc;
       if (bindLocalPort) {
         if (multi) {
-          sc = await _runClientSideMulti(
-            hosts: hosts,
-            encrypter: encrypter,
-            decrypter: decrypter,
-          );
+          if (sessionAESKeyString == null || sessionIVString == null) {
+            throw ArgumentError('Symmetric session encryption key required');
+          }
+          sc = await _runClientSideMulti(hosts: hosts);
         } else {
-          sc = await _runClientSideSingle(
-            hosts: hosts,
-            encrypter: encrypter,
-            decrypter: decrypter,
-          );
+          sc = await _runClientSideSingle(hosts: hosts);
         }
       } else {
         // daemon side
         if (multi) {
-          sc = await _runDaemonSideMulti(
-            hosts: hosts,
-            encrypter: encrypter,
-            decrypter: decrypter,
-          );
+          if (sessionAESKeyString == null || sessionIVString == null) {
+            throw ArgumentError('Symmetric session encryption key required');
+          }
+          sc = await _runDaemonSideMulti(hosts: hosts);
         } else {
-          sc = await _runDaemonSideSingle(
-            hosts: hosts,
-            encrypter: encrypter,
-            decrypter: decrypter,
-          );
+          sc = await _runDaemonSideSingle(hosts: hosts);
         }
       }
 
@@ -433,9 +429,13 @@ class SrvImplDart implements Srv<SocketConnector> {
 
   Future<SocketConnector> _runClientSideSingle({
     required List<InternetAddress> hosts,
-    required DataTransformer? encrypter,
-    required DataTransformer? decrypter,
   }) async {
+    DataTransformer? encrypter;
+    DataTransformer? decrypter;
+    if (sessionAESKeyString != null && sessionIVString != null) {
+      encrypter = createEncrypter(sessionAESKeyString!, sessionIVString!);
+      decrypter = createDecrypter(sessionAESKeyString!, sessionIVString!);
+    }
     // client side
     SocketConnector sc = await SocketConnector.serverToSocket(
       portA: localPort,
@@ -460,81 +460,109 @@ class SrvImplDart implements Srv<SocketConnector> {
 
   Future<SocketConnector> _runClientSideMulti({
     required List<InternetAddress> hosts,
-    required DataTransformer? encrypter,
-    required DataTransformer? decrypter,
   }) async {
     // client side
-    SocketConnector? sc;
+    SocketConnector? socketConnector;
 
-    Socket controlSocket = await Socket.connect(streamingHost, streamingPort,
+    Socket sessionControlSocket = await Socket.connect(
+        streamingHost, streamingPort,
         timeout: Duration(seconds: 1));
     // Authenticate the control socket
     if (rvdAuthString != null) {
       logger.info(
           '_runClientSideMulti authenticating control socket connection to rvd');
-      controlSocket.writeln(rvdAuthString);
+      sessionControlSocket.writeln(rvdAuthString);
     }
-    controlSocket.listen((event) {
+    DataTransformer controlEncrypter =
+        createEncrypter(sessionAESKeyString!, sessionIVString!);
+    DataTransformer controlDecrypter =
+        createDecrypter(sessionAESKeyString!, sessionIVString!);
+
+    // Listen to stream which is decrypting the socket stream
+    // Write to a stream controller which encrypts and writes to the socket
+    Stream<List<int>> controlStream = controlDecrypter(sessionControlSocket);
+    StreamController<Uint8List> controlSink = StreamController<Uint8List>();
+    controlEncrypter(controlSink.stream).listen(sessionControlSocket.add);
+
+    controlStream.listen((event) {
       String response = String.fromCharCodes(event).trim();
       logger.info(
           '_runClientSideMulti Received control socket response: [$response]');
     }, onError: (e) {
       logger.severe('_runClientSideMulti controlSocket error: $e');
-      sc?.close();
+      socketConnector?.close();
     }, onDone: () {
       logger.info('_runClientSideMulti controlSocket done');
-      sc?.close();
+      socketConnector?.close();
     });
 
-    sc = await SocketConnector.serverToSocket(
+    socketConnector = await SocketConnector.serverToSocket(
       portA: localPort,
       addressB: hosts[0],
       portB: streamingPort,
       verbose: false,
-      transformAtoB: encrypter,
-      transformBtoA: decrypter,
       multi: multi,
-      onConnect: (Socket sideA, Socket sideB) {
+      beforeJoining: (Side sideA, Side sideB) {
         // For some bizarro reason, we can't write to stderr in this callback
         // when the Srv has been started via SrvImplExec. Thus it is very
         // important that the srv binary never have a logger root level of
         // anything below 'warning'
         logger.info('_runClientSideMulti Sending connect request');
-        controlSocket.writeln('connect');
+
+        String socketAESKey =
+            AtChopsUtil.generateSymmetricKey(EncryptionKeyType.aes256).key;
+        String socketIV =
+            base64Encode(AtChopsUtil.generateRandomIV(16).ivBytes);
+        controlSink.add(
+            Uint8List.fromList('connect:$socketAESKey:$socketIV'.codeUnits));
         // Authenticate the sideB socket (to the rvd)
         if (rvdAuthString != null) {
           logger
               .info('_runClientSideMulti authenticating new connection to rvd');
-          sideB.writeln(rvdAuthString);
+          sideB.socket.writeln(rvdAuthString);
         }
+        sideA.transformer = createEncrypter(socketAESKey, socketIV);
+        sideB.transformer = createDecrypter(socketAESKey, socketIV);
       },
     );
 
     // upon socketConnector.done, destroy the control socket, and complete
-    unawaited(sc.done.whenComplete(() {
+    unawaited(socketConnector.done.whenComplete(() {
       logger.info('_runClientSideMulti sc.done');
-      controlSocket.destroy();
+      sessionControlSocket.destroy();
     }));
 
-    return sc;
+    return socketConnector;
   }
 
   Future<SocketConnector> _runDaemonSideMulti({
     required List<InternetAddress> hosts,
-    required DataTransformer? encrypter,
-    required DataTransformer? decrypter,
   }) async {
     SocketConnector sc = SocketConnector();
 
     // - create control socket and listen for requests
     // - for each request, create a socketToSocket connection
-    Socket controlSocket = await Socket.connect(streamingHost, streamingPort,
+    Socket sessionControlSocket = await Socket.connect(
+        streamingHost, streamingPort,
         timeout: Duration(seconds: 1));
+    // Authenticate the control socket
     if (rvdAuthString != null) {
-      logger.info('authenticating control socket connection to rvd');
-      controlSocket.writeln(rvdAuthString);
+      logger.info(
+          '_runClientSideMulti authenticating control socket connection to rvd');
+      sessionControlSocket.writeln(rvdAuthString);
     }
-    controlSocket.listen((event) async {
+    DataTransformer controlEncrypter =
+        createEncrypter(sessionAESKeyString!, sessionIVString!);
+    DataTransformer controlDecrypter =
+        createDecrypter(sessionAESKeyString!, sessionIVString!);
+
+    // Listen to stream which is decrypting the socket stream
+    // Write to a stream controller which encrypts and writes to the socket
+    Stream<List<int>> controlStream = controlDecrypter(sessionControlSocket);
+    StreamController<Uint8List> controlSink = StreamController<Uint8List>();
+    controlEncrypter(controlSink.stream).listen(sessionControlSocket.add);
+
+    controlStream.listen((event) async {
       if (event.isEmpty) {
         logger.info('Empty control message (Uint8List) received');
         return;
@@ -544,9 +572,14 @@ class SrvImplDart implements Srv<SocketConnector> {
         logger.info('Empty control message (String) received');
         return;
       }
-      switch (request) {
+      List<String> args = request.split(":");
+      switch (args.first) {
         case 'connect':
-          logger.info('Control socket received request: [$request];'
+          if (args.length != 3) {
+            logger.severe('Unknown request to control socket: [$request]');
+            return;
+          }
+          logger.info('Control socket received ${args.first} request - '
               ' creating new socketToSocket connection');
           await SocketConnector.socketToSocket(
               connector: sc,
@@ -556,8 +589,8 @@ class SrvImplDart implements Srv<SocketConnector> {
               addressB: hosts[0],
               portB: streamingPort,
               verbose: false,
-              transformAtoB: encrypter,
-              transformBtoA: decrypter);
+              transformAtoB: createEncrypter(args[1], args[2]),
+              transformBtoA: createDecrypter(args[1], args[2]));
           if (rvdAuthString != null) {
             stderr.writeln('authenticating new socket connection to rvd');
             sc.connections.last.sideB.socket.writeln(rvdAuthString);
@@ -577,7 +610,7 @@ class SrvImplDart implements Srv<SocketConnector> {
 
     // upon socketConnector.done, destroy the control socket, and complete
     unawaited(sc.done.whenComplete(() {
-      controlSocket.destroy();
+      sessionControlSocket.destroy();
     }));
 
     return sc;
@@ -585,9 +618,13 @@ class SrvImplDart implements Srv<SocketConnector> {
 
   Future<SocketConnector> _runDaemonSideSingle({
     required List<InternetAddress> hosts,
-    required DataTransformer? encrypter,
-    required DataTransformer? decrypter,
   }) async {
+    DataTransformer? encrypter;
+    DataTransformer? decrypter;
+    if (sessionAESKeyString != null && sessionIVString != null) {
+      encrypter = createEncrypter(sessionAESKeyString!, sessionIVString!);
+      decrypter = createDecrypter(sessionAESKeyString!, sessionIVString!);
+    }
     SocketConnector socketConnector = await SocketConnector.socketToSocket(
         addressA: (await InternetAddress.lookup(localHost ?? 'localhost'))[0],
         portA: localPort,

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -21,14 +21,10 @@ dependencies:
   openssh_ed25519: ^1.1.0
   path: ^1.9.0
   posix: ^6.0.1
-  socket_connector: ^2.1.0
+  socket_connector: ^2.2.0
   uuid: ^3.0.7
 
 dependency_overrides:
-  socket_connector:
-    git:
-      ref: gkc/enhance-server-to-socket
-      url: https://github.com/atsign-foundation/socket_connector
   args:
     git:
       ref: gkc/show-aliases-in-usage

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -25,6 +25,8 @@ dependencies:
   uuid: ^3.0.7
 
 dependency_overrides:
+  socket_connector:
+    path: /Users/gary/dev/atsign/repos/socket_connector
   args:
     git:
       ref: gkc/show-aliases-in-usage

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -26,7 +26,9 @@ dependencies:
 
 dependency_overrides:
   socket_connector:
-    path: /Users/gary/dev/atsign/repos/socket_connector
+    git:
+      ref: gkc/enhance-server-to-socket
+      url: https://github.com/atsign-foundation/socket_connector
   args:
     git:
       ref: gkc/show-aliases-in-usage

--- a/packages/dart/sshnoports/bin/npt.dart
+++ b/packages/dart/sshnoports/bin/npt.dart
@@ -11,7 +11,6 @@ import 'package:at_utils/at_logger.dart';
 import 'package:at_cli_commons/at_cli_commons.dart' as cli;
 import 'package:noports_core/npt.dart';
 import 'package:noports_core/sshnp_foundation.dart';
-import 'package:sshnoports/src/extended_arg_parser.dart';
 
 // local packages
 import 'package:sshnoports/src/print_version.dart';
@@ -144,13 +143,13 @@ void main(List<String> args) async {
           defaultsTo: false, negatable: false, help: 'Print usage');
 
       parser.addFlag(
-        outputExecutionCommandFlag,
+        'exit-when-connected',
         abbr: 'x',
         help: 'Instead of running the srv in the same process,'
             ' fork the srv,'
             ' print the local port to stdout,'
             ' and exit this program.',
-        defaultsTo: DefaultExtendedArgs.outputExecutionCommand,
+        defaultsTo: false,
         negatable: false,
       );
 
@@ -171,7 +170,7 @@ void main(List<String> args) async {
       String rootDomain = parsedArgs['root-domain'];
       perSessionStorage = parsedArgs['per-session-storage'];
       int localPort = int.parse(parsedArgs['local-port']);
-      bool inline = !parsedArgs[outputExecutionCommandFlag];
+      bool inline = !parsedArgs['exit-when-connected'];
 
       // Windows will not let us delete files in use so
       // We will point storage to temp directory and let OS clean up

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.2.0';
+const packageVersion = '5.1.0';

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -74,6 +74,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  at_cli_commons:
+    dependency: "direct main"
+    description:
+      name: at_cli_commons
+      sha256: "9165a0547ee36024f5d013cbb455197ef6f1f8a2c93620b1c49cb2eeead92157"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   at_client:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -78,10 +78,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_cli_commons
-      sha256: "9165a0547ee36024f5d013cbb455197ef6f1f8a2c93620b1c49cb2eeead92157"
+      sha256: "6360c1a05a358240e7ffb264e9ae089a95db0367f4ae3649c30c18763c398ea0"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   at_client:
     dependency: transitive
     description:
@@ -716,11 +716,10 @@ packages:
   socket_connector:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "gkc/enhance-server-to-socket"
-      resolved-ref: "88fddf55787a25f085f4d56b8eff5db3108df800"
-      url: "https://github.com/atsign-foundation/socket_connector"
-    source: git
+      name: socket_connector
+      sha256: "3c641546699aa58e9ab8be9841627a30af3c1ffcf4461ca5d00d7c56392ab63a"
+      url: "https://pub.dev"
+    source: hosted
     version: "2.2.0"
   source_map_stack_trace:
     dependency: transitive

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -719,7 +719,7 @@ packages:
       path: "/Users/gary/dev/atsign/repos/socket_connector"
       relative: false
     source: path
-    version: "2.1.0"
+    version: "2.2.0"
   source_map_stack_trace:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -716,10 +716,9 @@ packages:
   socket_connector:
     dependency: "direct main"
     description:
-      name: socket_connector
-      sha256: a614741652395393bc8e06987a0569bac116b2112645cc846015949dcf66aebd
-      url: "https://pub.dev"
-    source: hosted
+      path: "/Users/gary/dev/atsign/repos/socket_connector"
+      relative: false
+    source: path
     version: "2.1.0"
   source_map_stack_trace:
     dependency: transitive

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -716,9 +716,11 @@ packages:
   socket_connector:
     dependency: "direct main"
     description:
-      path: "/Users/gary/dev/atsign/repos/socket_connector"
-      relative: false
-    source: path
+      path: "."
+      ref: "gkc/enhance-server-to-socket"
+      resolved-ref: "88fddf55787a25f085f4d56b8eff5db3108df800"
+      url: "https://github.com/atsign-foundation/socket_connector"
+    source: git
     version: "2.2.0"
   source_map_stack_trace:
     dependency: transitive

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -10,17 +10,13 @@ dependencies:
   noports_core:
     path: "../noports_core"
   at_onboarding_cli: 1.4.3
-  at_cli_commons: ^1.0.4
+  at_cli_commons: ^1.0.5
   args: 2.4.2
-  socket_connector: ^2.1.0
+  socket_connector: ^2.2.0
   dartssh2: 2.8.2
   at_utils: 3.0.16
 
 dependency_overrides:
-  socket_connector:
-    git:
-      ref: gkc/enhance-server-to-socket
-      url: https://github.com/atsign-foundation/socket_connector
   args:
     git:
       ref: gkc/show-aliases-in-usage

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   noports_core:
     path: "../noports_core"
   at_onboarding_cli: 1.4.3
+  at_cli_commons: ^1.0.4
   args: 2.4.2
   socket_connector: ^2.1.0
   dartssh2: 2.8.2

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -18,7 +18,9 @@ dependencies:
 
 dependency_overrides:
   socket_connector:
-    path: /Users/gary/dev/atsign/repos/socket_connector
+    git:
+      ref: gkc/enhance-server-to-socket
+      url: https://github.com/atsign-foundation/socket_connector
   args:
     git:
       ref: gkc/show-aliases-in-usage

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -16,6 +16,8 @@ dependencies:
   at_utils: 3.0.16
 
 dependency_overrides:
+  socket_connector:
+    path: /Users/gary/dev/atsign/repos/socket_connector
   args:
     git:
       ref: gkc/show-aliases-in-usage

--- a/packages/dart/sshnp_flutter/pubspec.lock
+++ b/packages/dart/sshnp_flutter/pubspec.lock
@@ -792,11 +792,10 @@ packages:
   noports_core:
     dependency: "direct main"
     description:
-      name: noports_core
-      sha256: "616afc599117dd9881aaf59893cbaacf1234a4e2e16e415e3a08b2d4b45eac05"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.0.2"
+      path: "../noports_core"
+      relative: true
+    source: path
+    version: "6.0.5"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/sshnp_flutter/pubspec.lock
+++ b/packages/dart/sshnp_flutter/pubspec.lock
@@ -1149,10 +1149,10 @@ packages:
     dependency: "direct main"
     description:
       name: socket_connector
-      sha256: a614741652395393bc8e06987a0569bac116b2112645cc846015949dcf66aebd
+      sha256: "3c641546699aa58e9ab8be9841627a30af3c1ffcf4461ca5d00d7c56392ab63a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   source_span:
     dependency: transitive
     description:

--- a/tests/e2e_all/scripts/common/cleanup_tmp_files.sh
+++ b/tests/e2e_all/scripts/common/cleanup_tmp_files.sh
@@ -14,10 +14,19 @@ localLogInfo() {
   if [[ "$silent" == "true" ]]; then return; fi
   logInfo "$1"
 }
+
+safeRemoveDir() {
+  dirToRemove="$1"
+  if grep -q "e2e_all/runtime" <<< "$dirToRemove" || grep -q "e2e_all/${commitId}" <<< "$dirToRemove"
+  then
+    localLogInfo "rm -rf ${dirToRemove:fubar}"
+    rm -rf "${dirToRemove:fubar}"
+  fi
+}
 echo
 localLogInfo ""
 localLogInfo "Cleaning up"
 
-outputDir=$(getOutputDir)
-localLogInfo "rm -rf ${outputDir}"
-rm -rf "${outputDir}"
+safeRemoveDir "$(getOutputDir)"
+
+safeRemoveDir "$testRuntimeDir"

--- a/tests/e2e_all/scripts/common/cleanup_tmp_files.sh
+++ b/tests/e2e_all/scripts/common/cleanup_tmp_files.sh
@@ -28,5 +28,3 @@ localLogInfo ""
 localLogInfo "Cleaning up"
 
 safeRemoveDir "$(getOutputDir)"
-
-safeRemoveDir "$testRuntimeDir"

--- a/tests/e2e_all/scripts/common/common_functions.include.sh
+++ b/tests/e2e_all/scripts/common/common_functions.include.sh
@@ -19,6 +19,17 @@ getBaseSshnpCommand() {
   echo "$l1" "$l2" "$l3"
 }
 
+getBaseNptCommand() {
+  if (( $# != 1 )); then
+    logErrorAndExit "getBaseNptCommand requires 1 argument (clientBinaryPath)"
+  fi
+  clientBinaryPath="$1"
+  l1="$clientBinaryPath/npt -f $clientAtSign -d $deviceName"
+  l2=" -t $daemonAtSign -r $srvAtSign"
+  l3=" --root-domain $atDirectoryHost"
+  echo "$l1" "$l2" "$l3"
+}
+
 getTestSshCommand() {
   testSshCommand="$1"
 

--- a/tests/e2e_all/scripts/main.sh
+++ b/tests/e2e_all/scripts/main.sh
@@ -159,6 +159,8 @@ cd "$commitId" || exit 1 # should now be in <repo_root>/tests/e2e_all/runtime/$c
 testRuntimeDir="$(pwd)"
 export testRuntimeDir
 
+"$testScriptsDir/common/cleanup_tmp_files.sh" -s
+
 logInfo "  --> will execute setup_binaries, start_daemons and tests [$testsToRun] with "
 logInfo "    testRootDir:      $testRootDir"
 logInfo "    testRuntimeDir:   $testRuntimeDir"

--- a/tests/e2e_all/scripts/main.sh
+++ b/tests/e2e_all/scripts/main.sh
@@ -159,8 +159,6 @@ cd "$commitId" || exit 1 # should now be in <repo_root>/tests/e2e_all/runtime/$c
 testRuntimeDir="$(pwd)"
 export testRuntimeDir
 
-"$testScriptsDir/common/cleanup_tmp_files.sh" -s
-
 logInfo "  --> will execute setup_binaries, start_daemons and tests [$testsToRun] with "
 logInfo "    testRootDir:      $testRootDir"
 logInfo "    testRuntimeDir:   $testRuntimeDir"
@@ -223,19 +221,19 @@ restoreAuthorizedKeys
 
 reportFile=$(getReportFile)
 
+echo
+logInfo "Calling common/cleanup_tmp_files.sh"
+"$testScriptsDir/common/cleanup_tmp_files.sh"
+retCode=$?
+if test "$retCode" != 0; then
+  log "cleanup_tmp_files failed with exit status $retCode"
+fi
+
 logInfo ""
 logInfo "Tests completed. Report follows. (Can also be found at ${reportFile}) : "
 echo
 cat "$reportFile"
 logInfo ""
 logInfo ""
-
-echo
-logInfo "Calling common/cleanup_tmp_files.sh"
-"$testScriptsDir/common/cleanup_tmp_files.sh"
-retCode=$?
-if test "$retCode" != 0; then
-  logError "cleanup_tmp_files failed with exit status $retCode"
-fi
 
 exit $testExitStatus

--- a/tests/e2e_all/scripts/tests/npt_to_port_22
+++ b/tests/e2e_all/scripts/tests/npt_to_port_22
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+scriptName=$(basename -- "$0")
+
+if test -z "$testScriptsDir" ; then
+  echo -e "    ${RED}check_env: testScriptsDir is not set${NC}" && exit 1
+fi
+
+source "$testScriptsDir/common/common_functions.include.sh"
+source "$testScriptsDir/common/check_env.include.sh" || exit $?
+
+daemonVersion="$1"
+clientVersion="$2"
+additionalFlags="--remote-port 22 --exit-when-connected"
+
+# If client has already been released
+# then it has already have been tested against all released daemon versions
+# So only test it against the 'current' daemon
+# i.e. if client != current and daemon != current then exit 50
+
+if ! grep -q "current" <<< "$clientVersion" && ! grep -q "current" <<< "$daemonVersion" ; then
+  logInfoAndReport "    N/A  because released client $(getVersionDescription "$clientVersion") has already been tested against released daemon $(getVersionDescription "$daemonVersion")"
+  exit 50
+fi
+
+# Require a v5.1+ client to test v5.1+ features
+if [[ $(versionIsLessThan "$clientVersion" "d:5.1.0") == "true" ]] \
+    || \
+   [[ $(versionIsLessThan "$daemonVersion" "d:5.1.0") == "true" ]]; then
+  logInfoAndReport "    N/A  because npt requires client and daemon versions >= v5.1.x"
+  exit 50 # test rig interprets this exit status as 'test was not applicable'
+fi
+
+deviceName=$(getDeviceNameWithFlags "$commitId" "$daemonVersion" )
+
+clientBinaryPath=$(getPathToBinariesForTypeAndVersion "$clientVersion")
+
+baseNptCommand=$(getBaseNptCommand "$clientBinaryPath")
+
+# Let's put together the npt command we will execute
+nptCommand="$baseNptCommand $additionalFlags"
+
+# 1. Execute the npt command - its output is the port that npt is using
+echo "$(iso8601Date) | Executing $nptCommand" | tee -a "$(getReportFile)"
+nptPort=$($nptCommand)
+
+# 2. Check the exit status
+nptExitStatus=$?
+if (( nptExitStatus != 0 )); then
+  exit $nptExitStatus
+fi
+
+# 3. Execute an ssh
+sshCommand="ssh -p $nptPort -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes"
+sshCommand="${sshCommand} ${remoteUsername}@localhost -i $identityFilename"
+
+echo "$(iso8601Date) | Executing $sshCommand" | tee -a "$(getReportFile)"
+
+# shellcheck disable=SC2091
+$(getTestSshCommand "$sshCommand")
+
+# 4. Exit with the exit status of the ssh command
+exit $?

--- a/tests/e2e_all/scripts/tests/shared/sshnp
+++ b/tests/e2e_all/scripts/tests/shared/sshnp
@@ -38,10 +38,8 @@ fi
 
 additionalSshnpFlags=" --ssh-client ${sshClient}"
 
-# logInfo "Daemon version : $d_type : $d_major.$d_minor.$d_patch"
 deviceName=$(getDeviceNameWithFlags "$commitId" "$daemonVersion" )
 
-# logInfo "Client version : $c_type : $c_major.$c_minor.$c_patch"
 clientBinaryPath=$(getPathToBinariesForTypeAndVersion "$clientVersion")
 
 baseSshnpCommand=$(getBaseSshnpCommand "$clientBinaryPath")


### PR DESCRIPTION
**- What I did**
- feat: npt: use different session keys for each socket pair
- test: add end-to-end test of npt (NoPorts Tunnel)
- Resolves #866 
- Resolves #890 

**- How I did it**
- **Daemon and client** Currently, both sides create a control socket and authenticate
  - but there is no e2ee on the control socket
  - **Change** Now have e2ee on the control socket with encrypters / decrypters using the AES key and IV which were exchanged earlier via atProtocol notifications
- **Client** Currently, client side calls serverToSocket
  - On new local socket, sends 'connect' message on the control socket
  - Uses same encrypter & decrypter for all connections
  - **Change** We now generate new AES key and IV for each new connection and send it along with the 'connect' message. It's safe to do so because the control socket is now end-to-end-encrypted using session key which is exchanged via atProtocol notifications
  - **Change** And then, using the new 'beforeJoining' callback provided by socket_connector's `serverToSocket` method, we set encrypt/decrypt transformers on the new Connection's Sides before they start exchanging data
- **Daemon** Currently, the daemon side listens for 'connect' messages on the control socket and then creates new socket pairs all of which have the same session keys
  - **Change** And when we receive a `connect` message from the client, we use the provided AES and IV to create new encrypters / decrypters for the new socketToSocket pair


**- How to verify it**
- Tests pass
