### PR TITLE
feat: Updated bundle file to mention comma separated list of atsigns …

### DIFF
--- a/packages/dart/sshnoports/bundles/shell/headless/sshnpd.sh
+++ b/packages/dart/sshnoports/bundles/shell/headless/sshnpd.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2154
 # SCRIPT METADATA
 binary_path="$HOME/.local/bin"
-manager_atsign="@example_client" # MANDATORY: Manager/client address (atSign)
+manager_atsign="@example_client" # MANDATORY: Manager/client address/Comma separated addresses (atSign/s)
 device_atsign="@example_device"  # MANDATORY: Device address (atSign)
 device_name="default"            # Device name
 user="$(whoami)"                 # MANDATORY: Username


### PR DESCRIPTION
Added comment for a list of manager atSigns in the default file.


**- What I did**
Noticed that the list of manager atsigns was not noted in the template
**- How I did it**
Added a comment
**- How to verify it**
Checked to see that this feature now works by adding multiple atSigns
**- Description for the changelog**
Updated template config file
