### PR TITLE
ci: universal.sh tagged version build output

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -173,7 +173,8 @@ jobs:
             file=$1
             variable=$2
             value=$3
-            sed -i'' "/$start_line/,/$end_line/;s/$variable=\".*\"/$variable=\"$value\"/" "$file"
+            # since this is linux only, sed -i is safe without a file ext.
+            sed -i "/$start_line/,/$end_line/s|$variable=\".*\"|$variable=\"$value\"|g" "$file"
           }
           REF=${{ github.ref }}
           TAG=${REF:10}

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -177,7 +177,7 @@ jobs:
             sed -i "/$start_line/,/$end_line/s|$variable=\".*\"|$variable=\"$value\"|g" "$file"
           }
           REF=${{ github.ref }}
-          TAG=${REF:10}
+          TAG=${REF:11}
           write_metadata universal.sh sshnp_version "$TAG"
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -184,7 +184,7 @@ jobs:
           path: ./packages/dart/sshnoports/bundles/universal.sh
           if-no-files-found: error
   notify_on_completion:
-    needs: [main_build, other_build, universal_installer]
+    needs: [main_build, other_build, universal_sh]
     runs-on: ubuntu-latest
     steps:
       - name: Google Chat Notification
@@ -196,7 +196,7 @@ jobs:
 
   notify_on_failure:
     if: failure()
-    needs: [main_build, other_build, universal_installer]
+    needs: [main_build, other_build, universal_sh]
     runs-on: ubuntu-latest
     steps:
       - name: Google Chat Notification

--- a/packages/dart/sshnoports/bundles/shell/install.sh
+++ b/packages/dart/sshnoports/bundles/shell/install.sh
@@ -34,6 +34,14 @@ is_darwin() {
 	[ "$(uname)" = 'Darwin' ]
 }
 
+sedi() {
+	if is_darwin; then
+		sed -i '' "$@"
+	else
+		sed -i "$@"
+	fi
+}
+
 no_mac() {
 	if is_darwin; then
 		echo "Error: this operation is only supported on linux"
@@ -294,7 +302,7 @@ install_headless_job() {
 	if ! [ -f "$dest" ]; then
 		cp "$script_dir/headless/$job_name.sh" "$dest"
 		if is_root; then
-			sed -i'' "s|^binary_path=\".*\"$|binary_path=\"$bin_dir\"|g" "$dest"
+			sedi "s|^binary_path=\".*\"$|binary_path=\"$bin_dir\"|g" "$dest"
 		fi
 	fi
 
@@ -376,7 +384,7 @@ install_tmux_service() {
 	if ! [ -f "$dest" ]; then
 		cp "$script_dir/headless/$service_name.sh" "$dest"
 		if is_root; then
-			sed -i'' "s|^binary_path=\".*\"$|binary_path=\"$bin_dir\"|g" "$dest"
+			sedi "s|^binary_path=\".*\"$|binary_path=\"$bin_dir\"|g" "$dest"
 		fi
 	fi
 

--- a/packages/dart/sshnoports/bundles/shell/magic/sshnp.sh
+++ b/packages/dart/sshnoports/bundles/shell/magic/sshnp.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-#SCRIPT METADATA
+# SCRIPT METADATA
 binary_path="$HOME/.local/bin"
 client_atsign=""
 device_atsign=""
 host_atsign=""
 devices=(device1 device2 device3)
 additional_args=()
-#END METADATA
+# END METADATA
 
 unset d
 select d in "${devices[@]}"; do

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -11,7 +11,7 @@ repo_url="https://github.com/atsign-foundation/sshnoports"
 # nothing else should be writen outside the main function to avoid side effects
 
 ### Environment based variables
-unset arg_zero="$0"
+arg_zero="$0"
 unset script_dir
 unset platform_name
 unset system_arch

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -60,6 +60,15 @@ is_root() {
 is_darwin() {
 	[ "$(uname)" = 'Darwin' ]
 }
+
+sedi() {
+	if is_darwin; then
+		sed -i '' "$@"
+	else
+		sed -i "$@"
+	fi
+}
+
 version() {
 	echo "Version: $script_version (Target: $sshnp_version)"
 }
@@ -274,7 +283,7 @@ write_metadata() {
 	file=$1
 	variable=$2
 	value=$3
-	sed -i'' "/$start_line/,/$end_line/;s/$variable=\".*\"/$variable=\"$value\"/" "$file"
+	sedi "/$start_line/,/$end_line/s|$variable=\".*\"|$variable=\"$value\"|g " "$file"
 }
 
 write_metadata_array() {
@@ -284,7 +293,7 @@ write_metadata_array() {
 	file=$1
 	variable=$2
 	value=$(echo "$3" | tr ',' ' ')
-	sed -i'' "/$start_line/,/$end_line/;s/$variable=(.*)/$variable=($value)" "$file"
+	sedi "/$start_line/,/$end_line/s|$variable=(.*)|$variable=($value)|g" "$file"
 }
 
 write_program_arguments_plist() {
@@ -299,14 +308,14 @@ write_program_arguments_plist() {
 		string_array="$string_array\n<string>$1</string>"
 		shift
 	done
-	sed -i'' "/$start_line/,/$end_line/c\\$start_line\n$second_line$string_array\n$end_line\n" "$file"
+	sedi "/$start_line/,/$end_line/c\\$start_line\n$second_line$string_array\n$end_line\n" "$file"
 }
 
 write_systemd_environment() {
 	file=$1
 	variable=$2
 	value=$3
-	sed -i'' "s/Environment=$variable=\".*\"/Environment=$variable=\"$value\"/" "$file"
+	sedi "s|Environment=$variable=\".*\"|Environment=$variable=\"$value\"|g" "$file"
 }
 
 get_client_device_atsigns() {

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.1.0';
+const packageVersion = '5.1.0-rc.1';

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.1.0-rc.2';
+const packageVersion = '5.1.0-rc.3';

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.1.0-rc.3';
+const packageVersion = '5.1.0-rc.4';

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.1.0-rc.1';
+const packageVersion = '5.1.0-rc.2';

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.1.0-rc.2
+version: 5.1.0-rc.3
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.1.0
+version: 5.1.0-rc.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.1.0-rc.3
+version: 5.1.0-rc.4
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.1.0-rc.1
+version: 5.1.0-rc.2
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Created this PR for visibility, so that I can show the multibuild script creating the universal.sh correctly

Metadata of the generated file (notice that sshnp_version successfully matches the github tag - intentionally without the v)
```sh
#!/bin/sh

# SCRIPT METADATA
# DO NOT MODIFY/DELETE THIS BLOCK
script_version="3.0.0"
sshnp_version="5.1.0-rc.4"
repo_url="https://github.com/atsign-foundation/sshnoports"
# END METADATA
```
[Link to the workflow](https://github.com/atsign-foundation/noports/actions/runs/8382007278)


**- How I did it**

**- How to verify it**

**- Description for the changelog**
ci: universal.sh tagged version build output
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
