### PR TITLE
fix: the rest of universal installer

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -57,6 +57,7 @@ jobs:
       - run: dart run build_runner build --delete-conflicting-outputs
       - run: dart compile exe bin/activate_cli.dart -v -o sshnp/at_activate${{ matrix.ext }}
       - run: dart compile exe bin/sshnp.dart -v -o sshnp/sshnp${{ matrix.ext }}
+      - run: dart compile exe bin/npt.dart -v -o sshnp/npt${{ matrix.ext }}
       - if: ${{ matrix.os != 'windows-latest' }}
         run: dart compile exe bin/sshnpd.dart -v -o sshnp/sshnpd${{ matrix.ext }}
       - run: dart compile exe bin/srv.dart -v -o sshnp/srv${{ matrix.ext }}
@@ -97,7 +98,7 @@ jobs:
             --prefix "com.atsign." \
             --timestamp \
             -v \
-            sshnp/{ssh*,srv,srvd,at_activate,debug/srvd}
+            sshnp/{sshnp,sshnpd,srv,srvd,at_activate,debug/srvd,npt}
 
       # zip the build
       - if: ${{ matrix.os == 'macOS-latest' || matrix.os == 'macos-14'}}

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -154,7 +154,7 @@ jobs:
       - run: tar -xvf bins.tar -C tarballs
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: ${{ matrix.output-name }}--${{github.ref_name}}-${{github.run_number}}--${{github.run_attempt}}
+          name: ${{ matrix.output-name }}-${{github.ref_name}}-${{github.run_number}}-${{github.run_attempt}}
           path: ./packages/dart/tarballs/${{ matrix.output-name }}.tgz
           if-no-files-found: error
 

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -122,7 +122,7 @@ jobs:
       # upload the build
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: ${{ matrix.output-name }}-${{github.ref_name}}-${{github.run_number}}${{github.run_attempt}}
+          name: ${{ matrix.output-name }}-${{github.ref_name}}-${{github.run_number}}-${{github.run_attempt}}
           path: ./packages/dart/sshnoports/tarball
           if-no-files-found: error
 
@@ -154,7 +154,7 @@ jobs:
       - run: tar -xvf bins.tar -C tarballs
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: ${{ matrix.output-name }}-${{github.ref_name}}-${{github.run_number}}${{github.run_attempt}}
+          name: ${{ matrix.output-name }}--${{github.ref_name}}-${{github.run_number}}--${{github.run_attempt}}
           path: ./packages/dart/tarballs/${{ matrix.output-name }}.tgz
           if-no-files-found: error
 
@@ -181,7 +181,7 @@ jobs:
           write_metadata universal.sh sshnp_version "$TAG"
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: universal.sh-${{github.ref_name}}-${{github.run_number}}${{github.run_attempt}}
+          name: universal.sh-${{github.ref_name}}-${{github.run_number}}-${{github.run_attempt}}
           path: ./packages/dart/sshnoports/bundles/universal.sh
           if-no-files-found: error
   notify_on_completion:

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -122,7 +122,7 @@ jobs:
       # upload the build
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: ${{ matrix.output-name }}-upload
+          name: ${{ matrix.output-name }}-${{github.ref_name}}-${{github.run_number}}${{github.run_attempt}}
           path: ./packages/dart/sshnoports/tarball
           if-no-files-found: error
 
@@ -154,7 +154,7 @@ jobs:
       - run: tar -xvf bins.tar -C tarballs
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: ${{ matrix.output-name }}-upload
+          name: ${{ matrix.output-name }}-${{github.ref_name}}-${{github.run_number}}${{github.run_attempt}}
           path: ./packages/dart/tarballs/${{ matrix.output-name }}.tgz
           if-no-files-found: error
 
@@ -181,7 +181,7 @@ jobs:
           write_metadata universal.sh sshnp_version "$TAG"
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: universal.sh
+          name: universal.sh-${{github.ref_name}}-${{github.run_number}}${{github.run_attempt}}
           path: ./packages/dart/sshnoports/bundles/universal.sh
           if-no-files-found: error
   notify_on_completion:

--- a/packages/dart/sshnoports/bundles/shell/install.sh
+++ b/packages/dart/sshnoports/bundles/shell/install.sh
@@ -2,483 +2,483 @@
 
 # SYSTEM GIVENS #
 is_root() {
-	[ "$(id -u)" -eq 0 ]
+    [ "$(id -u)" -eq 0 ]
 }
 
 unset binary_dir
 user_home=$HOME
 define_env() {
-	script_dir="$(dirname -- "$(readlink -f -- "$0")")"
-	bin_dir="/usr/local/bin"
-	systemd_dir="/etc/systemd/system"
-	if is_root; then
-		user="$SUDO_USER"
-		if [ -z "$user" ]; then
-			user="root"
-		else
-			# we are root, but via sudo
-			# so get home directory of SUDO_USER
-			user_home=$(sudo -u "$user" sh -c 'echo $HOME')
-		fi
-	else
-		user="$USER"
-	fi
-	launchd_dir="$user_home/Library/LaunchAgents"
-	user_bin_dir="$user_home/.local/bin"
-	user_sshnpd_dir="$user_home/.sshnpd"
-	user_log_dir="$user_sshnpd_dir/logs"
-	user_ssh_dir="$user_home/.ssh"
+    script_dir="$(dirname -- "$(readlink -f -- "$0")")"
+    bin_dir="/usr/local/bin"
+    systemd_dir="/etc/systemd/system"
+    if is_root; then
+        user="$SUDO_USER"
+        if [ -z "$user" ]; then
+            user="root"
+        else
+            # we are root, but via sudo
+            # so get home directory of SUDO_USER
+            user_home=$(sudo -u "$user" sh -c 'echo $HOME')
+        fi
+    else
+        user="$USER"
+    fi
+    launchd_dir="$user_home/Library/LaunchAgents"
+    user_bin_dir="$user_home/.local/bin"
+    user_sshnpd_dir="$user_home/.sshnpd"
+    user_log_dir="$user_sshnpd_dir/logs"
+    user_ssh_dir="$user_home/.ssh"
 }
 
 is_darwin() {
-	[ "$(uname)" = 'Darwin' ]
+    [ "$(uname)" = 'Darwin' ]
 }
 
 sedi() {
-	if is_darwin; then
-		sed -i '' "$@"
-	else
-		sed -i "$@"
-	fi
+    if is_darwin; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
 }
 
 no_mac() {
-	if is_darwin; then
-		echo "Error: this operation is only supported on linux"
-		exit 1
-	fi
+    if is_darwin; then
+        echo "Error: this operation is only supported on linux"
+        exit 1
+    fi
 }
 
 root_only() {
-	if ! is_root; then
-		echo "Error: this operation requires root privileges"
-		exit 1
-	fi
+    if ! is_root; then
+        echo "Error: this operation requires root privileges"
+        exit 1
+    fi
 }
 
 # USAGE #
 
 usage() {
-	if [ -z "$arg_zero" ]; then
-		arg_zero='install.sh'
-	fi
-	echo "$arg_zero [...options] [command]"
-	echo "Available commands:"
-	echo "at_activate     - install at_activate"
-	echo "npt             - install npt"
-	echo "sshnp           - install sshnp"
-	echo "sshnpd          - install sshnpd"
-	echo "srv             - install srv"
-	echo "srvd            - install srvd"
-	echo "binaries        - install all base binaries (everything above)"
-	echo ""
-	echo "debug_srvd      - install srvd with debugging enabled"
-	echo "debug           - install all debug binaries"
-	echo ""
-	echo "all             - install all binaries (everything above)"
-	if ! is_darwin; then
-		echo ""
-		echo "systemd <unit>  - install a systemd unit"
-		echo "                  available units: [sshnpd, srvd]"
-	fi
-	if is_darwin; then
-		echo ""
-		echo "launchd <unit>  - install a launchd unit"
-		echo "                  available units: [sshnpd]"
-	fi
-	echo ""
-	echo "headless <job>  - install a headless cron job"
-	echo "                  available jobs: [sshnpd, srvd]"
-	echo ""
-	echo "tmux <service>  - install a service in a tmux session"
-	echo "                  available services: [sshnpd, srvd]"
-	echo ""
-	echo "Options:"
-	echo "-b <dir>        - override the directory in which the binaries are written to"
-	echo "-u <username>   - override the user to install the binaries for"
+    if [ -z "$arg_zero" ]; then
+        arg_zero='install.sh'
+    fi
+    echo "$arg_zero [...options] [command]"
+    echo "Available commands:"
+    echo "at_activate     - install at_activate"
+    echo "npt             - install npt"
+    echo "sshnp           - install sshnp"
+    echo "sshnpd          - install sshnpd"
+    echo "srv             - install srv"
+    echo "srvd            - install srvd"
+    echo "binaries        - install all base binaries (everything above)"
+    echo ""
+    echo "debug_srvd      - install srvd with debugging enabled"
+    echo "debug           - install all debug binaries"
+    echo ""
+    echo "all             - install all binaries (everything above)"
+    if ! is_darwin; then
+        echo ""
+        echo "systemd <unit>  - install a systemd unit"
+        echo "                  available units: [sshnpd, srvd]"
+    fi
+    if is_darwin; then
+        echo ""
+        echo "launchd <unit>  - install a launchd unit"
+        echo "                  available units: [sshnpd]"
+    fi
+    echo ""
+    echo "headless <job>  - install a headless cron job"
+    echo "                  available jobs: [sshnpd, srvd]"
+    echo ""
+    echo "tmux <service>  - install a service in a tmux session"
+    echo "                  available services: [sshnpd, srvd]"
+    echo ""
+    echo "Options:"
+    echo "-b <dir>        - override the directory in which the binaries are written to"
+    echo "-u <username>   - override the user to install the binaries for"
 }
 
 # SETUP AUTHORIZED KEYS #
 
 setup_authorized_keys() {
-	mkdir -p "$user_ssh_dir"
-	touch "$user_ssh_dir/authorized_keys"
-	chmod 644 "$user_ssh_dir/authorized_keys"
+    mkdir -p "$user_ssh_dir"
+    touch "$user_ssh_dir/authorized_keys"
+    chmod 644 "$user_ssh_dir/authorized_keys"
 }
 
 # INSTALL BINARIES #
 
 install_single_binary() {
-	if [ -n "$binary_dir" ]; then
-		dest="$binary_dir"
-	elif is_root; then
-		dest="$bin_dir"
-	else
-		dest="$user_bin_dir"
-	fi
-	mkdir -p "$dest"
-	if test -f "$dest/$1"; then
-		if test -f "$dest/$1.old"; then
-			if rm -f "$dest/$1.old"; then
-				echo "=> Removed $dest/$1.old"
-			else
-				echo "Failed to remove $dest/$1.old - aborting"
-				exit 1
-			fi
-		fi
-		if mv "$dest/$1" "$dest/$1.old"; then
-			echo "=> Renamed existing binary $dest/$1 to $dest/$1.old"
-		else
-			echo "Failed to rename $dest/$1 to $dest/$1.old - aborting"
-			exit 1
-		fi
-	fi
-	cp -f "$script_dir/$1" "$dest/$1"
+    if [ -n "$binary_dir" ]; then
+        dest="$binary_dir"
+    elif is_root; then
+        dest="$bin_dir"
+    else
+        dest="$user_bin_dir"
+    fi
+    mkdir -p "$dest"
+    if test -f "$dest/$1"; then
+        if test -f "$dest/$1.old"; then
+            if rm -f "$dest/$1.old"; then
+                echo "=> Removed $dest/$1.old"
+            else
+                echo "Failed to remove $dest/$1.old - aborting"
+                exit 1
+            fi
+        fi
+        if mv "$dest/$1" "$dest/$1.old"; then
+            echo "=> Renamed existing binary $dest/$1 to $dest/$1.old"
+        else
+            echo "Failed to rename $dest/$1 to $dest/$1.old - aborting"
+            exit 1
+        fi
+    fi
+    cp -f "$script_dir/$1" "$dest/$1"
 
-	echo "=> Installed $1 to $dest"
-	if
-		is_root &
-		! [ -f "$user_bin_dir/$1" ]
-	then
-		mkdir -p "$user_bin_dir"
-		ln -sf "$dest/$1" "$user_bin_dir/$1"
-		echo "=> Linked $user_bin_dir/$1 to $dest/$1"
-	fi
+    echo "=> Installed $1 to $dest"
+    if
+        is_root &
+        ! [ -f "$user_bin_dir/$1" ]
+    then
+        mkdir -p "$user_bin_dir"
+        ln -sf "$dest/$1" "$user_bin_dir/$1"
+        echo "=> Linked $user_bin_dir/$1 to $dest/$1"
+    fi
 }
 
 install_base_binaries() {
-	install_single_binary "at_activate"
-	install_single_binary "sshnp"
-	install_single_binary "sshnpd"
-	install_single_binary "srv"
-	install_single_binary "srvd"
-	install_single_binary "npt"
+    install_single_binary "at_activate"
+    install_single_binary "sshnp"
+    install_single_binary "sshnpd"
+    install_single_binary "srv"
+    install_single_binary "srvd"
+    install_single_binary "npt"
 }
 
 install_debug_binary() {
-	if [ -n "$binary_dir" ]; then
-		dest="$binary_dir"
-	elif is_root; then
-		dest="$bin_dir"
-	else
-		dest="$user_bin_dir"
-	fi
-	mkdir -p "$dest"
-	cp "$script_dir/debug/$1" "$bin_dir/debug_$1"
-	echo "=> Installed debug_$1 to $dest"
+    if [ -n "$binary_dir" ]; then
+        dest="$binary_dir"
+    elif is_root; then
+        dest="$bin_dir"
+    else
+        dest="$user_bin_dir"
+    fi
+    mkdir -p "$dest"
+    cp "$script_dir/debug/$1" "$bin_dir/debug_$1"
+    echo "=> Installed debug_$1 to $dest"
 }
 
 install_debug_binaries() {
-	install_debug_binary "srvd"
+    install_debug_binary "srvd"
 }
 
 install_all_binaries() {
-	install_base_binaries
-	install_debug_binaries
+    install_base_binaries
+    install_debug_binaries
 }
 
 # SYSTEMD #
 
 post_systemd_message() {
-	echo "Systemd unit installed, make sure to configure the unit by editing $dest"
-	echo "Learn more in $script_dir/systemd/README.md"
-	echo ""
-	echo "To enable the service on next boot:"
-	echo "  sudo systemctl enable $unit_name"
-	echo ""
-	echo "To start the service immediately:"
-	echo "  sudo systemctl start $unit_name"
+    echo "Systemd unit installed, make sure to configure the unit by editing $dest"
+    echo "Learn more in $script_dir/systemd/README.md"
+    echo ""
+    echo "To enable the service on next boot:"
+    echo "  sudo systemctl enable $unit_name"
+    echo ""
+    echo "To start the service immediately:"
+    echo "  sudo systemctl start $unit_name"
 }
 
 install_systemd_unit() {
-	unit_name="$1"
-	no_mac
-	mkdir -p "$systemd_dir"
-	dest="$systemd_dir/$unit_name"
-	cp "$script_dir/systemd/$unit_name" "$dest"
-	post_systemd_message
+    unit_name="$1"
+    no_mac
+    mkdir -p "$systemd_dir"
+    dest="$systemd_dir/$unit_name"
+    cp "$script_dir/systemd/$unit_name" "$dest"
+    post_systemd_message
 }
 
 install_systemd_sshnpd() {
-	root_only
-	install_single_binary "sshnpd"
-	install_single_binary "srv"
-	install_systemd_unit "sshnpd.service"
+    root_only
+    install_single_binary "sshnpd"
+    install_single_binary "srv"
+    install_systemd_unit "sshnpd.service"
 }
 
 install_systemd_srvd() {
-	root_only
-	install_single_binary "srvd"
-	install_systemd_unit "srvd.service"
+    root_only
+    install_single_binary "srvd"
+    install_systemd_unit "srvd.service"
 }
 
 systemd() {
-	if is_darwin; then
-		echo "Unknown command: systemd"
-		usage
-		exit 1
-	fi
-	case "$1" in
-	--help)
-		usage
-		exit 0
-		;;
-	sshnpd) install_systemd_sshnpd ;;
-	srvd) install_systemd_srvd ;;
-	*)
-		echo "Unknown systemd unit: $1"
-		usage
-		exit 1
-		;;
-	esac
-	setup_authorized_keys
+    if is_darwin; then
+        echo "Unknown command: systemd"
+        usage
+        exit 1
+    fi
+    case "$1" in
+    --help)
+        usage
+        exit 0
+        ;;
+    sshnpd) install_systemd_sshnpd ;;
+    srvd) install_systemd_srvd ;;
+    *)
+        echo "Unknown systemd unit: $1"
+        usage
+        exit 1
+        ;;
+    esac
+    setup_authorized_keys
 }
 
 # LAUNCHD SERVICES #
 post_launchd_message() {
-	echo "Launchd unit installed, make sure to configure the unit by editing $dest"
-	echo ""
-	echo "To enable the service see \"Login Items\" in settings"
+    echo "Launchd unit installed, make sure to configure the unit by editing $dest"
+    echo ""
+    echo "To enable the service see \"Login Items\" in settings"
 }
 
 install_launchd_unit() {
-	unit_name="$1"
-	mac_only
-	mkdir -p "$launchd_dir"
-	dest="$launchd_dir/$unit_name"
-	cp "$script_dir/launchd/$unit_name" "$dest"
-	post_launchd_message
+    unit_name="$1"
+    mac_only
+    mkdir -p "$launchd_dir"
+    dest="$launchd_dir/$unit_name"
+    cp "$script_dir/launchd/$unit_name" "$dest"
+    post_launchd_message
 }
 
 install_launchd_sshnpd() {
-	install_single_binary "sshnpd"
-	install_single_binary "srv"
-	install_launchd_unit "com.atsign.sshnpd.plist"
+    install_single_binary "sshnpd"
+    install_single_binary "srv"
+    install_launchd_unit "com.atsign.sshnpd.plist"
 }
 
 launchd() {
-	if ! is_darwin; then
-		echo "Unknown command: launchd"
-		usage
-		exit 1
-	fi
-	case "$1" in
-	--help)
-		usage
-		exit 0
-		;;
-	sshnpd) install_launchd_sshnpd ;;
-	*)
-		echo "Unknown launchd unit: $1"
-		usage
-		exit 1
-		;;
-	esac
-	setup_authorized_keys
+    if ! is_darwin; then
+        echo "Unknown command: launchd"
+        usage
+        exit 1
+    fi
+    case "$1" in
+    --help)
+        usage
+        exit 0
+        ;;
+    sshnpd) install_launchd_sshnpd ;;
+    *)
+        echo "Unknown launchd unit: $1"
+        usage
+        exit 1
+        ;;
+    esac
+    setup_authorized_keys
 }
 
 # HEADLESS SERVICES #
 
 post_headless_message() {
-	echo "Headless job installed, make sure to configure the job by editing $dest"
-	echo "Learn more in $script_dir/headless/README.md"
-	echo ""
-	echo "The job will start upon next system boot"
-	echo "To start the job immediately:"
-	echo "  $command &"
-	echo ""
-	echo "Warning: logs stored at $log_file and $err_file have unlimited potential size"
-	echo "In a production environment, it's recommended that you install via systemd"
-	echo "or use a cron job to call logrotate on these log files if systemd is not available"
+    echo "Headless job installed, make sure to configure the job by editing $dest"
+    echo "Learn more in $script_dir/headless/README.md"
+    echo ""
+    echo "The job will start upon next system boot"
+    echo "To start the job immediately:"
+    echo "  $command &"
+    echo ""
+    echo "Warning: logs stored at $log_file and $err_file have unlimited potential size"
+    echo "In a production environment, it's recommended that you install via systemd"
+    echo "or use a cron job to call logrotate on these log files if systemd is not available"
 }
 
 install_headless_job() {
-	job_name=$1
-	mkdir -p "$user_bin_dir"
-	mkdir -p "$user_log_dir"
+    job_name=$1
+    mkdir -p "$user_bin_dir"
+    mkdir -p "$user_log_dir"
 
-	dest="$user_bin_dir/$job_name.sh"
-	if ! [ -f "$dest" ]; then
-		cp "$script_dir/headless/$job_name.sh" "$dest"
-		if is_root; then
-			sedi "s|^binary_path=\".*\"$|binary_path=\"$bin_dir\"|g" "$dest"
-		fi
-	fi
+    dest="$user_bin_dir/$job_name.sh"
+    if ! [ -f "$dest" ]; then
+        cp "$script_dir/headless/$job_name.sh" "$dest"
+        if is_root; then
+            sedi "s|^binary_path=\".*\"$|binary_path=\"$bin_dir\"|g" "$dest"
+        fi
+    fi
 
-	log_file="$user_sshnpd_dir/logs/$job_name.log"
-	err_file="$user_sshnpd_dir/logs/$job_name.err"
+    log_file="$user_sshnpd_dir/logs/$job_name.log"
+    err_file="$user_sshnpd_dir/logs/$job_name.err"
 
-	command="nohup $dest > $log_file 2> $err_file"
-	cron_entry="@reboot $command"
-	crontab_contents=$(crontab -l 2>/dev/null)
+    command="nohup $dest > $log_file 2> $err_file"
+    cron_entry="@reboot $command"
+    crontab_contents=$(crontab -l 2>/dev/null)
 
-	if echo "$crontab_contents" | grep -Fxq "$cron_entry"; then
-		echo "=> cron job already installed, killing any old $job_name.sh processes"
-		pids=$(pgrep "$command")
-		if [ -n "$pids" ]; then
-			echo "$pids" | xargs kill
-		fi
-	else
-		echo "=> Installing cron job: $cron_entry"
-		(
-			echo "$crontab_contents"
-			echo "$cron_entry"
-		) | crontab -
-	fi
+    if echo "$crontab_contents" | grep -Fxq "$cron_entry"; then
+        echo "=> cron job already installed, killing any old $job_name.sh processes"
+        pids=$(pgrep "$command")
+        if [ -n "$pids" ]; then
+            echo "$pids" | xargs kill
+        fi
+    else
+        echo "=> Installing cron job: $cron_entry"
+        (
+            echo "$crontab_contents"
+            echo "$cron_entry"
+        ) | crontab -
+    fi
 
-	echo ""
-	post_headless_message
+    echo ""
+    post_headless_message
 }
 
 install_headless_sshnpd() {
-	install_single_binary "sshnpd"
-	install_single_binary "srv"
-	install_headless_job "sshnpd"
+    install_single_binary "sshnpd"
+    install_single_binary "srv"
+    install_headless_job "sshnpd"
 }
 
 install_headless_srvd() {
-	install_single_binary "srvd"
-	install_headless_job "srvd"
+    install_single_binary "srvd"
+    install_headless_job "srvd"
 }
 
 headless() {
-	case "$1" in
-	--help | '')
-		usage
-		exit 0
-		;;
-	sshnpd) install_headless_sshnpd ;;
-	srvd) install_headless_srvd ;;
-	*)
-		echo "Error: Unknown headless job: $1"
-		usage
-		exit 1
-		;;
-	esac
-	setup_authorized_keys
+    case "$1" in
+    --help | '')
+        usage
+        exit 0
+        ;;
+    sshnpd) install_headless_sshnpd ;;
+    srvd) install_headless_srvd ;;
+    *)
+        echo "Error: Unknown headless job: $1"
+        usage
+        exit 1
+        ;;
+    esac
+    setup_authorized_keys
 }
 
 # TMUX SESSION #
 
 post_tmux_message() {
-	# Explain what needs to be edited
-	# Provide initial startup command
-	echo "tmux service installed, make sure to configure the service by editing $dest"
-	echo "Learn more in $script_dir/headless/README.md"
-	echo ""
-	echo "To start the service immediately:"
-	echo "  $command &"
-	echo ""
-	echo "Warning: sometimes tmux is not set to linger which will kill the tmux session on logout"
-	echo "Make sure your system is configured so that tmux sessions can linger, or disown the tmux process before logging out"
+    # Explain what needs to be edited
+    # Provide initial startup command
+    echo "tmux service installed, make sure to configure the service by editing $dest"
+    echo "Learn more in $script_dir/headless/README.md"
+    echo ""
+    echo "To start the service immediately:"
+    echo "  $command &"
+    echo ""
+    echo "Warning: sometimes tmux is not set to linger which will kill the tmux session on logout"
+    echo "Make sure your system is configured so that tmux sessions can linger, or disown the tmux process before logging out"
 }
 
 install_tmux_service() {
-	service_name=$1
-	mkdir -p "$user_bin_dir"
+    service_name=$1
+    mkdir -p "$user_bin_dir"
 
-	dest="$user_bin_dir/$service_name.sh"
+    dest="$user_bin_dir/$service_name.sh"
 
-	# Only copy the "$service_name".sh script if it's not already there
-	if ! [ -f "$dest" ]; then
-		cp "$script_dir/headless/$service_name.sh" "$dest"
-		if is_root; then
-			sedi "s|^binary_path=\".*\"$|binary_path=\"$bin_dir\"|g" "$dest"
-		fi
-	fi
+    # Only copy the "$service_name".sh script if it's not already there
+    if ! [ -f "$dest" ]; then
+        cp "$script_dir/headless/$service_name.sh" "$dest"
+        if is_root; then
+            sedi "s|^binary_path=\".*\"$|binary_path=\"$bin_dir\"|g" "$dest"
+        fi
+    fi
 
-	command="tmux new-session -d -s $service_name && tmux send-keys -t $service_name $dest C-m"
-	cron_entry="@reboot $command"
-	crontab_contents=$(crontab -l 2>/dev/null)
+    command="tmux new-session -d -s $service_name && tmux send-keys -t $service_name $dest C-m"
+    cron_entry="@reboot $command"
+    crontab_contents=$(crontab -l 2>/dev/null)
 
-	if echo "$crontab_contents" | grep -Fxq "$cron_entry"; then
-		echo "=> Cron job already installed, will not re-install"
-	else
-		echo "=> Installing cron job: $cron_entry"
-		(
-			echo "$crontab_contents"
-			echo "$cron_entry"
-		) | crontab -
-	fi
+    if echo "$crontab_contents" | grep -Fxq "$cron_entry"; then
+        echo "=> Cron job already installed, will not re-install"
+    else
+        echo "=> Installing cron job: $cron_entry"
+        (
+            echo "$crontab_contents"
+            echo "$cron_entry"
+        ) | crontab -
+    fi
 
-	if (command tmux has-session -t "$service_name" 2>/dev/null); then
-		echo "=> Found existing tmux session for $service_name - will kill and restart it"
-		command tmux kill-session -t "$service_name"
-		command tmux new-session -d -s "$service_name" && command tmux send-keys -t "$service_name" "$dest" C-m
-	fi
+    if (command tmux has-session -t "$service_name" 2>/dev/null); then
+        echo "=> Found existing tmux session for $service_name - will kill and restart it"
+        command tmux kill-session -t "$service_name"
+        command tmux new-session -d -s "$service_name" && command tmux send-keys -t "$service_name" "$dest" C-m
+    fi
 
-	echo ""
-	post_tmux_message
+    echo ""
+    post_tmux_message
 }
 
 install_tmux_sshnpd() {
-	install_single_binary "sshnpd"
-	install_single_binary "srv"
-	install_tmux_service "sshnpd"
+    install_single_binary "sshnpd"
+    install_single_binary "srv"
+    install_tmux_service "sshnpd"
 }
 
 install_tmux_srvd() {
-	install_single_binary "srvd"
-	install_tmux_service "srvd"
+    install_single_binary "srvd"
+    install_tmux_service "srvd"
 }
 
 tmux() {
-	case "$1" in
-	--help | '')
-		usage
-		exit 0
-		;;
-	sshnpd) install_tmux_sshnpd ;;
-	srvd) install_tmux_srvd ;;
-	*)
-		echo "Unknown tmux service: $1"
-		usage
-		exit 1
-		;;
-	esac
-	setup_authorized_keys
+    case "$1" in
+    --help | '')
+        usage
+        exit 0
+        ;;
+    sshnpd) install_tmux_sshnpd ;;
+    srvd) install_tmux_srvd ;;
+    *)
+        echo "Unknown tmux service: $1"
+        usage
+        exit 1
+        ;;
+    esac
+    setup_authorized_keys
 }
 
 # MAIN #
 
 main() {
-	arg_zero=$0
+    arg_zero=$0
 
-	define_env
+    define_env
 
     while [ $# -gt 0 ]; do
-	    case "$1" in
-			-h)
-				usage
-				exit 0
-				;;
-			-b)
-				binary_dir="$2"
-				shift
-				;;
-			-u)
-				user="$2"
-				user_home=$(sudo -u "$user" sh -c 'echo $HOME')
-				shift
-				;;
-			at_activate | npt | sshnp | sshnpd | srv | srvd) install_single_binary "$1" ;;
-			binaries) install_base_binaries ;;
-			debug_srvd) install_debug_binary "${1#"debug_"}" ;; # strips debug_ prefix from the command input
-			debug) install_debug_binaries ;;
-			all) install_all_binaries ;;
-			systemd | launchd | headless | tmux)
-				command=$1
-				shift 1
-				$command "$@"
-				;;
-			*)
-				echo "Unknown command: $1"
-				usage
-				exit 1
-				;;
-		esac
-		shift
-	done
+        case "$1" in
+            -h)
+                usage
+                exit 0
+                ;;
+            -b)
+                binary_dir="$2"
+                shift
+                ;;
+            -u)
+                user="$2"
+                user_home=$(sudo -u "$user" sh -c 'echo $HOME')
+                shift
+                ;;
+            at_activate | npt | sshnp | sshnpd | srv | srvd) install_single_binary "$1" ;;
+            binaries) install_base_binaries ;;
+            debug_srvd) install_debug_binary "${1#"debug_"}" ;; # strips debug_ prefix from the command input
+            debug) install_debug_binaries ;;
+            all) install_all_binaries ;;
+            systemd | launchd | headless | tmux)
+                command=$1
+                shift 1
+                $command "$@"
+                ;;
+            *)
+                echo "Unknown command: $1"
+                usage
+                exit 1
+                ;;
+        esac
+        shift
+    done
 
 }
 

--- a/packages/dart/sshnoports/bundles/shell/install.sh
+++ b/packages/dart/sshnoports/bundles/shell/install.sh
@@ -246,7 +246,7 @@ install_launchd_unit() {
 	mac_only
 	mkdir -p "$launchd_dir"
 	dest="$launchd_dir/$unit_name"
-	cp "$script_dir/launchd_dir/$unit_name" "$dest"
+	cp "$script_dir/launchd/$unit_name" "$dest"
 	post_launchd_message
 }
 

--- a/packages/dart/sshnoports/bundles/shell/install.sh
+++ b/packages/dart/sshnoports/bundles/shell/install.sh
@@ -446,36 +446,40 @@ main() {
 
 	define_env
 
-	case "$1" in
-	--help | '')
-		usage
-		exit 0
-		;;
-	-b)
-		binary_dir="$1"
+    while [ $# -gt 0 ]; do
+	    case "$1" in
+			-h)
+				usage
+				exit 0
+				;;
+			-b)
+				binary_dir="$2"
+				shift
+				;;
+			-u)
+				user="$2"
+				user_home=$(sudo -u "$user" sh -c 'echo $HOME')
+				shift
+				;;
+			at_activate | npt | sshnp | sshnpd | srv | srvd) install_single_binary "$1" ;;
+			binaries) install_base_binaries ;;
+			debug_srvd) install_debug_binary "${1#"debug_"}" ;; # strips debug_ prefix from the command input
+			debug) install_debug_binaries ;;
+			all) install_all_binaries ;;
+			systemd | launchd | headless | tmux)
+				command=$1
+				shift 1
+				$command "$@"
+				;;
+			*)
+				echo "Unknown command: $1"
+				usage
+				exit 1
+				;;
+		esac
 		shift
-		;;
-	-u)
-		user="$1"
-		user_home=$(sudo -u "$user" sh -c 'echo $HOME')
-		shift
-		;;
-	at_activate | npt | sshnp | sshnpd | srv | srvd) install_single_binary "$1" ;;
-	binaries) install_base_binaries ;;
-	debug_srvd) install_debug_binary "${1#"debug_"}" ;; # strips debug_ prefix from the command input
-	debug) install_debug_binaries ;;
-	all) install_all_binaries ;;
-	systemd | launchd | headless | tmux)
-		command=$1
-		shift 1
-		$command "$@"
-		;;
-	*)
-		echo "Unknown command: $1"
-		usage
-		exit 1
-		;;
-	esac
+	done
+
 }
 
 main "$@"

--- a/packages/dart/sshnoports/bundles/shell/install.sh
+++ b/packages/dart/sshnoports/bundles/shell/install.sh
@@ -2,483 +2,488 @@
 
 # SYSTEM GIVENS #
 is_root() {
-    [ "$(id -u)" -eq 0 ]
+	[ "$(id -u)" -eq 0 ]
 }
 
 unset binary_dir
 user_home=$HOME
 define_env() {
-    script_dir="$(dirname -- "$(readlink -f -- "$0")")"
-    bin_dir="/usr/local/bin"
-    systemd_dir="/etc/systemd/system"
-    if is_root; then
-        user="$SUDO_USER"
-        if [ -z "$user" ]; then
-            user="root"
-        else
-            # we are root, but via sudo
-            # so get home directory of SUDO_USER
-            user_home=$(sudo -u "$user" sh -c 'echo $HOME')
-        fi
-    else
-        user="$USER"
-    fi
-    launchd_dir="$user_home/Library/LaunchAgents"
-    user_bin_dir="$user_home/.local/bin"
-    user_sshnpd_dir="$user_home/.sshnpd"
-    user_log_dir="$user_sshnpd_dir/logs"
-    user_ssh_dir="$user_home/.ssh"
+	script_dir="$(dirname -- "$(readlink -f -- "$0")")"
+	bin_dir="/usr/local/bin"
+	systemd_dir="/etc/systemd/system"
+	if is_root; then
+		user="$SUDO_USER"
+		if [ -z "$user" ]; then
+			user="root"
+		else
+			# we are root, but via sudo
+			# so get home directory of SUDO_USER
+			user_home=$(sudo -u "$user" sh -c 'echo $HOME')
+		fi
+	else
+		user="$USER"
+	fi
+	launchd_dir="$user_home/Library/LaunchAgents"
+	user_bin_dir="$user_home/.local/bin"
+	user_sshnpd_dir="$user_home/.sshnpd"
+	user_log_dir="$user_sshnpd_dir/logs"
+	user_ssh_dir="$user_home/.ssh"
 }
 
 is_darwin() {
-    [ "$(uname)" = 'Darwin' ]
+	[ "$(uname)" = 'Darwin' ]
 }
 
 sedi() {
-    if is_darwin; then
-        sed -i '' "$@"
-    else
-        sed -i "$@"
-    fi
+	if is_darwin; then
+		sed -i '' "$@"
+	else
+		sed -i "$@"
+	fi
 }
 
 no_mac() {
-    if is_darwin; then
-        echo "Error: this operation is only supported on linux"
-        exit 1
-    fi
+	if is_darwin; then
+		echo "Error: this operation is only supported on linux"
+		exit 1
+	fi
 }
 
 root_only() {
-    if ! is_root; then
-        echo "Error: this operation requires root privileges"
-        exit 1
-    fi
+	if ! is_root; then
+		echo "Error: this operation requires root privileges"
+		exit 1
+	fi
 }
 
 # USAGE #
 
 usage() {
-    if [ -z "$arg_zero" ]; then
-        arg_zero='install.sh'
-    fi
-    echo "$arg_zero [...options] [command]"
-    echo "Available commands:"
-    echo "at_activate     - install at_activate"
-    echo "npt             - install npt"
-    echo "sshnp           - install sshnp"
-    echo "sshnpd          - install sshnpd"
-    echo "srv             - install srv"
-    echo "srvd            - install srvd"
-    echo "binaries        - install all base binaries (everything above)"
-    echo ""
-    echo "debug_srvd      - install srvd with debugging enabled"
-    echo "debug           - install all debug binaries"
-    echo ""
-    echo "all             - install all binaries (everything above)"
-    if ! is_darwin; then
-        echo ""
-        echo "systemd <unit>  - install a systemd unit"
-        echo "                  available units: [sshnpd, srvd]"
-    fi
-    if is_darwin; then
-        echo ""
-        echo "launchd <unit>  - install a launchd unit"
-        echo "                  available units: [sshnpd]"
-    fi
-    echo ""
-    echo "headless <job>  - install a headless cron job"
-    echo "                  available jobs: [sshnpd, srvd]"
-    echo ""
-    echo "tmux <service>  - install a service in a tmux session"
-    echo "                  available services: [sshnpd, srvd]"
-    echo ""
-    echo "Options:"
-    echo "-b <dir>        - override the directory in which the binaries are written to"
-    echo "-u <username>   - override the user to install the binaries for"
+	if [ -z "$arg_zero" ]; then
+		arg_zero='install.sh'
+	fi
+	echo "$arg_zero [...options] [command]"
+	echo "Available commands:"
+	echo "at_activate     - install at_activate"
+	echo "npt             - install npt"
+	echo "sshnp           - install sshnp"
+	echo "sshnpd          - install sshnpd"
+	echo "srv             - install srv"
+	echo "srvd            - install srvd"
+	echo "binaries        - install all base binaries (everything above)"
+	echo ""
+	echo "debug_srvd      - install srvd with debugging enabled"
+	echo "debug           - install all debug binaries"
+	echo ""
+	echo "all             - install all binaries (everything above)"
+	if ! is_darwin; then
+		echo ""
+		echo "systemd <unit>  - install a systemd unit"
+		echo "                  available units: [sshnpd, srvd]"
+	fi
+	if is_darwin; then
+		echo ""
+		echo "launchd <unit>  - install a launchd unit"
+		echo "                  available units: [sshnpd]"
+	fi
+	echo ""
+	echo "headless <job>  - install a headless cron job"
+	echo "                  available jobs: [sshnpd, srvd]"
+	echo ""
+	echo "tmux <service>  - install a service in a tmux session"
+	echo "                  available services: [sshnpd, srvd]"
+	echo ""
+	echo "Options:"
+	echo "-b <dir>        - override the directory in which the binaries are written to"
+	echo "-u <username>   - override the user to install the binaries for"
 }
 
 # SETUP AUTHORIZED KEYS #
 
 setup_authorized_keys() {
-    mkdir -p "$user_ssh_dir"
-    touch "$user_ssh_dir/authorized_keys"
-    chmod 644 "$user_ssh_dir/authorized_keys"
+	mkdir -p "$user_ssh_dir"
+	touch "$user_ssh_dir/authorized_keys"
+	chmod 644 "$user_ssh_dir/authorized_keys"
 }
 
 # INSTALL BINARIES #
 
 install_single_binary() {
-    if [ -n "$binary_dir" ]; then
-        dest="$binary_dir"
-    elif is_root; then
-        dest="$bin_dir"
-    else
-        dest="$user_bin_dir"
-    fi
-    mkdir -p "$dest"
-    if test -f "$dest/$1"; then
-        if test -f "$dest/$1.old"; then
-            if rm -f "$dest/$1.old"; then
-                echo "=> Removed $dest/$1.old"
-            else
-                echo "Failed to remove $dest/$1.old - aborting"
-                exit 1
-            fi
-        fi
-        if mv "$dest/$1" "$dest/$1.old"; then
-            echo "=> Renamed existing binary $dest/$1 to $dest/$1.old"
-        else
-            echo "Failed to rename $dest/$1 to $dest/$1.old - aborting"
-            exit 1
-        fi
-    fi
-    cp -f "$script_dir/$1" "$dest/$1"
+	if [ -n "$binary_dir" ]; then
+		dest="$binary_dir"
+	elif is_root; then
+		dest="$bin_dir"
+	else
+		dest="$user_bin_dir"
+	fi
+	mkdir -p "$dest"
+	if test -f "$dest/$1"; then
+		if test -f "$dest/$1.old"; then
+			if rm -f "$dest/$1.old"; then
+				echo "=> Removed $dest/$1.old"
+			else
+				echo "Failed to remove $dest/$1.old - aborting"
+				exit 1
+			fi
+		fi
+		if mv "$dest/$1" "$dest/$1.old"; then
+			echo "=> Renamed existing binary $dest/$1 to $dest/$1.old"
+		else
+			echo "Failed to rename $dest/$1 to $dest/$1.old - aborting"
+			exit 1
+		fi
+	fi
+	cp -f "$script_dir/$1" "$dest/$1"
 
-    echo "=> Installed $1 to $dest"
-    if
-        is_root &
-        ! [ -f "$user_bin_dir/$1" ]
-    then
-        mkdir -p "$user_bin_dir"
-        ln -sf "$dest/$1" "$user_bin_dir/$1"
-        echo "=> Linked $user_bin_dir/$1 to $dest/$1"
-    fi
+	echo "=> Installed $1 to $dest"
+	if
+		is_root &
+		! [ -f "$user_bin_dir/$1" ]
+	then
+		mkdir -p "$user_bin_dir"
+		if [ -f "$dest/$1" ]; then
+			ln -sf "$dest/$1" "$user_bin_dir/$1"
+			echo "=> Linked $user_bin_dir/$1 to $dest/$1"
+		else
+			echo "Failed to link $user_bin_dir/$1 to $dest/$1:"
+			echo "  $dest/$1 does not exist"
+		fi
+	fi
 }
 
 install_base_binaries() {
-    install_single_binary "at_activate"
-    install_single_binary "sshnp"
-    install_single_binary "sshnpd"
-    install_single_binary "srv"
-    install_single_binary "srvd"
-    install_single_binary "npt"
+	install_single_binary "at_activate"
+	install_single_binary "sshnp"
+	install_single_binary "sshnpd"
+	install_single_binary "srv"
+	install_single_binary "srvd"
+	install_single_binary "npt"
 }
 
 install_debug_binary() {
-    if [ -n "$binary_dir" ]; then
-        dest="$binary_dir"
-    elif is_root; then
-        dest="$bin_dir"
-    else
-        dest="$user_bin_dir"
-    fi
-    mkdir -p "$dest"
-    cp "$script_dir/debug/$1" "$bin_dir/debug_$1"
-    echo "=> Installed debug_$1 to $dest"
+	if [ -n "$binary_dir" ]; then
+		dest="$binary_dir"
+	elif is_root; then
+		dest="$bin_dir"
+	else
+		dest="$user_bin_dir"
+	fi
+	mkdir -p "$dest"
+	cp "$script_dir/debug/$1" "$bin_dir/debug_$1"
+	echo "=> Installed debug_$1 to $dest"
 }
 
 install_debug_binaries() {
-    install_debug_binary "srvd"
+	install_debug_binary "srvd"
 }
 
 install_all_binaries() {
-    install_base_binaries
-    install_debug_binaries
+	install_base_binaries
+	install_debug_binaries
 }
 
 # SYSTEMD #
 
 post_systemd_message() {
-    echo "Systemd unit installed, make sure to configure the unit by editing $dest"
-    echo "Learn more in $script_dir/systemd/README.md"
-    echo ""
-    echo "To enable the service on next boot:"
-    echo "  sudo systemctl enable $unit_name"
-    echo ""
-    echo "To start the service immediately:"
-    echo "  sudo systemctl start $unit_name"
+	echo "Systemd unit installed, make sure to configure the unit by editing $dest"
+	echo "Learn more in $script_dir/systemd/README.md"
+	echo ""
+	echo "To enable the service on next boot:"
+	echo "  sudo systemctl enable $unit_name"
+	echo ""
+	echo "To start the service immediately:"
+	echo "  sudo systemctl start $unit_name"
 }
 
 install_systemd_unit() {
-    unit_name="$1"
-    no_mac
-    mkdir -p "$systemd_dir"
-    dest="$systemd_dir/$unit_name"
-    cp "$script_dir/systemd/$unit_name" "$dest"
-    post_systemd_message
+	unit_name="$1"
+	no_mac
+	mkdir -p "$systemd_dir"
+	dest="$systemd_dir/$unit_name"
+	cp "$script_dir/systemd/$unit_name" "$dest"
+	post_systemd_message
 }
 
 install_systemd_sshnpd() {
-    root_only
-    install_single_binary "sshnpd"
-    install_single_binary "srv"
-    install_systemd_unit "sshnpd.service"
+	root_only
+	install_single_binary "sshnpd"
+	install_single_binary "srv"
+	install_systemd_unit "sshnpd.service"
 }
 
 install_systemd_srvd() {
-    root_only
-    install_single_binary "srvd"
-    install_systemd_unit "srvd.service"
+	root_only
+	install_single_binary "srvd"
+	install_systemd_unit "srvd.service"
 }
 
 systemd() {
-    if is_darwin; then
-        echo "Unknown command: systemd"
-        usage
-        exit 1
-    fi
-    case "$1" in
-    --help)
-        usage
-        exit 0
-        ;;
-    sshnpd) install_systemd_sshnpd ;;
-    srvd) install_systemd_srvd ;;
-    *)
-        echo "Unknown systemd unit: $1"
-        usage
-        exit 1
-        ;;
-    esac
-    setup_authorized_keys
+	if is_darwin; then
+		echo "Unknown command: systemd"
+		usage
+		exit 1
+	fi
+	case "$1" in
+	--help)
+		usage
+		exit 0
+		;;
+	sshnpd) install_systemd_sshnpd ;;
+	srvd) install_systemd_srvd ;;
+	*)
+		echo "Unknown systemd unit: $1"
+		usage
+		exit 1
+		;;
+	esac
+	setup_authorized_keys
 }
 
 # LAUNCHD SERVICES #
 post_launchd_message() {
-    echo "Launchd unit installed, make sure to configure the unit by editing $dest"
-    echo ""
-    echo "To enable the service see \"Login Items\" in settings"
+	echo "Launchd unit installed, make sure to configure the unit by editing $dest"
+	echo ""
+	echo "To enable the service see \"Login Items\" in settings"
 }
 
 install_launchd_unit() {
-    unit_name="$1"
-    mac_only
-    mkdir -p "$launchd_dir"
-    dest="$launchd_dir/$unit_name"
-    cp "$script_dir/launchd/$unit_name" "$dest"
-    post_launchd_message
+	unit_name="$1"
+	mac_only
+	mkdir -p "$launchd_dir"
+	dest="$launchd_dir/$unit_name"
+	cp "$script_dir/launchd/$unit_name" "$dest"
+	post_launchd_message
 }
 
 install_launchd_sshnpd() {
-    install_single_binary "sshnpd"
-    install_single_binary "srv"
-    install_launchd_unit "com.atsign.sshnpd.plist"
+	install_single_binary "sshnpd"
+	install_single_binary "srv"
+	install_launchd_unit "com.atsign.sshnpd.plist"
 }
 
 launchd() {
-    if ! is_darwin; then
-        echo "Unknown command: launchd"
-        usage
-        exit 1
-    fi
-    case "$1" in
-    --help)
-        usage
-        exit 0
-        ;;
-    sshnpd) install_launchd_sshnpd ;;
-    *)
-        echo "Unknown launchd unit: $1"
-        usage
-        exit 1
-        ;;
-    esac
-    setup_authorized_keys
+	if ! is_darwin; then
+		echo "Unknown command: launchd"
+		usage
+		exit 1
+	fi
+	case "$1" in
+	--help)
+		usage
+		exit 0
+		;;
+	sshnpd) install_launchd_sshnpd ;;
+	*)
+		echo "Unknown launchd unit: $1"
+		usage
+		exit 1
+		;;
+	esac
+	setup_authorized_keys
 }
 
 # HEADLESS SERVICES #
 
 post_headless_message() {
-    echo "Headless job installed, make sure to configure the job by editing $dest"
-    echo "Learn more in $script_dir/headless/README.md"
-    echo ""
-    echo "The job will start upon next system boot"
-    echo "To start the job immediately:"
-    echo "  $command &"
-    echo ""
-    echo "Warning: logs stored at $log_file and $err_file have unlimited potential size"
-    echo "In a production environment, it's recommended that you install via systemd"
-    echo "or use a cron job to call logrotate on these log files if systemd is not available"
+	echo "Headless job installed, make sure to configure the job by editing $dest"
+	echo "Learn more in $script_dir/headless/README.md"
+	echo ""
+	echo "The job will start upon next system boot"
+	echo "To start the job immediately:"
+	echo "  $command &"
+	echo ""
+	echo "Warning: logs stored at $log_file and $err_file have unlimited potential size"
+	echo "In a production environment, it's recommended that you install via systemd"
+	echo "or use a cron job to call logrotate on these log files if systemd is not available"
 }
 
 install_headless_job() {
-    job_name=$1
-    mkdir -p "$user_bin_dir"
-    mkdir -p "$user_log_dir"
+	job_name=$1
+	mkdir -p "$user_bin_dir"
+	mkdir -p "$user_log_dir"
 
-    dest="$user_bin_dir/$job_name.sh"
-    if ! [ -f "$dest" ]; then
-        cp "$script_dir/headless/$job_name.sh" "$dest"
-        if is_root; then
-            sedi "s|^binary_path=\".*\"$|binary_path=\"$bin_dir\"|g" "$dest"
-        fi
-    fi
+	dest="$user_bin_dir/$job_name.sh"
+	if ! [ -f "$dest" ]; then
+		cp "$script_dir/headless/$job_name.sh" "$dest"
+		if is_root; then
+			sedi "s|^binary_path=\".*\"$|binary_path=\"$bin_dir\"|g" "$dest"
+		fi
+	fi
 
-    log_file="$user_sshnpd_dir/logs/$job_name.log"
-    err_file="$user_sshnpd_dir/logs/$job_name.err"
+	log_file="$user_sshnpd_dir/logs/$job_name.log"
+	err_file="$user_sshnpd_dir/logs/$job_name.err"
 
-    command="nohup $dest > $log_file 2> $err_file"
-    cron_entry="@reboot $command"
-    crontab_contents=$(crontab -l 2>/dev/null)
+	command="nohup $dest > $log_file 2> $err_file"
+	cron_entry="@reboot $command"
+	crontab_contents=$(crontab -l 2>/dev/null)
 
-    if echo "$crontab_contents" | grep -Fxq "$cron_entry"; then
-        echo "=> cron job already installed, killing any old $job_name.sh processes"
-        pids=$(pgrep "$command")
-        if [ -n "$pids" ]; then
-            echo "$pids" | xargs kill
-        fi
-    else
-        echo "=> Installing cron job: $cron_entry"
-        (
-            echo "$crontab_contents"
-            echo "$cron_entry"
-        ) | crontab -
-    fi
+	if echo "$crontab_contents" | grep -Fxq "$cron_entry"; then
+		echo "=> cron job already installed, killing any old $job_name.sh processes"
+		pids=$(pgrep "$command")
+		if [ -n "$pids" ]; then
+			echo "$pids" | xargs kill
+		fi
+	else
+		echo "=> Installing cron job: $cron_entry"
+		(
+			echo "$crontab_contents"
+			echo "$cron_entry"
+		) | crontab -
+	fi
 
-    echo ""
-    post_headless_message
+	echo ""
+	post_headless_message
 }
 
 install_headless_sshnpd() {
-    install_single_binary "sshnpd"
-    install_single_binary "srv"
-    install_headless_job "sshnpd"
+	install_single_binary "sshnpd"
+	install_single_binary "srv"
+	install_headless_job "sshnpd"
 }
 
 install_headless_srvd() {
-    install_single_binary "srvd"
-    install_headless_job "srvd"
+	install_single_binary "srvd"
+	install_headless_job "srvd"
 }
 
 headless() {
-    case "$1" in
-    --help | '')
-        usage
-        exit 0
-        ;;
-    sshnpd) install_headless_sshnpd ;;
-    srvd) install_headless_srvd ;;
-    *)
-        echo "Error: Unknown headless job: $1"
-        usage
-        exit 1
-        ;;
-    esac
-    setup_authorized_keys
+	case "$1" in
+	--help | '')
+		usage
+		exit 0
+		;;
+	sshnpd) install_headless_sshnpd ;;
+	srvd) install_headless_srvd ;;
+	*)
+		echo "Error: Unknown headless job: $1"
+		usage
+		exit 1
+		;;
+	esac
+	setup_authorized_keys
 }
 
 # TMUX SESSION #
 
 post_tmux_message() {
-    # Explain what needs to be edited
-    # Provide initial startup command
-    echo "tmux service installed, make sure to configure the service by editing $dest"
-    echo "Learn more in $script_dir/headless/README.md"
-    echo ""
-    echo "To start the service immediately:"
-    echo "  $command &"
-    echo ""
-    echo "Warning: sometimes tmux is not set to linger which will kill the tmux session on logout"
-    echo "Make sure your system is configured so that tmux sessions can linger, or disown the tmux process before logging out"
+	# Explain what needs to be edited
+	# Provide initial startup command
+	echo "tmux service installed, make sure to configure the service by editing $dest"
+	echo "Learn more in $script_dir/headless/README.md"
+	echo ""
+	echo "To start the service immediately:"
+	echo "  $command &"
+	echo ""
+	echo "Warning: sometimes tmux is not set to linger which will kill the tmux session on logout"
+	echo "Make sure your system is configured so that tmux sessions can linger, or disown the tmux process before logging out"
 }
 
 install_tmux_service() {
-    service_name=$1
-    mkdir -p "$user_bin_dir"
+	service_name=$1
+	mkdir -p "$user_bin_dir"
 
-    dest="$user_bin_dir/$service_name.sh"
+	dest="$user_bin_dir/$service_name.sh"
 
-    # Only copy the "$service_name".sh script if it's not already there
-    if ! [ -f "$dest" ]; then
-        cp "$script_dir/headless/$service_name.sh" "$dest"
-        if is_root; then
-            sedi "s|^binary_path=\".*\"$|binary_path=\"$bin_dir\"|g" "$dest"
-        fi
-    fi
+	# Only copy the "$service_name".sh script if it's not already there
+	if ! [ -f "$dest" ]; then
+		cp "$script_dir/headless/$service_name.sh" "$dest"
+		if is_root; then
+			sedi "s|^binary_path=\".*\"$|binary_path=\"$bin_dir\"|g" "$dest"
+		fi
+	fi
 
-    command="tmux new-session -d -s $service_name && tmux send-keys -t $service_name $dest C-m"
-    cron_entry="@reboot $command"
-    crontab_contents=$(crontab -l 2>/dev/null)
+	command="tmux new-session -d -s $service_name && tmux send-keys -t $service_name $dest C-m"
+	cron_entry="@reboot $command"
+	crontab_contents=$(crontab -l 2>/dev/null)
 
-    if echo "$crontab_contents" | grep -Fxq "$cron_entry"; then
-        echo "=> Cron job already installed, will not re-install"
-    else
-        echo "=> Installing cron job: $cron_entry"
-        (
-            echo "$crontab_contents"
-            echo "$cron_entry"
-        ) | crontab -
-    fi
+	if echo "$crontab_contents" | grep -Fxq "$cron_entry"; then
+		echo "=> Cron job already installed, will not re-install"
+	else
+		echo "=> Installing cron job: $cron_entry"
+		(
+			echo "$crontab_contents"
+			echo "$cron_entry"
+		) | crontab -
+	fi
 
-    if (command tmux has-session -t "$service_name" 2>/dev/null); then
-        echo "=> Found existing tmux session for $service_name - will kill and restart it"
-        command tmux kill-session -t "$service_name"
-        command tmux new-session -d -s "$service_name" && command tmux send-keys -t "$service_name" "$dest" C-m
-    fi
+	if (command tmux has-session -t "$service_name" 2>/dev/null); then
+		echo "=> Found existing tmux session for $service_name - will kill and restart it"
+		command tmux kill-session -t "$service_name"
+		command tmux new-session -d -s "$service_name" && command tmux send-keys -t "$service_name" "$dest" C-m
+	fi
 
-    echo ""
-    post_tmux_message
+	echo ""
+	post_tmux_message
 }
 
 install_tmux_sshnpd() {
-    install_single_binary "sshnpd"
-    install_single_binary "srv"
-    install_tmux_service "sshnpd"
+	install_single_binary "sshnpd"
+	install_single_binary "srv"
+	install_tmux_service "sshnpd"
 }
 
 install_tmux_srvd() {
-    install_single_binary "srvd"
-    install_tmux_service "srvd"
+	install_single_binary "srvd"
+	install_tmux_service "srvd"
 }
 
 tmux() {
-    case "$1" in
-    --help | '')
-        usage
-        exit 0
-        ;;
-    sshnpd) install_tmux_sshnpd ;;
-    srvd) install_tmux_srvd ;;
-    *)
-        echo "Unknown tmux service: $1"
-        usage
-        exit 1
-        ;;
-    esac
-    setup_authorized_keys
+	case "$1" in
+	--help | '')
+		usage
+		exit 0
+		;;
+	sshnpd) install_tmux_sshnpd ;;
+	srvd) install_tmux_srvd ;;
+	*)
+		echo "Unknown tmux service: $1"
+		usage
+		exit 1
+		;;
+	esac
+	setup_authorized_keys
 }
 
 # MAIN #
 
 main() {
-    arg_zero=$0
+	arg_zero=$0
 
-    define_env
+	define_env
 
-    while [ $# -gt 0 ]; do
-        case "$1" in
-            -h)
-                usage
-                exit 0
-                ;;
-            -b)
-                binary_dir="$2"
-                shift
-                ;;
-            -u)
-                user="$2"
-                user_home=$(sudo -u "$user" sh -c 'echo $HOME')
-                shift
-                ;;
-            at_activate | npt | sshnp | sshnpd | srv | srvd) install_single_binary "$1" ;;
-            binaries) install_base_binaries ;;
-            debug_srvd) install_debug_binary "${1#"debug_"}" ;; # strips debug_ prefix from the command input
-            debug) install_debug_binaries ;;
-            all) install_all_binaries ;;
-            systemd | launchd | headless | tmux)
-                command=$1
-                shift 1
-                $command "$@"
-                ;;
-            *)
-                echo "Unknown command: $1"
-                usage
-                exit 1
-                ;;
-        esac
-        shift
-    done
+	while [ $# -gt 0 ]; do
+		case "$1" in
+		-h)
+			usage
+			exit 0
+			;;
+		-b)
+			binary_dir="$2"
+			shift
+			;;
+		-u)
+			user="$2"
+			user_home=$(sudo -u "$user" sh -c 'echo $HOME')
+			shift
+			;;
+		at_activate | npt | sshnp | sshnpd | srv | srvd) install_single_binary "$1" ;;
+		binaries) install_base_binaries ;;
+		debug_srvd) install_debug_binary "${1#"debug_"}" ;; # strips debug_ prefix from the command input
+		debug) install_debug_binaries ;;
+		all) install_all_binaries ;;
+		systemd | launchd | headless | tmux)
+			command=$1
+			shift 1
+			$command "$@"
+			;;
+		*)
+			echo "Unknown command: $1"
+			usage
+			exit 1
+			;;
+		esac
+		shift
+	done
 
 }
 

--- a/packages/dart/sshnoports/bundles/shell/install.sh
+++ b/packages/dart/sshnoports/bundles/shell/install.sh
@@ -2,488 +2,488 @@
 
 # SYSTEM GIVENS #
 is_root() {
-	[ "$(id -u)" -eq 0 ]
+  [ "$(id -u)" -eq 0 ]
 }
 
 unset binary_dir
 user_home=$HOME
 define_env() {
-	script_dir="$(dirname -- "$(readlink -f -- "$0")")"
-	bin_dir="/usr/local/bin"
-	systemd_dir="/etc/systemd/system"
-	if is_root; then
-		user="$SUDO_USER"
-		if [ -z "$user" ]; then
-			user="root"
-		else
-			# we are root, but via sudo
-			# so get home directory of SUDO_USER
-			user_home=$(sudo -u "$user" sh -c 'echo $HOME')
-		fi
-	else
-		user="$USER"
-	fi
-	launchd_dir="$user_home/Library/LaunchAgents"
-	user_bin_dir="$user_home/.local/bin"
-	user_sshnpd_dir="$user_home/.sshnpd"
-	user_log_dir="$user_sshnpd_dir/logs"
-	user_ssh_dir="$user_home/.ssh"
+  script_dir="$(dirname -- "$(readlink -f -- "$0")")"
+  bin_dir="/usr/local/bin"
+  systemd_dir="/etc/systemd/system"
+  if is_root; then
+    user="$SUDO_USER"
+    if [ -z "$user" ]; then
+      user="root"
+    else
+      # we are root, but via sudo
+      # so get home directory of SUDO_USER
+      user_home=$(sudo -u "$user" sh -c 'echo $HOME')
+    fi
+  else
+    user="$USER"
+  fi
+  launchd_dir="$user_home/Library/LaunchAgents"
+  user_bin_dir="$user_home/.local/bin"
+  user_sshnpd_dir="$user_home/.sshnpd"
+  user_log_dir="$user_sshnpd_dir/logs"
+  user_ssh_dir="$user_home/.ssh"
 }
 
 is_darwin() {
-	[ "$(uname)" = 'Darwin' ]
+  [ "$(uname)" = 'Darwin' ]
 }
 
 sedi() {
-	if is_darwin; then
-		sed -i '' "$@"
-	else
-		sed -i "$@"
-	fi
+  if is_darwin; then
+    sed -i '' "$@"
+  else
+    sed -i "$@"
+  fi
 }
 
 no_mac() {
-	if is_darwin; then
-		echo "Error: this operation is only supported on linux"
-		exit 1
-	fi
+  if is_darwin; then
+    echo "Error: this operation is only supported on linux"
+    exit 1
+  fi
 }
 
 root_only() {
-	if ! is_root; then
-		echo "Error: this operation requires root privileges"
-		exit 1
-	fi
+  if ! is_root; then
+    echo "Error: this operation requires root privileges"
+    exit 1
+  fi
 }
 
 # USAGE #
 
 usage() {
-	if [ -z "$arg_zero" ]; then
-		arg_zero='install.sh'
-	fi
-	echo "$arg_zero [...options] [command]"
-	echo "Available commands:"
-	echo "at_activate     - install at_activate"
-	echo "npt             - install npt"
-	echo "sshnp           - install sshnp"
-	echo "sshnpd          - install sshnpd"
-	echo "srv             - install srv"
-	echo "srvd            - install srvd"
-	echo "binaries        - install all base binaries (everything above)"
-	echo ""
-	echo "debug_srvd      - install srvd with debugging enabled"
-	echo "debug           - install all debug binaries"
-	echo ""
-	echo "all             - install all binaries (everything above)"
-	if ! is_darwin; then
-		echo ""
-		echo "systemd <unit>  - install a systemd unit"
-		echo "                  available units: [sshnpd, srvd]"
-	fi
-	if is_darwin; then
-		echo ""
-		echo "launchd <unit>  - install a launchd unit"
-		echo "                  available units: [sshnpd]"
-	fi
-	echo ""
-	echo "headless <job>  - install a headless cron job"
-	echo "                  available jobs: [sshnpd, srvd]"
-	echo ""
-	echo "tmux <service>  - install a service in a tmux session"
-	echo "                  available services: [sshnpd, srvd]"
-	echo ""
-	echo "Options:"
-	echo "-b <dir>        - override the directory in which the binaries are written to"
-	echo "-u <username>   - override the user to install the binaries for"
+  if [ -z "$arg_zero" ]; then
+    arg_zero='install.sh'
+  fi
+  echo "$arg_zero [...options] [command]"
+  echo "Available commands:"
+  echo "at_activate     - install at_activate"
+  echo "npt             - install npt"
+  echo "sshnp           - install sshnp"
+  echo "sshnpd          - install sshnpd"
+  echo "srv             - install srv"
+  echo "srvd            - install srvd"
+  echo "binaries        - install all base binaries (everything above)"
+  echo ""
+  echo "debug_srvd      - install srvd with debugging enabled"
+  echo "debug           - install all debug binaries"
+  echo ""
+  echo "all             - install all binaries (everything above)"
+  if ! is_darwin; then
+    echo ""
+    echo "systemd <unit>  - install a systemd unit"
+    echo "                  available units: [sshnpd, srvd]"
+  fi
+  if is_darwin; then
+    echo ""
+    echo "launchd <unit>  - install a launchd unit"
+    echo "                  available units: [sshnpd]"
+  fi
+  echo ""
+  echo "headless <job>  - install a headless cron job"
+  echo "                  available jobs: [sshnpd, srvd]"
+  echo ""
+  echo "tmux <service>  - install a service in a tmux session"
+  echo "                  available services: [sshnpd, srvd]"
+  echo ""
+  echo "Options:"
+  echo "-b <dir>        - override the directory in which the binaries are written to"
+  echo "-u <username>   - override the user to install the binaries for"
 }
 
 # SETUP AUTHORIZED KEYS #
 
 setup_authorized_keys() {
-	mkdir -p "$user_ssh_dir"
-	touch "$user_ssh_dir/authorized_keys"
-	chmod 644 "$user_ssh_dir/authorized_keys"
+  mkdir -p "$user_ssh_dir"
+  touch "$user_ssh_dir/authorized_keys"
+  chmod 644 "$user_ssh_dir/authorized_keys"
 }
 
 # INSTALL BINARIES #
 
 install_single_binary() {
-	if [ -n "$binary_dir" ]; then
-		dest="$binary_dir"
-	elif is_root; then
-		dest="$bin_dir"
-	else
-		dest="$user_bin_dir"
-	fi
-	mkdir -p "$dest"
-	if test -f "$dest/$1"; then
-		if test -f "$dest/$1.old"; then
-			if rm -f "$dest/$1.old"; then
-				echo "=> Removed $dest/$1.old"
-			else
-				echo "Failed to remove $dest/$1.old - aborting"
-				exit 1
-			fi
-		fi
-		if mv "$dest/$1" "$dest/$1.old"; then
-			echo "=> Renamed existing binary $dest/$1 to $dest/$1.old"
-		else
-			echo "Failed to rename $dest/$1 to $dest/$1.old - aborting"
-			exit 1
-		fi
-	fi
-	cp -f "$script_dir/$1" "$dest/$1"
+  if [ -n "$binary_dir" ]; then
+    dest="$binary_dir"
+  elif is_root; then
+    dest="$bin_dir"
+  else
+    dest="$user_bin_dir"
+  fi
+  mkdir -p "$dest"
+  if test -f "$dest/$1"; then
+    if test -f "$dest/$1.old"; then
+      if rm -f "$dest/$1.old"; then
+        echo "=> Removed $dest/$1.old"
+      else
+        echo "Failed to remove $dest/$1.old - aborting"
+        exit 1
+      fi
+    fi
+    if mv "$dest/$1" "$dest/$1.old"; then
+      echo "=> Renamed existing binary $dest/$1 to $dest/$1.old"
+    else
+      echo "Failed to rename $dest/$1 to $dest/$1.old - aborting"
+      exit 1
+    fi
+  fi
+  cp -f "$script_dir/$1" "$dest/$1"
 
-	echo "=> Installed $1 to $dest"
-	if
-		is_root &
-		! [ -f "$user_bin_dir/$1" ]
-	then
-		mkdir -p "$user_bin_dir"
-		if [ -f "$dest/$1" ]; then
-			ln -sf "$dest/$1" "$user_bin_dir/$1"
-			echo "=> Linked $user_bin_dir/$1 to $dest/$1"
-		else
-			echo "Failed to link $user_bin_dir/$1 to $dest/$1:"
-			echo "  $dest/$1 does not exist"
-		fi
-	fi
+  echo "=> Installed $1 to $dest"
+  if
+    is_root &
+    ! [ -f "$user_bin_dir/$1" ]
+  then
+    mkdir -p "$user_bin_dir"
+    if [ -f "$dest/$1" ]; then
+      ln -sf "$dest/$1" "$user_bin_dir/$1"
+      echo "=> Linked $user_bin_dir/$1 to $dest/$1"
+    else
+      echo "Failed to link $user_bin_dir/$1 to $dest/$1:"
+      echo "  $dest/$1 does not exist"
+    fi
+  fi
 }
 
 install_base_binaries() {
-	install_single_binary "at_activate"
-	install_single_binary "sshnp"
-	install_single_binary "sshnpd"
-	install_single_binary "srv"
-	install_single_binary "srvd"
-	install_single_binary "npt"
+  install_single_binary "at_activate"
+  install_single_binary "sshnp"
+  install_single_binary "sshnpd"
+  install_single_binary "srv"
+  install_single_binary "srvd"
+  install_single_binary "npt"
 }
 
 install_debug_binary() {
-	if [ -n "$binary_dir" ]; then
-		dest="$binary_dir"
-	elif is_root; then
-		dest="$bin_dir"
-	else
-		dest="$user_bin_dir"
-	fi
-	mkdir -p "$dest"
-	cp "$script_dir/debug/$1" "$bin_dir/debug_$1"
-	echo "=> Installed debug_$1 to $dest"
+  if [ -n "$binary_dir" ]; then
+    dest="$binary_dir"
+  elif is_root; then
+    dest="$bin_dir"
+  else
+    dest="$user_bin_dir"
+  fi
+  mkdir -p "$dest"
+  cp "$script_dir/debug/$1" "$bin_dir/debug_$1"
+  echo "=> Installed debug_$1 to $dest"
 }
 
 install_debug_binaries() {
-	install_debug_binary "srvd"
+  install_debug_binary "srvd"
 }
 
 install_all_binaries() {
-	install_base_binaries
-	install_debug_binaries
+  install_base_binaries
+  install_debug_binaries
 }
 
 # SYSTEMD #
 
 post_systemd_message() {
-	echo "Systemd unit installed, make sure to configure the unit by editing $dest"
-	echo "Learn more in $script_dir/systemd/README.md"
-	echo ""
-	echo "To enable the service on next boot:"
-	echo "  sudo systemctl enable $unit_name"
-	echo ""
-	echo "To start the service immediately:"
-	echo "  sudo systemctl start $unit_name"
+  echo "Systemd unit installed, make sure to configure the unit by editing $dest"
+  echo "Learn more in $script_dir/systemd/README.md"
+  echo ""
+  echo "To enable the service on next boot:"
+  echo "  sudo systemctl enable $unit_name"
+  echo ""
+  echo "To start the service immediately:"
+  echo "  sudo systemctl start $unit_name"
 }
 
 install_systemd_unit() {
-	unit_name="$1"
-	no_mac
-	mkdir -p "$systemd_dir"
-	dest="$systemd_dir/$unit_name"
-	cp "$script_dir/systemd/$unit_name" "$dest"
-	post_systemd_message
+  unit_name="$1"
+  no_mac
+  mkdir -p "$systemd_dir"
+  dest="$systemd_dir/$unit_name"
+  cp "$script_dir/systemd/$unit_name" "$dest"
+  post_systemd_message
 }
 
 install_systemd_sshnpd() {
-	root_only
-	install_single_binary "sshnpd"
-	install_single_binary "srv"
-	install_systemd_unit "sshnpd.service"
+  root_only
+  install_single_binary "sshnpd"
+  install_single_binary "srv"
+  install_systemd_unit "sshnpd.service"
 }
 
 install_systemd_srvd() {
-	root_only
-	install_single_binary "srvd"
-	install_systemd_unit "srvd.service"
+  root_only
+  install_single_binary "srvd"
+  install_systemd_unit "srvd.service"
 }
 
 systemd() {
-	if is_darwin; then
-		echo "Unknown command: systemd"
-		usage
-		exit 1
-	fi
-	case "$1" in
-	--help)
-		usage
-		exit 0
-		;;
-	sshnpd) install_systemd_sshnpd ;;
-	srvd) install_systemd_srvd ;;
-	*)
-		echo "Unknown systemd unit: $1"
-		usage
-		exit 1
-		;;
-	esac
-	setup_authorized_keys
+  if is_darwin; then
+    echo "Unknown command: systemd"
+    usage
+    exit 1
+  fi
+  case "$1" in
+    --help)
+      usage
+      exit 0
+      ;;
+    sshnpd) install_systemd_sshnpd ;;
+    srvd) install_systemd_srvd ;;
+    *)
+      echo "Unknown systemd unit: $1"
+      usage
+      exit 1
+      ;;
+  esac
+  setup_authorized_keys
 }
 
 # LAUNCHD SERVICES #
 post_launchd_message() {
-	echo "Launchd unit installed, make sure to configure the unit by editing $dest"
-	echo ""
-	echo "To enable the service see \"Login Items\" in settings"
+  echo "Launchd unit installed, make sure to configure the unit by editing $dest"
+  echo ""
+  echo "To enable the service see \"Login Items\" in settings"
 }
 
 install_launchd_unit() {
-	unit_name="$1"
-	mac_only
-	mkdir -p "$launchd_dir"
-	dest="$launchd_dir/$unit_name"
-	cp "$script_dir/launchd/$unit_name" "$dest"
-	post_launchd_message
+  unit_name="$1"
+  mac_only
+  mkdir -p "$launchd_dir"
+  dest="$launchd_dir/$unit_name"
+  cp "$script_dir/launchd/$unit_name" "$dest"
+  post_launchd_message
 }
 
 install_launchd_sshnpd() {
-	install_single_binary "sshnpd"
-	install_single_binary "srv"
-	install_launchd_unit "com.atsign.sshnpd.plist"
+  install_single_binary "sshnpd"
+  install_single_binary "srv"
+  install_launchd_unit "com.atsign.sshnpd.plist"
 }
 
 launchd() {
-	if ! is_darwin; then
-		echo "Unknown command: launchd"
-		usage
-		exit 1
-	fi
-	case "$1" in
-	--help)
-		usage
-		exit 0
-		;;
-	sshnpd) install_launchd_sshnpd ;;
-	*)
-		echo "Unknown launchd unit: $1"
-		usage
-		exit 1
-		;;
-	esac
-	setup_authorized_keys
+  if ! is_darwin; then
+    echo "Unknown command: launchd"
+    usage
+    exit 1
+  fi
+  case "$1" in
+    --help)
+      usage
+      exit 0
+      ;;
+    sshnpd) install_launchd_sshnpd ;;
+    *)
+      echo "Unknown launchd unit: $1"
+      usage
+      exit 1
+      ;;
+  esac
+  setup_authorized_keys
 }
 
 # HEADLESS SERVICES #
 
 post_headless_message() {
-	echo "Headless job installed, make sure to configure the job by editing $dest"
-	echo "Learn more in $script_dir/headless/README.md"
-	echo ""
-	echo "The job will start upon next system boot"
-	echo "To start the job immediately:"
-	echo "  $command &"
-	echo ""
-	echo "Warning: logs stored at $log_file and $err_file have unlimited potential size"
-	echo "In a production environment, it's recommended that you install via systemd"
-	echo "or use a cron job to call logrotate on these log files if systemd is not available"
+  echo "Headless job installed, make sure to configure the job by editing $dest"
+  echo "Learn more in $script_dir/headless/README.md"
+  echo ""
+  echo "The job will start upon next system boot"
+  echo "To start the job immediately:"
+  echo "  $command &"
+  echo ""
+  echo "Warning: logs stored at $log_file and $err_file have unlimited potential size"
+  echo "In a production environment, it's recommended that you install via systemd"
+  echo "or use a cron job to call logrotate on these log files if systemd is not available"
 }
 
 install_headless_job() {
-	job_name=$1
-	mkdir -p "$user_bin_dir"
-	mkdir -p "$user_log_dir"
+  job_name=$1
+  mkdir -p "$user_bin_dir"
+  mkdir -p "$user_log_dir"
 
-	dest="$user_bin_dir/$job_name.sh"
-	if ! [ -f "$dest" ]; then
-		cp "$script_dir/headless/$job_name.sh" "$dest"
-		if is_root; then
-			sedi "s|^binary_path=\".*\"$|binary_path=\"$bin_dir\"|g" "$dest"
-		fi
-	fi
+  dest="$user_bin_dir/$job_name.sh"
+  if ! [ -f "$dest" ]; then
+    cp "$script_dir/headless/$job_name.sh" "$dest"
+    if is_root; then
+      sedi "s|^binary_path=\".*\"$|binary_path=\"$bin_dir\"|g" "$dest"
+    fi
+  fi
 
-	log_file="$user_sshnpd_dir/logs/$job_name.log"
-	err_file="$user_sshnpd_dir/logs/$job_name.err"
+  log_file="$user_sshnpd_dir/logs/$job_name.log"
+  err_file="$user_sshnpd_dir/logs/$job_name.err"
 
-	command="nohup $dest > $log_file 2> $err_file"
-	cron_entry="@reboot $command"
-	crontab_contents=$(crontab -l 2>/dev/null)
+  command="nohup $dest > $log_file 2> $err_file"
+  cron_entry="@reboot $command"
+  crontab_contents=$(crontab -l 2>/dev/null)
 
-	if echo "$crontab_contents" | grep -Fxq "$cron_entry"; then
-		echo "=> cron job already installed, killing any old $job_name.sh processes"
-		pids=$(pgrep "$command")
-		if [ -n "$pids" ]; then
-			echo "$pids" | xargs kill
-		fi
-	else
-		echo "=> Installing cron job: $cron_entry"
-		(
-			echo "$crontab_contents"
-			echo "$cron_entry"
-		) | crontab -
-	fi
+  if echo "$crontab_contents" | grep -Fxq "$cron_entry"; then
+    echo "=> cron job already installed, killing any old $job_name.sh processes"
+    pids=$(pgrep "$command")
+    if [ -n "$pids" ]; then
+      echo "$pids" | xargs kill
+    fi
+  else
+    echo "=> Installing cron job: $cron_entry"
+    (
+      echo "$crontab_contents"
+      echo "$cron_entry"
+    ) | crontab -
+  fi
 
-	echo ""
-	post_headless_message
+  echo ""
+  post_headless_message
 }
 
 install_headless_sshnpd() {
-	install_single_binary "sshnpd"
-	install_single_binary "srv"
-	install_headless_job "sshnpd"
+  install_single_binary "sshnpd"
+  install_single_binary "srv"
+  install_headless_job "sshnpd"
 }
 
 install_headless_srvd() {
-	install_single_binary "srvd"
-	install_headless_job "srvd"
+  install_single_binary "srvd"
+  install_headless_job "srvd"
 }
 
 headless() {
-	case "$1" in
-	--help | '')
-		usage
-		exit 0
-		;;
-	sshnpd) install_headless_sshnpd ;;
-	srvd) install_headless_srvd ;;
-	*)
-		echo "Error: Unknown headless job: $1"
-		usage
-		exit 1
-		;;
-	esac
-	setup_authorized_keys
+  case "$1" in
+    --help | '')
+      usage
+      exit 0
+      ;;
+    sshnpd) install_headless_sshnpd ;;
+    srvd) install_headless_srvd ;;
+    *)
+      echo "Error: Unknown headless job: $1"
+      usage
+      exit 1
+      ;;
+  esac
+  setup_authorized_keys
 }
 
 # TMUX SESSION #
 
 post_tmux_message() {
-	# Explain what needs to be edited
-	# Provide initial startup command
-	echo "tmux service installed, make sure to configure the service by editing $dest"
-	echo "Learn more in $script_dir/headless/README.md"
-	echo ""
-	echo "To start the service immediately:"
-	echo "  $command &"
-	echo ""
-	echo "Warning: sometimes tmux is not set to linger which will kill the tmux session on logout"
-	echo "Make sure your system is configured so that tmux sessions can linger, or disown the tmux process before logging out"
+  # Explain what needs to be edited
+  # Provide initial startup command
+  echo "tmux service installed, make sure to configure the service by editing $dest"
+  echo "Learn more in $script_dir/headless/README.md"
+  echo ""
+  echo "To start the service immediately:"
+  echo "  $command &"
+  echo ""
+  echo "Warning: sometimes tmux is not set to linger which will kill the tmux session on logout"
+  echo "Make sure your system is configured so that tmux sessions can linger, or disown the tmux process before logging out"
 }
 
 install_tmux_service() {
-	service_name=$1
-	mkdir -p "$user_bin_dir"
+  service_name=$1
+  mkdir -p "$user_bin_dir"
 
-	dest="$user_bin_dir/$service_name.sh"
+  dest="$user_bin_dir/$service_name.sh"
 
-	# Only copy the "$service_name".sh script if it's not already there
-	if ! [ -f "$dest" ]; then
-		cp "$script_dir/headless/$service_name.sh" "$dest"
-		if is_root; then
-			sedi "s|^binary_path=\".*\"$|binary_path=\"$bin_dir\"|g" "$dest"
-		fi
-	fi
+  # Only copy the "$service_name".sh script if it's not already there
+  if ! [ -f "$dest" ]; then
+    cp "$script_dir/headless/$service_name.sh" "$dest"
+    if is_root; then
+      sedi "s|^binary_path=\".*\"$|binary_path=\"$bin_dir\"|g" "$dest"
+    fi
+  fi
 
-	command="tmux new-session -d -s $service_name && tmux send-keys -t $service_name $dest C-m"
-	cron_entry="@reboot $command"
-	crontab_contents=$(crontab -l 2>/dev/null)
+  command="tmux new-session -d -s $service_name && tmux send-keys -t $service_name $dest C-m"
+  cron_entry="@reboot $command"
+  crontab_contents=$(crontab -l 2>/dev/null)
 
-	if echo "$crontab_contents" | grep -Fxq "$cron_entry"; then
-		echo "=> Cron job already installed, will not re-install"
-	else
-		echo "=> Installing cron job: $cron_entry"
-		(
-			echo "$crontab_contents"
-			echo "$cron_entry"
-		) | crontab -
-	fi
+  if echo "$crontab_contents" | grep -Fxq "$cron_entry"; then
+    echo "=> Cron job already installed, will not re-install"
+  else
+    echo "=> Installing cron job: $cron_entry"
+    (
+      echo "$crontab_contents"
+      echo "$cron_entry"
+    ) | crontab -
+  fi
 
-	if (command tmux has-session -t "$service_name" 2>/dev/null); then
-		echo "=> Found existing tmux session for $service_name - will kill and restart it"
-		command tmux kill-session -t "$service_name"
-		command tmux new-session -d -s "$service_name" && command tmux send-keys -t "$service_name" "$dest" C-m
-	fi
+  if (command tmux has-session -t "$service_name" 2>/dev/null); then
+    echo "=> Found existing tmux session for $service_name - will kill and restart it"
+    command tmux kill-session -t "$service_name"
+    command tmux new-session -d -s "$service_name" && command tmux send-keys -t "$service_name" "$dest" C-m
+  fi
 
-	echo ""
-	post_tmux_message
+  echo ""
+  post_tmux_message
 }
 
 install_tmux_sshnpd() {
-	install_single_binary "sshnpd"
-	install_single_binary "srv"
-	install_tmux_service "sshnpd"
+  install_single_binary "sshnpd"
+  install_single_binary "srv"
+  install_tmux_service "sshnpd"
 }
 
 install_tmux_srvd() {
-	install_single_binary "srvd"
-	install_tmux_service "srvd"
+  install_single_binary "srvd"
+  install_tmux_service "srvd"
 }
 
 tmux() {
-	case "$1" in
-	--help | '')
-		usage
-		exit 0
-		;;
-	sshnpd) install_tmux_sshnpd ;;
-	srvd) install_tmux_srvd ;;
-	*)
-		echo "Unknown tmux service: $1"
-		usage
-		exit 1
-		;;
-	esac
-	setup_authorized_keys
+  case "$1" in
+    --help | '')
+      usage
+      exit 0
+      ;;
+    sshnpd) install_tmux_sshnpd ;;
+    srvd) install_tmux_srvd ;;
+    *)
+      echo "Unknown tmux service: $1"
+      usage
+      exit 1
+      ;;
+  esac
+  setup_authorized_keys
 }
 
 # MAIN #
 
 main() {
-	arg_zero=$0
+  arg_zero=$0
 
-	define_env
+  define_env
 
-	while [ $# -gt 0 ]; do
-		case "$1" in
-		-h)
-			usage
-			exit 0
-			;;
-		-b)
-			binary_dir="$2"
-			shift
-			;;
-		-u)
-			user="$2"
-			user_home=$(sudo -u "$user" sh -c 'echo $HOME')
-			shift
-			;;
-		at_activate | npt | sshnp | sshnpd | srv | srvd) install_single_binary "$1" ;;
-		binaries) install_base_binaries ;;
-		debug_srvd) install_debug_binary "${1#"debug_"}" ;; # strips debug_ prefix from the command input
-		debug) install_debug_binaries ;;
-		all) install_all_binaries ;;
-		systemd | launchd | headless | tmux)
-			command=$1
-			shift 1
-			$command "$@"
-			;;
-		*)
-			echo "Unknown command: $1"
-			usage
-			exit 1
-			;;
-		esac
-		shift
-	done
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -h)
+        usage
+        exit 0
+        ;;
+      -b)
+        binary_dir="$2"
+        shift
+        ;;
+      -u)
+        user="$2"
+        user_home=$(sudo -u "$user" sh -c 'echo $HOME')
+        shift
+        ;;
+      at_activate | npt | sshnp | sshnpd | srv | srvd) install_single_binary "$1" ;;
+      binaries) install_base_binaries ;;
+      debug_srvd) install_debug_binary "${1#"debug_"}" ;; # strips debug_ prefix from the command input
+      debug) install_debug_binaries ;;
+      all) install_all_binaries ;;
+      systemd | launchd | headless | tmux)
+        command=$1
+        shift 1
+        $command "$@"
+        ;;
+      *)
+        echo "Unknown command: $1"
+        usage
+        exit 1
+        ;;
+    esac
+    shift
+  done
 
 }
 

--- a/packages/dart/sshnoports/bundles/shell/install.sh
+++ b/packages/dart/sshnoports/bundles/shell/install.sh
@@ -49,6 +49,13 @@ no_mac() {
   fi
 }
 
+mac_only() {
+  if ! is_darwin; then
+    echo "Error: this operation is only supported on macos"
+    exit 1
+  fi
+}
+
 root_only() {
   if ! is_root; then
     echo "Error: this operation requires root privileges"

--- a/packages/dart/sshnoports/bundles/shell/launchd/com.atsign.sshnpd.plist
+++ b/packages/dart/sshnoports/bundles/shell/launchd/com.atsign.sshnpd.plist
@@ -15,6 +15,8 @@
       <string>[device_name]</string>
       <string>-su</string>
 	</array>
+  <key>KeepAlive</key>
+  <true/>
 	<key>RunAtLoad</key>
 	<true/>
 </dict>

--- a/packages/dart/sshnoports/bundles/shell/magic/sshnp.sh
+++ b/packages/dart/sshnoports/bundles/shell/magic/sshnp.sh
@@ -9,6 +9,7 @@ additional_args=()
 # END METADATA
 
 unset d
+echo "Select a device (enter the number):"
 select d in "${devices[@]}"; do
 	break
 done

--- a/packages/dart/sshnoports/bundles/shell/magic/sshnp.sh
+++ b/packages/dart/sshnoports/bundles/shell/magic/sshnp.sh
@@ -19,4 +19,5 @@ if [ -z "$d" ]; then
 	exit 1
 fi
 
+echo "Executing $binary_path"/sshnp -f "$client_atsign" -t "$device_atsign" -h "$host_atsign" -d "$d" "${additional_args[@]}" "$@"
 "$binary_path"/sshnp -f "$client_atsign" -t "$device_atsign" -h "$host_atsign" -d "$d" "${additional_args[@]}" "$@"

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -452,6 +452,7 @@ get_device_atsign() {
 }
 
 get_installed_atsigns() {
+  clientOrDevice="$1"
   atkeycount=0
   atkeys=""
   selectedatsign=""
@@ -476,13 +477,11 @@ get_installed_atsigns() {
           ;;
       esac
     else
-      echo "${atkeycount} atKeys found: ${atkeys}"
-      echo "Which one should be used:"
       echo "0) None"
       for i in $(seq 1 $atkeycount); do
         echo "$i) @$(echo "$atkeys" | cut -d' ' -f"$i")"
       done
-      printf '$ '
+      printf '=> Found .atKeys for %s atSigns. Choose %s atSign : $ ' "$atkeycount" "$clientOrDevice"
       read -r selectedinput
 
       selectedindex=$((selectedinput))
@@ -542,7 +541,7 @@ client() {
 
   # get the inputs for the magic script
   if [ -z "$client_atsign" ]; then
-    get_installed_atsigns
+    get_installed_atsigns "client"
     client_atsign="$selectedatsign"
     get_client_atsign
   fi
@@ -602,7 +601,7 @@ client() {
   write_metadata "$magic_script" "host_atsign" "$(norm_atsign "$host_atsign")"
   write_metadata_array "$magic_script" "devices" "$devices"
 
-  echo "Run np.sh to get your quick pick of devices to connect to."
+  echo "Run ${bin_path}/np.sh to get your quick pick of devices to connect to."
 }
 
 # DEVICE INSTALLATION #
@@ -628,7 +627,7 @@ device() {
   get_client_atsign
 
   if [ -z "$device_atsign" ]; then
-    get_installed_atsigns
+    get_installed_atsigns "device"
     device_atsign="$selectedatsign"
     get_device_atsign
   fi

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -3,7 +3,7 @@
 # SCRIPT METADATA
 # DO NOT MODIFY/DELETE THIS BLOCK
 script_version="3.0.0"
-sshnp_version="5.1.0"
+sshnp_version="5.1.0-rc.5"
 repo_url="https://github.com/atsign-foundation/sshnoports"
 # END METADATA
 

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -9,6 +9,11 @@ repo_url="https://github.com/atsign-foundation/sshnoports"
 
 # N.B. Other than the variable definitions, and the call to the main function,
 # nothing else should be writen outside the main function to avoid side effects
+### Environment config
+
+# GREP_COLOR not used directly so ignore the shellcheck warning for it
+# shellcheck disable=SC2034
+GREP_COLOR=never
 
 ### Environment based variables
 arg_zero="$0"

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -3,7 +3,7 @@
 # SCRIPT METADATA
 # DO NOT MODIFY/DELETE THIS BLOCK
 script_version="3.0.0"
-sshnp_version="5.1.0-rc.8"
+sshnp_version="5.1.0-rc.9"
 repo_url="https://github.com/atsign-foundation/sshnoports"
 # END METADATA
 

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -45,570 +45,593 @@ device_name=""
 device_type=""
 
 norm_atsign() {
-	# Prepend an @ to the front of the atsign if missing
-	atsign="@$(echo "$1" | sed -e 's/"//g' -e 's/^@//g')"
-	echo "$atsign"
+    # Prepend an @ to the front of the atsign if missing
+    atsign="@$(echo "$1" | sed -e 's/"//g' -e 's/^@//g')"
+    echo "$atsign"
 }
 
 norm_version() {
-	# Ensure the version is in the format "tags/vX.Y.Z" (github version tag)
-	version="tags/v$(echo "$1" | sed -e 's/"//g' -e 's/^tags\///g' -e 's/^v//g')"
-	echo "$version"
+    # Ensure the version is in the format "tags/vX.Y.Z" (github version tag)
+    version="tags/v$(echo "$1" | sed -e 's/"//g' -e 's/^tags\///g' -e 's/^v//g')"
+    echo "$version"
 }
 
 is_root() {
-	[ "$(id -u)" -eq 0 ]
+    [ "$(id -u)" -eq 0 ]
 }
 
 is_darwin() {
-	[ "$(uname)" = 'Darwin' ]
+    [ "$(uname)" = 'Darwin' ]
 }
 
 is_systemd_available() {
-	# https://superuser.com/questions/1017959/how-to-know-if-i-am-using-systemd-on-linux
-	[ -d /run/systemd/system ]
+    # https://superuser.com/questions/1017959/how-to-know-if-i-am-using-systemd-on-linux
+    [ -d /run/systemd/system ]
 }
 
 sedi() {
-	if is_darwin; then
-		sed -i '' "$@"
-	else
-		sed -i "$@"
-	fi
+    if is_darwin; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
 }
 
 version() {
-	echo "Version: $script_version (Target: $sshnp_version)"
+    echo "Version: $script_version (Target: $sshnp_version)"
 }
 
 usage() {
-	if [ -z "$arg_zero" ]; then
-		arg_zero='install.sh'
-	fi
-	version
-	echo "Usage: $arg_zero [options]"
-	echo "  -h, --help                     Display help"
-	echo "  -v, --verbose                  Verbose tracing"
-	echo "      --version                  Display version"
-	echo "      --temp-path      <path>    Set the temporary path for downloads"
-	echo "  -t, --type           <type>    Set the install type (device, client, both)"
-	echo "      --local          <path>    Install from a local archive"
-	echo
-	echo "Client Options:"
-	echo "  -c, --client-atsign  <atsign>  Set the client atSign"
-	echo "  -d, --device-atsign  <atsign>  Set the device atSign"
-	echo "  -r, --region         <region>  Set the default rendezvous region (am, eu, ap)"
-	echo "      --rv-atsign      <atsign>  Set the default rendezvous atsign"
-	echo "  -l, --device-list    <names>   Set the device names for the quick picker script (comma separated)"
-	echo
-	echo "Note: only one of --region or --rv-atsign can be used"
-	echo
-	echo "Device Options:"
-	echo "  -c, --client-atsign  <atsign>  Set the client atSign"
-	echo "  -d, --device-atsign  <atsign>  Set the device atSign"
-	echo "  -n, --device-name    <name>    Set the device name"
-	echo "  --dt, --device-type  <type>    Set the device type (launchd, systemd, tmux, headless)"
+    if [ -z "$arg_zero" ]; then
+        arg_zero='install.sh'
+    fi
+    version
+    echo "Usage: $arg_zero [options]"
+    echo "  -h, --help                     Display help"
+    echo "  -v, --verbose                  Verbose tracing"
+    echo "      --version                  Display version"
+    echo "      --temp-path      <path>    Set the temporary path for downloads"
+    echo "  -t, --type           <type>    Set the install type (device, client, both)"
+    echo "      --local          <path>    Install from a local archive"
+    echo
+    echo "Client Options:"
+    echo "  -c, --client-atsign  <atsign>  Set the client atSign"
+    echo "  -d, --device-atsign  <atsign>  Set the device atSign"
+    echo "  -r, --region         <region>  Set the default rendezvous region (am, eu, ap)"
+    echo "      --rv-atsign      <atsign>  Set the default rendezvous atsign"
+    echo "  -l, --device-list    <names>   Set the device names for the quick picker script (comma separated)"
+    echo
+    echo "Note: only one of --region or --rv-atsign can be used"
+    echo
+    echo "Device Options:"
+    echo "  -c, --client-atsign  <atsign>  Set the client atSign"
+    echo "  -d, --device-atsign  <atsign>  Set the device atSign"
+    echo "  -n, --device-name    <name>    Set the device name"
+    echo "  --dt, --device-type  <type>    Set the device type (launchd, systemd, tmux, headless)"
 
 }
 
 parse_env() {
-	case "$(uname)" in
-	Darwin) platform_name='macos' ;;
-	Linux) platform_name='linux' ;;
-	*)
-		echo "Detected an unsupported platform: $(uname)"
-		echo "Please open an issue at: $repo_url"
-		echo "and provide the following information: $(uname -a)" exit 1
-		;;
-	esac
+    case "$(uname)" in
+    Darwin) platform_name='macos' ;;
+    Linux) platform_name='linux' ;;
+    *)
+        echo "Detected an unsupported platform: $(uname)"
+        echo "Please open an issue at: $repo_url"
+        echo "and provide the following information: $(uname -a)" exit 1
+        ;;
+    esac
 
-	case "$platform_name" in
-	macos) archive_ext="zip" ;;
-	linux) archive_ext="tgz" ;;
-	esac
+    case "$platform_name" in
+    macos) archive_ext="zip" ;;
+    linux) archive_ext="tgz" ;;
+    esac
 
-	case "$(uname -m)" in
-	x86_64 | amd64 | x64)
-		system_arch="x64"
-		;;
-	arm64 | aarch64)
-		system_arch="arm64"
-		;;
-	arm | armv7l)
-		system_arch="armv7"
-		;;
-	riscv64)
-		system_arch="riscv64"
-		;;
-	*)
-		echo "Detected an unsupported architecture: $(uname -m)"
-		echo "Please open an issue at: $repo_url"
-		echo "and provide the following information: $(uname -a)"
-		exit 1
-		;;
-	esac
+    case "$(uname -m)" in
+    x86_64 | amd64 | x64)
+        system_arch="x64"
+        ;;
+    arm64 | aarch64)
+        system_arch="arm64"
+        ;;
+    arm | armv7l)
+        system_arch="armv7"
+        ;;
+    riscv64)
+        system_arch="riscv64"
+        ;;
+    *)
+        echo "Detected an unsupported architecture: $(uname -m)"
+        echo "Please open an issue at: $repo_url"
+        echo "and provide the following information: $(uname -a)"
+        exit 1
+        ;;
+    esac
 
-	time_stamp=$(date +%s)
+    time_stamp=$(date +%s)
 
-	tmp_path="/tmp"
-	extract_path="$tmp_path/sshnp-$time_stamp"
-	archive_path="$extract_path.$archive_ext"
-	user_home="$HOME"
-	if is_root; then
-		user="$SUDO_USER"
-		as_root=true
-		bin_path="/usr/local/bin"
-		if [ -z "$user" ]; then
-			user="root"
-		else
-			# we are root, but via sudo
-			# so get home directory of SUDO_USER
-			user_home=$(sudo -u "$user" sh -c 'echo $HOME')
-		fi
-	else
-		as_root=false
-		bin_path="$HOME/.local/bin"
-		user="$USER"
-	fi
-	user_bin_dir=$user_home/.local/bin/@sshnp
+    tmp_path="/tmp"
+    extract_path="$tmp_path/sshnp-$time_stamp"
+    archive_path="$extract_path.$archive_ext"
+    user_home="$HOME"
+    if is_root; then
+        user="$SUDO_USER"
+        as_root=true
+        bin_path="/usr/local/bin"
+        if [ -z "$user" ]; then
+            user="root"
+        else
+            # we are root, but via sudo
+            # so get home directory of SUDO_USER
+            user_home=$(sudo -u "$user" sh -c 'echo $HOME')
+        fi
+    else
+        as_root=false
+        bin_path="$HOME/.local/bin"
+        user="$USER"
+    fi
+    user_bin_dir=$user_home/.local/bin/@sshnp
 }
 
 is_valid_source_mode() {
-	[ "$1" = "download" ] || [ "$1" = "local" ] || [ "$1" = "build" ]
+    [ "$1" = "download" ] || [ "$1" = "local" ] || [ "$1" = "build" ]
 }
 
 is_valid_install_type() {
-	[ "$1" = "device" ] || [ "$1" = "client" ] || [ "$1" = "both" ]
+    [ "$1" = "device" ] || [ "$1" = "client" ] || [ "$1" = "both" ]
 }
 
 norm_install_type() {
-	case "$1" in
-	d*)
-		echo "device"
-		;;
-	c*)
-		echo "client"
-		;;
-	b*)
-		echo "both"
-		;;
-	*)
-		echo ""
-		;;
-	esac
+    case "$1" in
+    d*)
+        echo "device"
+        ;;
+    c*)
+        echo "client"
+        ;;
+    b*)
+        echo "both"
+        ;;
+    *)
+        echo ""
+        ;;
+    esac
 }
 
 is_valid_device_type() {
-	[ "$1" = "launchd" ] || [ "$1" = "systemd" ] || [ "$1" = "tmux" ] || [ "$1" = "headless" ]
+    [ "$1" = "launchd" ] || [ "$1" = "systemd" ] || [ "$1" = "tmux" ] || [ "$1" = "headless" ]
 }
 
 norm_device_type() {
-	case "$1" in
-	l*)
-		echo "launchd"
-		;;
-	s*)
-		echo "systemd"
-		;;
-	t*)
-		echo "tmux"
-		;;
-	h*)
-		echo "headless"
-		;;
-	*)
-		echo ""
-		;;
-	esac
+    case "$1" in
+    l*)
+        echo "launchd"
+        ;;
+    s*)
+        echo "systemd"
+        ;;
+    t*)
+        echo "tmux"
+        ;;
+    h*)
+        echo "headless"
+        ;;
+    *)
+        echo ""
+        ;;
+    esac
 }
 
 parse_args() {
-	while [ $# -gt 0 ]; do
-		case "$1" in
-		-h | --help)
-			usage
-			exit 0
-			;;
-		-v | --verbose)
-			verbose=true
-			set -x
-			;;
-		--version)
-			version
-			exit 0
-			;;
-		--temp-path)
-			shift
-			mkdir -p "$1"
-			tmp_path="$1"
-			;;
-		-t | --type)
-			shift
-			install_type_input="$1"
-			install_type=$(norm_install_type "$install_type_input")
-			if ! is_valid_install_type "$install_type"; then
-				echo "Invalid install type: $install_type_input"
-				echo "Valid options are: (device, client, both)" exit 1
-			fi
-			;;
-		--local)
-			shift
-			if [ -f "$1" ]; then
-				local_archive="$1"
-			else
-				echo "Local archive not found: $1"
-				exit 1
-			fi
-			;;
-		-c | --client-atsign)
-			shift
-			client_atsign="$1"
-			;;
-		-d | --device-atsign)
-			shift
-			device_atsign="$1"
-			;;
-		-r | --region)
-			# notice that --region and --rv-atsign are basically the same under the hood,
-			# if region's input starts with an "@" it will be equivalent to using --rv-atsign
-			# without an "@", it will try to map to one of the @rv_XX regions
-			shift
-			host_atsign="$1"
-			;;
-		--rv-atsign)
-			shift
-			host_atsign="$(norm_atsign "$1")"
-			;;
-		-l | --device-list)
-			shift
-			devices="$1"
-			;;
-		-n | --device-name)
-			shift
-			device_name="$1"
-			;;
-		--dt | --device-type)
-			shift
-			device_type_input="$1"
-			device_type=$(norm_device_type "$device_type_input")
-			if ! is_valid_device_type "$device_type"; then
-				echo "Invalid device type: $device_type_input"
-				echo "Valid options are: (launchd, systemd, tmux, headless)" exit 1
-			fi
-			;;
-		*)
-			echo "Unexpected option: $1"
-			exit 1
-			;;
-		esac
-		shift
-	done
+    while [ $# -gt 0 ]; do
+        case "$1" in
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        -v | --verbose)
+            verbose=true
+            set -x
+            ;;
+        --version)
+            version
+            exit 0
+            ;;
+        --temp-path)
+            shift
+            mkdir -p "$1"
+            tmp_path="$1"
+            ;;
+        -t | --type)
+            shift
+            install_type_input="$1"
+            install_type=$(norm_install_type "$install_type_input")
+            if ! is_valid_install_type "$install_type"; then
+                echo "Invalid install type: $install_type_input"
+                echo "Valid options are: (device, client, both)" exit 1
+            fi
+            ;;
+        --local)
+            shift
+            if [ -f "$1" ]; then
+                local_archive="$1"
+            else
+                echo "Local archive not found: $1"
+                exit 1
+            fi
+            ;;
+        -c | --client-atsign)
+            shift
+            client_atsign="$1"
+            ;;
+        -d | --device-atsign)
+            shift
+            device_atsign="$1"
+            ;;
+        -r | --region)
+            # notice that --region and --rv-atsign are basically the same under the hood,
+            # if region's input starts with an "@" it will be equivalent to using --rv-atsign
+            # without an "@", it will try to map to one of the @rv_XX regions
+            shift
+            host_atsign="$1"
+            ;;
+        --rv-atsign)
+            shift
+            host_atsign="$(norm_atsign "$1")"
+            ;;
+        -l | --device-list)
+            shift
+            devices="$1"
+            ;;
+        -n | --device-name)
+            shift
+            device_name="$1"
+            ;;
+        --dt | --device-type)
+            shift
+            device_type_input="$1"
+            device_type=$(norm_device_type "$device_type_input")
+            if ! is_valid_device_type "$device_type"; then
+                echo "Invalid device type: $device_type_input"
+                echo "Valid options are: (launchd, systemd, tmux, headless)" exit 1
+            fi
+            ;;
+        *)
+            echo "Unexpected option: $1"
+            exit 1
+            ;;
+        esac
+        shift
+    done
 }
 
 get_user_inputs() {
-	if [ -z "$install_type" ]; then
-		unset install_type_input
-		while [ -z "$install_type" ]; do
-			echo "Install type (device, client, both): "
-			printf "$ "
-			read -r install_type_input
-			install_type=$(norm_install_type "$install_type_input")
-		done
-	fi
+    if [ -z "$install_type" ]; then
+        unset install_type_input
+        while [ -z "$install_type" ]; do
+            printf "Install type (device, client, both):  "
+            read -r install_type_input
+            install_type=$(norm_install_type "$install_type_input")
+        done
+    fi
 }
 
 print_env() {
-	echo "Environment:"
-	echo "Platform Name: $platform_name"
-	echo "System Arch: $system_arch"
-	echo "Temporary Path: $tmp_path"
-	echo "As Root: $as_root"
-	echo "Binary Path: $bin_path"
-	echo "User: $user"
+    echo "Environment:"
+    echo "Platform Name: $platform_name"
+    echo "System Arch: $system_arch"
+    echo "Temporary Path: $tmp_path"
+    echo "As Root: $as_root"
+    echo "Binary Path: $bin_path"
+    echo "User: $user"
 }
 
 get_download_url() {
-	unset download_urls
-	download_urls=$(
-		curl -fsSL "https://api.github.com/repos/atsign-foundation/noports/releases/$(norm_version $sshnp_version)" |
-			grep browser_download_url |
-			cut -d\" -f4
-	)
+    unset download_urls
+    download_urls=$(
+        curl -fsSL "https://api.github.com/repos/atsign-foundation/noports/releases/$(norm_version $sshnp_version)" |
+            grep browser_download_url |
+            cut -d\" -f4
+    )
 
-	if [ -z "$download_urls" ]; then
-		echo "Failed to get download url for sshnoports"
-		exit 1
-	fi
+    if [ -z "$download_urls" ]; then
+        echo "Failed to get download url for sshnoports"
+        exit 1
+    fi
 
-	echo "$download_urls" |
-		grep "$platform_name" | grep "$system_arch" |
-		cut -d\" -f4
+    echo "$download_urls" |
+        grep "$platform_name" | grep "$system_arch" |
+        cut -d\" -f4
 }
 
 download_archive() {
-	read -r download_url
-	echo "Downloading archive from $download_url"
-	curl -sL "$download_url" -o "$archive_path"
-	if [ ! -f "$archive_path" ]; then
-		echo "Failed to download archive"
-		exit 1
-	fi
+    read -r download_url
+    echo "Downloading archive from $download_url"
+    curl -sL "$download_url" -o "$archive_path"
+    if [ ! -f "$archive_path" ]; then
+        echo "Failed to download archive"
+        exit 1
+    fi
 }
 
 unpack_archive() {
-	case "$archive_ext" in
-	zip)
-		unzip -qo "$archive_path" -d "$extract_path"
-		;;
-	tgz | tar.gz)
-		mkdir -p "$extract_path"
-		tar -zxf "$archive_path" -C "$extract_path"
-		;;
-	esac
+    case "$archive_ext" in
+    zip)
+        unzip -qo "$archive_path" -d "$extract_path"
+        ;;
+    tgz | tar.gz)
+        mkdir -p "$extract_path"
+        tar -zxf "$archive_path" -C "$extract_path"
+        ;;
+    esac
 }
 
 cleanup() {
-	# These should be in the tmp directory, attempt to remove them anyway
-	rm -f "$archive_path"
-	rm -rf "$extract_path"
+    # These should be in the tmp directory, attempt to remove them anyway
+    rm -f "$archive_path"
+    rm -rf "$extract_path"
 }
 
 write_metadata() {
-	start_line="# SCRIPT METADATA"
-	end_line="# END METADATA"
-	file=$1
-	variable=$2
-	value=$3
-	sedi "/$start_line/,/$end_line/s|$variable=\".*\"|$variable=\"$value\"|g " "$file"
+    start_line="# SCRIPT METADATA"
+    end_line="# END METADATA"
+    file=$1
+    variable=$2
+    value=$3
+    sedi "/$start_line/,/$end_line/s|$variable=\".*\"|$variable=\"$value\"|g " "$file"
 }
 
 write_metadata_array() {
-	# Takes a comma separated list and writes it into a bash array in the metadata of the script
-	start_line="# SCRIPT METADATA"
-	end_line="# END METADATA"
-	file=$1
-	variable=$2
-	value=$(echo "$3" | tr ',' ' ')
-	sedi "/$start_line/,/$end_line/s|$variable=(.*)|$variable=($value)|g" "$file"
+    # Takes a comma separated list and writes it into a bash array in the metadata of the script
+    start_line="# SCRIPT METADATA"
+    end_line="# END METADATA"
+    file=$1
+    variable=$2
+    value=$(echo "$3" | tr ',' ' ')
+    sedi "/$start_line/,/$end_line/s|$variable=(.*)|$variable=($value)|g" "$file"
 }
 
 write_program_arguments_plist() {
-	# Takes a comma separated list and writes it into a string array in the plist document
-	start_line="<key>ProgramArguments</key>"
-	second_line="<array>"
-	end_line="</array>"
-	file=$1
-	shift
-	string_array=""
-	while [ $# -gt 0 ]; do
-		string_array="$string_array\\
+    # Takes a comma separated list and writes it into a string array in the plist document
+    start_line="<key>ProgramArguments</key>"
+    second_line="<array>"
+    end_line="</array>"
+    file=$1
+    shift
+    string_array=""
+    while [ $# -gt 0 ]; do
+        string_array="$string_array\\
     <string>$1</string>"
-		shift
-	done
-	sedi "s|$end_line|\\
+        shift
+    done
+    sedi "s|$end_line|\\
     $end_line\\
     |g" "$file" # make sure </array> is on a new line or we might delete something we shouldn't
-	sedi "/<key>ProgramArguments<\\/key>/,/<\\/array>/c\\
+    sedi "/<key>ProgramArguments<\\/key>/,/<\\/array>/c\\
   $start_line\\
   $second_line$string_array\\
   $end_line\\
   " "$file"
-	sedi '/^[[:space:]]*$/d' "$file" # remove empty lines to keep things clean
+    sedi '/^[[:space:]]*$/d' "$file" # remove empty lines to keep things clean
 }
 
 write_systemd_user() {
-	file=$1
-	user=$2
-	sedi "s|<username>|$user|g" "$file"
+    file=$1
+    user=$2
+    sedi "s|<username>|$user|g" "$file"
 }
 
 write_systemd_environment() {
-	file=$1
-	variable=$2
-	value=$3
-	sedi "s|Environment=$variable=\".*\"|Environment=$variable=\"$value\"|g" "$file"
+    file=$1
+    variable=$2
+    value=$3
+    sedi "s|Environment=$variable=\".*\"|Environment=$variable=\"$value\"|g" "$file"
 }
 
 get_client_device_atsigns() {
-	while [ -z "$client_atsign" ]; do
-		echo "Enter client atSign:"
-		printf "$ "
-		read -r client_atsign
-	done
+    while [ -z "$client_atsign" ]; do
+        printf "Enter client atSign: "
+        read -r client_atsign
+    done
 
-	while [ -z "$device_atsign" ]; do
-		echo "Enter device atSign:"
-		printf "$ "
-		read -r device_atsign
-	done
+    while [ -z "$device_atsign" ]; do
+        printf "Enter device atSign: "
+        read -r device_atsign
+    done
+}
+
+suggest_sudo() {
+    echo
+    echo "Systemd is present but this script is not running with sudo"
+    echo "It is suggested that you exit and rerun:"
+    echo
+    echo "sudo sh universal.sh"
+    echo
+    echo "If you'd rather (P)roceed with a non systemd installation"
+    echo "then enter p or P, otherwise this script will exit."
+    printf "(P)roceed? "
+    read -r proceed
+    case $proceed in
+    p|P)
+        return
+        ;;
+    *)
+        exit 0
+        ;;
+    esac
 }
 
 # CLIENT INSTALLATION #
 client() {
-	mkdir -p "$bin_path"
+    mkdir -p "$bin_path"
 
-	# install the binaries
-	"$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" sshnp
-	"$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" npt
+    # install the binaries
+    "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" sshnp
+    "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" npt
 
-	# install the magic sshnp script
-	magic_script="$bin_path"/@sshnp
-	cp "$extract_path"/sshnp/magic/sshnp.sh "$magic_script"
-	chmod +x "$magic_script"
-	if is_root && [ -f "$bin_path"/@sshnp ]; then
-		ln -sf "$bin_path"/@sshnp "$user_bin_dir"/@sshnp
-		if [ $verbose = true ]; then
-			echo "=> Linked $user_bin_dir/@sshnp to $bin_path/@sshnp"
-		fi
-	fi
+    # install the magic sshnp script
+    magic_script="$bin_path"/@sshnp
+    cp "$extract_path"/sshnp/magic/sshnp.sh "$magic_script"
+    chmod +x "$magic_script"
+    if is_root && [ -f "$bin_path"/@sshnp ]; then
+        ln -sf "$bin_path"/@sshnp "$user_bin_dir"/@sshnp
+        if [ $verbose = true ]; then
+            echo "=> Linked $user_bin_dir/@sshnp to $bin_path/@sshnp"
+        fi
+    fi
 
-	# get the inputs for the magic script
-	get_client_device_atsigns
-	if [ -z "$host_atsign" ]; then
-		echo Pick your default region:
-		echo "  am   : Americas"
-		echo "  ap   : Asia Pacific"
-		echo "  eu   : Europe"
-		echo "  @___ : Specify a custom region atSign"
-		printf "$ "
-		read -r host_atsign
-	fi
+    # get the inputs for the magic script
+    get_client_device_atsigns
+    if [ -z "$host_atsign" ]; then
+        echo Pick your default region:
+        echo "  am   : Americas"
+        echo "  ap   : Asia Pacific"
+        echo "  eu   : Europe"
+        echo "  @___ : Specify a custom region atSign"
+        printf "Region: "
+        read -r host_atsign
+    fi
 
-	while ! echo "$host_atsign" | grep -Eq "@.*"; do
-		case "$host_atsign" in
-		[Aa][Mm]*)
-			host_atsign="@rv_am"
-			;;
-		[Ee]*)
-			host_atsign="@rv_eu"
-			;;
-		[Aa][Pp]*)
-			host_atsign="@rv_ap"
-			;;
-		@*)
-			# Do nothing for custom region
-			;;
-		*)
-			echo "Invalid region: $host_atsign"
-			printf "$ "
-			read -r host_atsign
-			;;
-		esac
-	done
+    while ! echo "$host_atsign" | grep -Eq "@.*"; do
+        case "$host_atsign" in
+        [Aa][Mm]*)
+            host_atsign="@rv_am"
+            ;;
+        [Ee]*)
+            host_atsign="@rv_eu"
+            ;;
+        [Aa][Pp]*)
+            host_atsign="@rv_ap"
+            ;;
+        @*)
+            # Do nothing for custom region
+            ;;
+        *)
+            printf "Invalid region: ${host_atsign}: "
+            read -r host_atsign
+            ;;
+        esac
+    done
 
-	if [ -z "$devices" ]; then
-		done_input=false
-		echo "Installing a quick picker script to make it easy to connect to devices..."
-		echo "Enter the device names you would like to include in the quick picker script"
-		echo "/done to finish"
-		while [ "$done_input" = false ]; do
-			printf "$ "
-			read -r device_name
-			if [ "$device_name" = "/done" ]; then
-				done_input=true
-			else
-				devices="$devices,$device_name"
-			fi
-		done
-	fi
+    if [ -z "$devices" ]; then
+        done_input=false
+        echo "Installing a quick picker script to make it easy to connect to devices..."
+        echo "Enter the device names you would like to include in the quick picker script"
+        echo "/done to finish"
+        while [ "$done_input" = false ]; do
+            printf "Device name: "
+            read -r device_name
+            if [ "$device_name" = "/done" ]; then
+                done_input=true
+            else
+                devices="$devices,$device_name"
+            fi
+        done
+    fi
 
-	# write the metadata to the magic script
-	write_metadata "$magic_script" "client_atsign" "$(norm_atsign "$client_atsign")"
-	write_metadata "$magic_script" "device_atsign" "$(norm_atsign "$device_atsign")"
-	write_metadata "$magic_script" "host_atsign" "$(norm_atsign "$host_atsign")"
-	write_metadata_array "$magic_script" "devices" "$devices"
+    # write the metadata to the magic script
+    write_metadata "$magic_script" "client_atsign" "$(norm_atsign "$client_atsign")"
+    write_metadata "$magic_script" "device_atsign" "$(norm_atsign "$device_atsign")"
+    write_metadata "$magic_script" "host_atsign" "$(norm_atsign "$host_atsign")"
+    write_metadata_array "$magic_script" "devices" "$devices"
 }
 
 # DEVICE INSTALLATION #
 device() {
-	unset device_install_type
-	if [ -z "$device_type" ]; then
-		if is_darwin; then
-			device_install_type="launchd"
-		elif is_root && is_systemd_available; then
-			device_install_type="systemd"
-		elif command -v tmux >/dev/null 2>&1; then
-			device_install_type="tmux"
-		else
-			device_install_type="headless"
-		fi
-	else
-		# override the device type if it is set
-		device_install_type=$device_type
-	fi
+    unset device_install_type
+    if [ -z "$device_type" ]; then
+        if is_darwin; then
+            device_install_type="launchd"
+        elif is_root && is_systemd_available; then
+            device_install_type="systemd"
+        elif is_systemd_available; then
+            suggest_sudo
+        elif command -v tmux >/dev/null 2>&1; then
+            device_install_type="tmux"
+        else
+            device_install_type="headless"
+        fi
+    else
+        # override the device type if it is set
+        device_install_type=$device_type
+    fi
 
-	get_client_device_atsigns
+    get_client_device_atsigns
 
-	while [ -z "$device_name" ]; do
-		printf "Enter device name:\n$ "
-		read -r device_name
-	done
+    while [ -z "$device_name" ]; do
+        printf "Enter device name:\n$ "
+        read -r device_name
+    done
 
-	# run the device install script and capture the output
-	install_output=$("$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" "$device_install_type" sshnpd)
+    # run the device install script and capture the output
+    install_output=$("$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" "$device_install_type" sshnpd)
 
-	if [ "$verbose" = true ]; then
-		echo "$install_output"
-	fi
+    if [ "$verbose" = true ]; then
+        echo "$install_output"
+    fi
 
-	case "$device_install_type" in
-	launchd)
-		launchd_plist="$HOME/Library/LaunchAgents/com.atsign.sshnpd.plist"
-		write_program_arguments_plist "$launchd_plist" "$bin_path/sshnpd" "-m" "$(norm_atsign "$client_atsign")" "-a" "$(norm_atsign "$device_atsign")" "-d" "$device_name" "-su"
-		launchctl unload "$launchd_plist"
-		launchctl load "$launchd_plist"
-		;;
-	systemd)
-		systemd_service="/etc/systemd/system/sshnpd.service"
+    case "$device_install_type" in
+    launchd)
+        launchd_plist="$HOME/Library/LaunchAgents/com.atsign.sshnpd.plist"
+        write_program_arguments_plist "$launchd_plist" "$bin_path/sshnpd" "-m" "$(norm_atsign "$client_atsign")" "-a" "$(norm_atsign "$device_atsign")" "-d" "$device_name" "-su"
+        launchctl unload "$launchd_plist"
+        launchctl load "$launchd_plist"
+        echo "sshnpd installed with launchd"
+        ;;
+    systemd)
+        systemd_service="/etc/systemd/system/sshnpd.service"
         write_systemd_user "$systemd_service" "$user"
-		write_systemd_environment "$systemd_service" "manager_atsign" "$(norm_atsign "$client_atsign")"
-		write_systemd_environment "$systemd_service" "device_atsign" "$(norm_atsign "$device_atsign")"
-		write_systemd_environment "$systemd_service" "device_name" "$device_name"
-		systemctl enable sshnpd
-		systemctl start sshnpd
-		;;
-	tmux | headless)
-		shell_script="$bin_path"/sshnpd.sh
-		write_metadata "$shell_script" "manager_atsign" "$(norm_atsign "$client_atsign")"
-		write_metadata "$shell_script" "device_atsign" "$(norm_atsign "$device_atsign")"
-		write_metadata "$shell_script" "device_name" "$device_name"
-		# split install output by lines, then grab the output after the line that says "To start immediately"
-		eval "$(echo "$install_output" | grep -A1 "To start .* immediately:" | tail -n1)"
-		;;
-	esac
+        write_systemd_environment "$systemd_service" "manager_atsign" "$(norm_atsign "$client_atsign")"
+        write_systemd_environment "$systemd_service" "device_atsign" "$(norm_atsign "$device_atsign")"
+        write_systemd_environment "$systemd_service" "device_name" "$device_name"
+        systemctl enable sshnpd
+        systemctl start sshnpd
+        echo "sshnpd installed with systemd"
+        echo "use: journalctl -u sshnpd.service -f"
+        echo "to see logs"
+        ;;
+    tmux | headless)
+        shell_script="$bin_path"/sshnpd.sh
+        write_metadata "$shell_script" "manager_atsign" "$(norm_atsign "$client_atsign")"
+        write_metadata "$shell_script" "device_atsign" "$(norm_atsign "$device_atsign")"
+        write_metadata "$shell_script" "device_name" "$device_name"
+        # split install output by lines, then grab the output after the line that says "To start immediately"
+        eval "$(echo "$install_output" | grep -A1 "To start .* immediately:" | tail -n1)"
+        ;;
+    esac
 }
 
 main() {
-	trap cleanup EXIT
-	set -eu
-	parse_env
-	parse_args "$@"
+    trap cleanup EXIT
+    set -eu
+    parse_env
+    parse_args "$@"
 
-	if [ $verbose = true ]; then print_env; fi
+    if [ $verbose = true ]; then print_env; fi
 
-	if [ -n "$local_archive" ]; then
-		echo "Using local archive: $local_archive"
-		cp "$local_archive" "$archive_path"
-	else
-		download_url=$(get_download_url)
-		echo "$download_url" | download_archive
-	fi
+    if [ -n "$local_archive" ]; then
+        echo "Using local archive: $local_archive"
+        cp "$local_archive" "$archive_path"
+    else
+        download_url=$(get_download_url)
+        echo "$download_url" | download_archive
+    fi
 
-	unpack_archive
+    unpack_archive
 
-	get_user_inputs
-	case "$install_type" in
-	client) client ;;
-	device) device ;;
-	both)
-		echo
-		echo "Installing device part..."
-		device
-		echo
-		echo "Installing client part..."
-		client
-		;;
-	esac
+    get_user_inputs
+    case "$install_type" in
+    client) client ;;
+    device) device ;;
+    both)
+        echo
+        echo "Installing device part..."
+        device
+        echo
+        echo "Installing client part..."
+        client
+        ;;
+    esac
 }
 
 main "$@"

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -42,429 +42,429 @@ unset devices
 device_name=""
 
 norm_atsign() {
-	# Prepend an @ to the front of the atsign if missing
-	atsign="@$(echo "$1" | sed -e 's/"//g' -e 's/^@//g')"
-	echo "$atsign"
+    # Prepend an @ to the front of the atsign if missing
+    atsign="@$(echo "$1" | sed -e 's/"//g' -e 's/^@//g')"
+    echo "$atsign"
 }
 
 norm_version() {
-	# Ensure the version is in the format "tags/vX.Y.Z" (github version tag)
-	version="tags/v$(echo "$1" | sed -e 's/"//g' -e 's/^tags\///g' -e 's/^v//g')"
-	echo "$version"
+    # Ensure the version is in the format "tags/vX.Y.Z" (github version tag)
+    version="tags/v$(echo "$1" | sed -e 's/"//g' -e 's/^tags\///g' -e 's/^v//g')"
+    echo "$version"
 }
 
 is_root() {
-	[ "$(id -u)" -eq 0 ]
+    [ "$(id -u)" -eq 0 ]
 }
 
 is_darwin() {
-	[ "$(uname)" = 'Darwin' ]
+    [ "$(uname)" = 'Darwin' ]
 }
 
 sedi() {
-	if is_darwin; then
-		sed -i '' "$@"
-	else
-		sed -i "$@"
-	fi
+    if is_darwin; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
 }
 
 version() {
-	echo "Version: $script_version (Target: $sshnp_version)"
+    echo "Version: $script_version (Target: $sshnp_version)"
 }
 
 usage() {
-	if [ -z "$arg_zero" ]; then
-		arg_zero='install.sh'
-	fi
-	version
-	echo "Usage: $arg_zero [options]"
-	echo "  -h, --help              Display help"
-	echo "  -v, --verbose           Verbose tracing"
-	echo "      --version           Display version"
-	echo "      --temp-path <path>  Set the temporary path for downloads"
-	echo "  -t, --type      <type>  Set the install type (device, client, both)"
-	echo "      --local     <path>  Install from a local archive"
+    if [ -z "$arg_zero" ]; then
+        arg_zero='install.sh'
+    fi
+    version
+    echo "Usage: $arg_zero [options]"
+    echo "  -h, --help              Display help"
+    echo "  -v, --verbose           Verbose tracing"
+    echo "      --version           Display version"
+    echo "      --temp-path <path>  Set the temporary path for downloads"
+    echo "  -t, --type      <type>  Set the install type (device, client, both)"
+    echo "      --local     <path>  Install from a local archive"
 }
 
 parse_env() {
-	case "$(uname)" in
-	Darwin) platform_name='macos' ;;
-	Linux) platform_name='linux' ;;
-	*)
-		echo "Detected an unsupported platform: $(uname)"
-		echo "Please open an issue at: $repo_url"
-		echo "and provide the following information: $(uname -a)" exit 1
-		;;
-	esac
+    case "$(uname)" in
+    Darwin) platform_name='macos' ;;
+    Linux) platform_name='linux' ;;
+    *)
+        echo "Detected an unsupported platform: $(uname)"
+        echo "Please open an issue at: $repo_url"
+        echo "and provide the following information: $(uname -a)" exit 1
+        ;;
+    esac
 
-	case "$platform_name" in
-	macos) archive_ext="zip" ;;
-	linux) archive_ext="tgz" ;;
-	esac
+    case "$platform_name" in
+    macos) archive_ext="zip" ;;
+    linux) archive_ext="tgz" ;;
+    esac
 
-	case "$(uname -m)" in
-	x86_64 | amd64 | x64)
-		system_arch="x64"
-		;;
-	arm64 | aarch64)
-		system_arch="arm64"
-		;;
-	arm | armv7l)
-		system_arch="armv7"
-		;;
-	riscv64)
-		system_arch="riscv64"
-		;;
-	*)
-		echo "Detected an unsupported architecture: $(uname -m)"
-		echo "Please open an issue at: $repo_url"
-		echo "and provide the following information: $(uname -a)"
-		exit 1
-		;;
-	esac
+    case "$(uname -m)" in
+    x86_64 | amd64 | x64)
+        system_arch="x64"
+        ;;
+    arm64 | aarch64)
+        system_arch="arm64"
+        ;;
+    arm | armv7l)
+        system_arch="armv7"
+        ;;
+    riscv64)
+        system_arch="riscv64"
+        ;;
+    *)
+        echo "Detected an unsupported architecture: $(uname -m)"
+        echo "Please open an issue at: $repo_url"
+        echo "and provide the following information: $(uname -a)"
+        exit 1
+        ;;
+    esac
 
-	time_stamp=$(date +%s)
+    time_stamp=$(date +%s)
 
-	tmp_path="/tmp"
-	extract_path="$tmp_path/sshnp-$time_stamp"
-	archive_path="$extract_path.$archive_ext"
+    tmp_path="/tmp"
+    extract_path="$tmp_path/sshnp-$time_stamp"
+    archive_path="$extract_path.$archive_ext"
 
-	if is_root; then
-		as_root=true
-		bin_path="/usr/local/bin"
-		user=$(logname)
-	else
-		as_root=false
-		bin_path="$HOME/.local/bin"
-		user="$USER"
-	fi
+    if is_root; then
+        as_root=true
+        bin_path="/usr/local/bin"
+        user=$(logname)
+    else
+        as_root=false
+        bin_path="$HOME/.local/bin"
+        user="$USER"
+    fi
 }
 
 is_valid_source_mode() {
-	[ "$1" = "download" ] || [ "$1" = "local" ] || [ "$1" = "build" ]
+    [ "$1" = "download" ] || [ "$1" = "local" ] || [ "$1" = "build" ]
 }
 
 is_valid_install_type() {
-	[ "$1" = "device" ] || [ "$1" = "client" ] || [ "$1" = "both" ]
+    [ "$1" = "device" ] || [ "$1" = "client" ] || [ "$1" = "both" ]
 }
 
 norm_install_type() {
-	case "$1" in
-	d*)
-		echo "device"
-		;;
-	c*)
-		echo "client"
-		;;
-	*)
-		echo ""
-		;;
-	esac
+    case "$1" in
+    d*)
+        echo "device"
+        ;;
+    c*)
+        echo "client"
+        ;;
+    *)
+        echo ""
+        ;;
+    esac
 }
 
 parse_args() {
-	while [ $# -gt 0 ]; do
-		case "$1" in
-		-h | --help)
-			usage
-			exit 0
-			;;
-		-v | --verbose)
-			verbose=true
-			set -x
-			;;
-		--version)
-			version
-			exit 0
-			;;
-		--temp-path)
-			shift
-			mkdir -p "$1"
-			tmp_path="$1"
-			;;
-		-t | --type)
-			shift
-			if is_valid_install_type "$1"; then
-				install_type="$1"
-			else
-				echo "Invalid install type: $1"
-				echo "Valid options are: device, client" exit 1
-			fi
-			;;
-		--local)
-			shift
-			if [ -f "$1" ]; then
-				local_archive="$1"
-			else
-				echo "Local archive not found: $1"
-				exit 1
-			fi
-			;;
-		*)
-			echo "Unexpected option: $1"
-			exit 1
-			;;
-		esac
-		shift
-	done
+    while [ $# -gt 0 ]; do
+        case "$1" in
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        -v | --verbose)
+            verbose=true
+            set -x
+            ;;
+        --version)
+            version
+            exit 0
+            ;;
+        --temp-path)
+            shift
+            mkdir -p "$1"
+            tmp_path="$1"
+            ;;
+        -t | --type)
+            shift
+            if is_valid_install_type "$1"; then
+                install_type="$1"
+            else
+                echo "Invalid install type: $1"
+                echo "Valid options are: device, client" exit 1
+            fi
+            ;;
+        --local)
+            shift
+            if [ -f "$1" ]; then
+                local_archive="$1"
+            else
+                echo "Local archive not found: $1"
+                exit 1
+            fi
+            ;;
+        *)
+            echo "Unexpected option: $1"
+            exit 1
+            ;;
+        esac
+        shift
+    done
 }
 
 get_user_inputs() {
-	if [ -z "$install_type" ]; then
-		unset install_type_input
-		while [ -z "$install_type" ]; do
-			echo "Install type (device, client, both): " 1>&2
-			read -r install_type_input
-			install_type=$(norm_install_type "$install_type_input")
-		done
-	fi
+    if [ -z "$install_type" ]; then
+        unset install_type_input
+        while [ -z "$install_type" ]; do
+            echo "Install type (device, client, both): " 1>&2
+            read -r install_type_input
+            install_type=$(norm_install_type "$install_type_input")
+        done
+    fi
 }
 
 print_env() {
-	echo "Environment:"
-	echo "Platform Name: $platform_name"
-	echo "System Arch: $system_arch"
-	echo "Temporary Path: $tmp_path"
-	echo "As Root: $as_root"
-	echo "Binary Path: $bin_path"
-	echo "User: $user"
+    echo "Environment:"
+    echo "Platform Name: $platform_name"
+    echo "System Arch: $system_arch"
+    echo "Temporary Path: $tmp_path"
+    echo "As Root: $as_root"
+    echo "Binary Path: $bin_path"
+    echo "User: $user"
 }
 
 get_download_url() {
-	unset download_urls
-	download_urls=$(
-		curl -fsSL "https://api.github.com/repos/atsign-foundation/noports/releases/$(norm_version $sshnp_version)" |
-			grep browser_download_url |
-			cut -d\" -f4
-	)
+    unset download_urls
+    download_urls=$(
+        curl -fsSL "https://api.github.com/repos/atsign-foundation/noports/releases/$(norm_version $sshnp_version)" |
+            grep browser_download_url |
+            cut -d\" -f4
+    )
 
-	if [ -z "$download_urls" ]; then
-		echo "Failed to get download url for sshnoports"
-		exit 1
-	fi
+    if [ -z "$download_urls" ]; then
+        echo "Failed to get download url for sshnoports"
+        exit 1
+    fi
 
-	echo "$download_urls" |
-		grep "$platform_name" | grep "$system_arch" |
-		cut -d\" -f4
+    echo "$download_urls" |
+        grep "$platform_name" | grep "$system_arch" |
+        cut -d\" -f4
 }
 
 download_archive() {
-	read -r download_url
-	echo "Downloading archive from $download_url"
-	curl -sL "$download_url" -o "$archive_path"
-	if [ ! -f "$archive_path" ]; then
-		echo "Failed to download archive"
-		exit 1
-	fi
+    read -r download_url
+    echo "Downloading archive from $download_url"
+    curl -sL "$download_url" -o "$archive_path"
+    if [ ! -f "$archive_path" ]; then
+        echo "Failed to download archive"
+        exit 1
+    fi
 }
 
 unpack_archive() {
-	case "$archive_ext" in
-	zip)
-		unzip -qo "$archive_path" -d "$extract_path"
-		;;
-	tgz | tar.gz)
+    case "$archive_ext" in
+    zip)
+        unzip -qo "$archive_path" -d "$extract_path"
+        ;;
+    tgz | tar.gz)
         mkdir -p "$extract_path"
-		tar -zxf "$archive_path" -C "$extract_path"
-		;;
-	esac
+        tar -zxf "$archive_path" -C "$extract_path"
+        ;;
+    esac
 }
 
 cleanup() {
-	# These should be in the tmp directory, attempt to remove them anyway
-	rm -f "$archive_path"
-	rm -rf "$extract_path"
+    # These should be in the tmp directory, attempt to remove them anyway
+    rm -f "$archive_path"
+    rm -rf "$extract_path"
 }
 
 write_metadata() {
-	start_line="# SCRIPT METADATA"
-	end_line="# END METADATA"
-	file=$1
-	variable=$2
-	value=$3
-	sedi "/$start_line/,/$end_line/s|$variable=\".*\"|$variable=\"$value\"|g " "$file"
+    start_line="# SCRIPT METADATA"
+    end_line="# END METADATA"
+    file=$1
+    variable=$2
+    value=$3
+    sedi "/$start_line/,/$end_line/s|$variable=\".*\"|$variable=\"$value\"|g " "$file"
 }
 
 write_metadata_array() {
-	# Takes a comma separated list and writes it into a bash array in the metadata of the script
-	start_line="# SCRIPT METADATA"
-	end_line="# END METADATA"
-	file=$1
-	variable=$2
-	value=$(echo "$3" | tr ',' ' ')
-	sedi "/$start_line/,/$end_line/s|$variable=(.*)|$variable=($value)|g" "$file"
+    # Takes a comma separated list and writes it into a bash array in the metadata of the script
+    start_line="# SCRIPT METADATA"
+    end_line="# END METADATA"
+    file=$1
+    variable=$2
+    value=$(echo "$3" | tr ',' ' ')
+    sedi "/$start_line/,/$end_line/s|$variable=(.*)|$variable=($value)|g" "$file"
 }
 
 write_program_arguments_plist() {
-	# Takes a comma separated list and writes it into a string array in the plist document
-	start_line="<key>ProgramArguments</key>"
-	second_line="<array>"
-	end_line="</array>"
-	file=$1
-	shift
-	string_array=""
-	while [ $# -gt 0 ]; do
-		string_array="$string_array\\
+    # Takes a comma separated list and writes it into a string array in the plist document
+    start_line="<key>ProgramArguments</key>"
+    second_line="<array>"
+    end_line="</array>"
+    file=$1
+    shift
+    string_array=""
+    while [ $# -gt 0 ]; do
+        string_array="$string_array\\
     <string>$1</string>"
-		shift
-	done
-	sedi "/<key>ProgramArguments<\\/key>/,/<\\/array>/c\\
+        shift
+    done
+    sedi "/<key>ProgramArguments<\\/key>/,/<\\/array>/c\\
   $start_line\\
   $second_line$string_array\\
   $end_line" "$file"
 }
 
 write_systemd_environment() {
-	file=$1
-	variable=$2
-	value=$3
-	sedi "s|Environment=$variable=\".*\"|Environment=$variable=\"$value\"|g" "$file"
+    file=$1
+    variable=$2
+    value=$3
+    sedi "s|Environment=$variable=\".*\"|Environment=$variable=\"$value\"|g" "$file"
 }
 
 get_client_device_atsigns() {
-	while [ -z "$client_atsign" ]; do
-		echo "Enter client atSign:"
-		read -r client_atsign
-	done
+    while [ -z "$client_atsign" ]; do
+        echo "Enter client atSign:"
+        read -r client_atsign
+    done
 
-	while [ -z "$device_atsign" ]; do
-		echo "Enter device atSign:"
-		read -r device_atsign
-	done
+    while [ -z "$device_atsign" ]; do
+        echo "Enter device atSign:"
+        read -r device_atsign
+    done
 }
 
 # CLIENT INSTALLATION #
 client() {
-	magic_script="$bin_path"/@sshnp
-	# install the magic sshnp script
-	cp "$extract_path"/sshnp/magic/sshnp.sh "$magic_script"
-	chmod +x "$magic_script"
+    magic_script="$bin_path"/@sshnp
+    # install the magic sshnp script
+    cp "$extract_path"/sshnp/magic/sshnp.sh "$magic_script"
+    chmod +x "$magic_script"
 
-	get_client_device_atsigns
-	if [ -z "$host_atsign" ]; then
-		echo Pick your default region:
-		echo "  am   : Americas"
-		echo "  ap   : Asia Pacific"
-		echo "  eu   : Europe"
-		echo "  @___ : Specify a custom region atSign"
-		echo "> "
-		read -r host_atsign
-	fi
+    get_client_device_atsigns
+    if [ -z "$host_atsign" ]; then
+        echo Pick your default region:
+        echo "  am   : Americas"
+        echo "  ap   : Asia Pacific"
+        echo "  eu   : Europe"
+        echo "  @___ : Specify a custom region atSign"
+        echo "> "
+        read -r host_atsign
+    fi
 
-	while ! echo "$host_atsign" | grep -Eq "@.*"; do
-		case "$host_atsign" in
-		[Aa][Mm]*)
-			host_atsign="@rv_am"
-			;;
-		[Ee][Uu]*)
-			host_atsign="@rv_eu"
-			;;
-		[Aa][Pp]*)
-			host_atsign="@rv_ap"
-			;;
-		@*)
-			# Do nothing for custom region
-			;;
-		*)
-			echo "Invalid region: $host_atsign"
-			echo "region: "
-			read -r host_atsign
-			;;
-		esac
-	done
+    while ! echo "$host_atsign" | grep -Eq "@.*"; do
+        case "$host_atsign" in
+        [Aa][Mm]*)
+            host_atsign="@rv_am"
+            ;;
+        [Ee][Uu]*)
+            host_atsign="@rv_eu"
+            ;;
+        [Aa][Pp]*)
+            host_atsign="@rv_ap"
+            ;;
+        @*)
+            # Do nothing for custom region
+            ;;
+        *)
+            echo "Invalid region: $host_atsign"
+            echo "region: "
+            read -r host_atsign
+            ;;
+        esac
+    done
 
-	done_input=false
+    done_input=false
 
-	echo "Enter the device names you would like to include in the magic script"
-	echo "/done to finish"
-	while [ "$done_input" = false ]; do
-		echo "device: "
-		read -r device_name
-		if [ "$device_name" = "/done" ]; then
-			done_input=true
-		else
-			devices="$devices,$device_name"
-		fi
-	done
+    echo "Enter the device names you would like to include in the magic script"
+    echo "/done to finish"
+    while [ "$done_input" = false ]; do
+        echo "device: "
+        read -r device_name
+        if [ "$device_name" = "/done" ]; then
+            done_input=true
+        else
+            devices="$devices,$device_name"
+        fi
+    done
 
-	write_metadata "$magic_script" "client_atsign" "$(norm_atsign "$client_atsign")"
-	write_metadata "$magic_script" "device_atsign" "$(norm_atsign "$device_atsign")"
-	write_metadata "$magic_script" "host_atsign" "$(norm_atsign "$host_atsign")"
-	write_metadata_array "$magic_script" "devices" "$devices"
+    write_metadata "$magic_script" "client_atsign" "$(norm_atsign "$client_atsign")"
+    write_metadata "$magic_script" "device_atsign" "$(norm_atsign "$device_atsign")"
+    write_metadata "$magic_script" "host_atsign" "$(norm_atsign "$host_atsign")"
+    write_metadata_array "$magic_script" "devices" "$devices"
 }
 
 # DEVICE INSTALLATION #
 device() {
-	unset device_install_type
-	if is_darwin; then
-		device_install_type="launchd"
-	elif is_root; then
-		device_install_type="systemd"
-	elif command -v tmux >/dev/null 2>&1; then
-		device_install_type="tmux"
-	else
-		device_install_type="headless"
-	fi
+    unset device_install_type
+    if is_darwin; then
+        device_install_type="launchd"
+    elif is_root; then
+        device_install_type="systemd"
+    elif command -v tmux >/dev/null 2>&1; then
+        device_install_type="tmux"
+    else
+        device_install_type="headless"
+    fi
 
-	get_client_device_atsigns
+    get_client_device_atsigns
 
-	while [ -z "$device_name" ]; do
-		echo "Enter device name:"
-		read -r device_name
-	done
+    while [ -z "$device_name" ]; do
+        echo "Enter device name:"
+        read -r device_name
+    done
 
-	install_output=$("$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" "$device_install_type" sshnpd)
-	case "$device_install_type" in
-	launchd)
-		launchd_plist="$HOME/Library/LaunchAgents/com.atsign.sshnpd.plist"
-		write_program_arguments_plist "$launchd_plist" "$bin_path/sshnpd" "-f" "$(norm_atsign "$client_atsign")" "-t" "$(norm_atsign "$device_atsign")" "-d" "$device_name" "-su"
-		launchctl load "$launchd_plist"
-		launchctl start "$launchd_plist"
-		;;
-	systemd)
-		systemd_service="/etc/systemd/system/sshnpd.service"
-		write_systemd_environment "$systemd_service" "manager_atsign" "$(norm_atsign "$client_atsign")"
-		write_systemd_environment "$systemd_service" "device_atsign" "$(norm_atsign "$device_atsign")"
-		write_systemd_environment "$systemd_service" "device_name" "$device_name"
-		systemctl enable sshnpd
-		systemctl start sshnpd
-		;;
-	tmux | headless)
-		shell_script="$bin_path"/sshnpd.sh
-		write_metadata "$shell_script" "manager_atsign" "$(norm_atsign "$client_atsign")"
-		write_metadata "$shell_script" "device_atsign" "$(norm_atsign "$device_atsign")"
-		write_metadata "$shell_script" "device_name" "$device_name"
-		# split install output by lines, then grab the output after the line that says "To start immediately"
-		eval "$(echo "$install_output" | grep -A1 "To start .* immediately:" | tail -n1)"
-		;;
-	esac
+    install_output=$("$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" "$device_install_type" sshnpd)
+    case "$device_install_type" in
+    launchd)
+        launchd_plist="$HOME/Library/LaunchAgents/com.atsign.sshnpd.plist"
+        write_program_arguments_plist "$launchd_plist" "$bin_path/sshnpd" "-f" "$(norm_atsign "$client_atsign")" "-t" "$(norm_atsign "$device_atsign")" "-d" "$device_name" "-su"
+        launchctl load "$launchd_plist"
+        launchctl start "$launchd_plist"
+        ;;
+    systemd)
+        systemd_service="/etc/systemd/system/sshnpd.service"
+        write_systemd_environment "$systemd_service" "manager_atsign" "$(norm_atsign "$client_atsign")"
+        write_systemd_environment "$systemd_service" "device_atsign" "$(norm_atsign "$device_atsign")"
+        write_systemd_environment "$systemd_service" "device_name" "$device_name"
+        systemctl enable sshnpd
+        systemctl start sshnpd
+        ;;
+    tmux | headless)
+        shell_script="$bin_path"/sshnpd.sh
+        write_metadata "$shell_script" "manager_atsign" "$(norm_atsign "$client_atsign")"
+        write_metadata "$shell_script" "device_atsign" "$(norm_atsign "$device_atsign")"
+        write_metadata "$shell_script" "device_name" "$device_name"
+        # split install output by lines, then grab the output after the line that says "To start immediately"
+        eval "$(echo "$install_output" | grep -A1 "To start .* immediately:" | tail -n1)"
+        ;;
+    esac
 }
 
 main() {
-	trap cleanup EXIT
-	set -eu
-	parse_env
-	parse_args "$@"
+    trap cleanup EXIT
+    set -eu
+    parse_env
+    parse_args "$@"
 
-	if [ $verbose = true ]; then print_env; fi
+    if [ $verbose = true ]; then print_env; fi
 
-	if [ -n "$local_archive" ]; then
-		echo "Using local archive: $local_archive"
-		cp "$local_archive" "$archive_path"
-	else
-		download_url=$(get_download_url)
-		echo "Downloading archive from $download_url"
-		echo "$download_url" | download_archive
-	fi
+    if [ -n "$local_archive" ]; then
+        echo "Using local archive: $local_archive"
+        cp "$local_archive" "$archive_path"
+    else
+        download_url=$(get_download_url)
+        echo "Downloading archive from $download_url"
+        echo "$download_url" | download_archive
+    fi
 
-	unpack_archive
+    unpack_archive
 
-	get_user_inputs
-	case "$install_type" in
-	client) client ;;
-	device) device ;;
-	esac
+    get_user_inputs
+    case "$install_type" in
+    client) client ;;
+    device) device ;;
+    esac
 }
 
 main "$@"

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -3,7 +3,7 @@
 # SCRIPT METADATA
 # DO NOT MODIFY/DELETE THIS BLOCK
 script_version="3.0.0"
-sshnp_version="5.1.0-rc.5"
+sshnp_version="5.1.0-rc.7"
 repo_url="https://github.com/atsign-foundation/sshnoports"
 # END METADATA
 

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -3,7 +3,7 @@
 # SCRIPT METADATA
 # DO NOT MODIFY/DELETE THIS BLOCK
 script_version="3.0.0"
-sshnp_version="5.1.0-rc.11"
+sshnp_version="5.1.0"
 repo_url="https://github.com/atsign-foundation/sshnoports"
 # END METADATA
 

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -443,15 +443,20 @@ get_client_device_atsigns() {
 
     while [ -z "$device_atsign" ]; do
         if [ -d "${user_home}/.atsign/keys" ]; then
-            atkeys=( $(ls -1 ${user_home}/.atsign/keys | sed s/@// | sed s/_key.atKeys//) )
-            if [ ${#atkeys[@]} -eq 0 ]; then
-                echo "~/.atsign/keys directory found but there are no keys there yet"
+            atkeycount=0
+            for file in $(find "$user_home"/.atsign/keys/*.atKeys -type f); do
+                atkeys="$atkeys $(echo "$file" | sed s/^.*@// | sed s/_key.atKeys//)"
+                atkeycount=$((atkeycount+1))
+            done
+            if [ $atkeycount -eq 0 ]; then
+                echo '$HOME/.atsign/keys directory found but there are no keys there yet'
                 echo "Which atSign do you plan to use?"
                 get_device_atsign
             else
-                echo "${#atkeys[@]} atKeys found: ${atkeys[@]}"
-                for atkey in "${atkeys[@]}"; do
-                    printf "Would you like to use @${atkey} for this device? "
+                echo "${atkeycount}} atKeys found: ${atkeys}"
+                for file in $(find "$user_home"/.atsign/keys/*.atKeys -type f); do
+                    atkey=$(echo "$file" | sed s/^.*@// | sed s/_key.atKeys//)
+                    printf "Would you like to use @%s for this device? " "$atkey"
                     read -r use_atkey
                     case $use_atkey in
                     y*|Y*)
@@ -464,8 +469,8 @@ get_client_device_atsigns() {
                 get_device_atsign
             fi
         else
-            mkdir -p ${user_home}/.atsign/keys
-            echo "~/.atsign/keys directory created"
+            mkdir -p "$user_home"/.atsign/keys
+            echo '$HOME/.atsign/keys directory created'
             echo "Which atSign do you plan to use?"
             get_device_atsign
         fi
@@ -540,7 +545,7 @@ client() {
             # Do nothing for custom region
             ;;
         *)
-            printf "Invalid region: ${host_atsign}: "
+            printf "Invalid region: %s: " "$host_atsign"
             read -r host_atsign
             ;;
         esac

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -265,6 +265,7 @@ unpack_archive() {
 		unzip -qo "$archive_path" -d "$extract_path"
 		;;
 	tgz | tar.gz)
+        mkdir -p "$extract_path"
 		tar -zxf "$archive_path" -C "$extract_path"
 		;;
 	esac

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -14,6 +14,7 @@ repo_url="https://github.com/atsign-foundation/sshnoports"
 # GREP_COLOR not used directly so ignore the shellcheck warning for it
 # shellcheck disable=SC2034
 GREP_COLOR=never
+unset GREP_OPTIONS
 
 ### Environment based variables
 arg_zero="$0"

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -3,7 +3,7 @@
 # SCRIPT METADATA
 # DO NOT MODIFY/DELETE THIS BLOCK
 script_version="3.0.0"
-sshnp_version="5.1.0-rc.7"
+sshnp_version="5.1.0-rc.8"
 repo_url="https://github.com/atsign-foundation/sshnoports"
 # END METADATA
 

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -449,7 +449,7 @@ client() {
 	magic_script="$bin_path"/@sshnp
 	cp "$extract_path"/sshnp/magic/sshnp.sh "$magic_script"
 	chmod +x "$magic_script"
-	if is_root; then
+	if is_root && [ -f "$bin_path"/@sshnp ]; then
 		ln -sf "$bin_path"/@sshnp "$user_bin_dir"/@sshnp
 		if [ $verbose = true ]; then
 			echo "=> Linked $user_bin_dir/@sshnp to $bin_path/@sshnp"

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -3,7 +3,7 @@
 # SCRIPT METADATA
 # DO NOT MODIFY/DELETE THIS BLOCK
 script_version="3.0.0"
-sshnp_version="5.1.0-rc.9"
+sshnp_version="5.1.0-rc.11"
 repo_url="https://github.com/atsign-foundation/sshnoports"
 # END METADATA
 

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -3,7 +3,7 @@
 # SCRIPT METADATA
 # DO NOT MODIFY/DELETE THIS BLOCK
 script_version="3.0.0"
-sshnp_version="5.1.0-rc.10"
+sshnp_version="5.1.0-rc.9"
 repo_url="https://github.com/atsign-foundation/sshnoports"
 # END METADATA
 
@@ -559,7 +559,7 @@ device() {
     get_client_device_atsigns
 
     while [ -z "$device_name" ]; do
-        printf "Enter device name:\n$ "
+        printf "Enter device name: "
         read -r device_name
     done
 
@@ -586,9 +586,8 @@ device() {
         write_systemd_environment "$systemd_service" "device_name" "$device_name"
         systemctl enable sshnpd
         systemctl start sshnpd
-        echo "sshnpd installed with systemd"
-        echo "use: journalctl -u sshnpd.service -f"
-        echo "to see logs"
+        echo "sshnpd installed with systemd. To see logs use:"
+        echo "journalctl -u sshnpd.service -f"
         ;;
     tmux | headless)
         shell_script="$bin_path"/sshnpd.sh

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -3,7 +3,7 @@
 # SCRIPT METADATA
 # DO NOT MODIFY/DELETE THIS BLOCK
 script_version="3.0.0"
-sshnp_version="5.1.0-rc.9"
+sshnp_version="5.1.0-rc.10"
 repo_url="https://github.com/atsign-foundation/sshnoports"
 # END METADATA
 

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -509,13 +509,13 @@ client() {
     "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" npt
 
     # install the magic sshnp script
-    magic_script="$bin_path"/@sshnp
+    magic_script="$bin_path"/np.sh
     cp "$extract_path"/sshnp/magic/sshnp.sh "$magic_script"
     chmod +x "$magic_script"
-    if is_root && [ -f "$bin_path"/@sshnp ]; then
-        ln -sf "$bin_path"/@sshnp "$user_bin_dir"/@sshnp
+    if is_root && [ -f "$bin_path"/np.sh ]; then
+        ln -sf "$bin_path"/np.sh "$user_bin_dir"/np.sh
         if [ $verbose = true ]; then
-            echo "=> Linked $user_bin_dir/@sshnp to $bin_path/@sshnp"
+            echo "=> Linked $user_bin_dir/np.sh to $bin_path/np.sh"
         fi
     fi
 
@@ -573,6 +573,8 @@ client() {
     write_metadata "$magic_script" "device_atsign" "$(norm_atsign "$device_atsign")"
     write_metadata "$magic_script" "host_atsign" "$(norm_atsign "$host_atsign")"
     write_metadata_array "$magic_script" "devices" "$devices"
+
+    echo "Run np.sh to get your quick pick of devices to connect to."
 }
 
 # DEVICE INSTALLATION #

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -444,6 +444,7 @@ get_client_device_atsigns() {
     while [ -z "$device_atsign" ]; do
         if [ -d "${user_home}/.atsign/keys" ]; then
             atkeycount=0
+            atkeys=""
             for file in $(find "$user_home"/.atsign/keys/*.atKeys -type f); do
                 atkeys="$atkeys $(echo "$file" | sed s/^.*@// | sed s/_key.atKeys//)"
                 atkeycount=$((atkeycount+1))
@@ -453,7 +454,7 @@ get_client_device_atsigns() {
                 echo "Which atSign do you plan to use?"
                 get_device_atsign
             else
-                echo "${atkeycount}} atKeys found: ${atkeys}"
+                echo "${atkeycount} atKeys found: ${atkeys}"
                 for file in $(find "$user_home"/.atsign/keys/*.atKeys -type f); do
                     atkey=$(echo "$file" | sed s/^.*@// | sed s/_key.atKeys//)
                     printf "Would you like to use @%s for this device? " "$atkey"

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -157,6 +157,9 @@ norm_install_type() {
     c*)
         echo "client"
         ;;
+    b*)
+        echo "both"
+        ;;
     *)
         echo ""
         ;;
@@ -463,6 +466,7 @@ main() {
     case "$install_type" in
     client) client ;;
     device) device ;;
+    both) client device ;;
     esac
 }
 

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -35,439 +35,557 @@ device_atsign=""
 
 ### Client Install Variables
 unset magic_script
-unset host_atsign
-unset devices
+host_atsign=""
+devices=""
 
 ### Device Install Variables
 device_name=""
+device_type=""
 
 norm_atsign() {
-    # Prepend an @ to the front of the atsign if missing
-    atsign="@$(echo "$1" | sed -e 's/"//g' -e 's/^@//g')"
-    echo "$atsign"
+	# Prepend an @ to the front of the atsign if missing
+	atsign="@$(echo "$1" | sed -e 's/"//g' -e 's/^@//g')"
+	echo "$atsign"
 }
 
 norm_version() {
-    # Ensure the version is in the format "tags/vX.Y.Z" (github version tag)
-    version="tags/v$(echo "$1" | sed -e 's/"//g' -e 's/^tags\///g' -e 's/^v//g')"
-    echo "$version"
+	# Ensure the version is in the format "tags/vX.Y.Z" (github version tag)
+	version="tags/v$(echo "$1" | sed -e 's/"//g' -e 's/^tags\///g' -e 's/^v//g')"
+	echo "$version"
 }
 
 is_root() {
-    [ "$(id -u)" -eq 0 ]
+	[ "$(id -u)" -eq 0 ]
 }
 
 is_darwin() {
-    [ "$(uname)" = 'Darwin' ]
+	[ "$(uname)" = 'Darwin' ]
+}
+
+is_systemd_available() {
+	# https://superuser.com/questions/1017959/how-to-know-if-i-am-using-systemd-on-linux
+	[ -d /run/systemd/system ]
 }
 
 sedi() {
-    if is_darwin; then
-        sed -i '' "$@"
-    else
-        sed -i "$@"
-    fi
+	if is_darwin; then
+		sed -i '' "$@"
+	else
+		sed -i "$@"
+	fi
 }
 
 version() {
-    echo "Version: $script_version (Target: $sshnp_version)"
+	echo "Version: $script_version (Target: $sshnp_version)"
 }
 
 usage() {
-    if [ -z "$arg_zero" ]; then
-        arg_zero='install.sh'
-    fi
-    version
-    echo "Usage: $arg_zero [options]"
-    echo "  -h, --help              Display help"
-    echo "  -v, --verbose           Verbose tracing"
-    echo "      --version           Display version"
-    echo "      --temp-path <path>  Set the temporary path for downloads"
-    echo "  -t, --type      <type>  Set the install type (device, client, both)"
-    echo "      --local     <path>  Install from a local archive"
+	if [ -z "$arg_zero" ]; then
+		arg_zero='install.sh'
+	fi
+	version
+	echo "Usage: $arg_zero [options]"
+	echo "  -h, --help                     Display help"
+	echo "  -v, --verbose                  Verbose tracing"
+	echo "      --version                  Display version"
+	echo "      --temp-path      <path>    Set the temporary path for downloads"
+	echo "  -t, --type           <type>    Set the install type (device, client, both)"
+	echo "      --local          <path>    Install from a local archive"
+	echo
+	echo "Client Options:"
+	echo "  -c, --client-atsign  <atsign>  Set the client atSign"
+	echo "  -d, --device-atsign  <atsign>  Set the device atSign"
+	echo "  -r, --region         <region>  Set the default rendezvous region (am, eu, ap)"
+	echo "      --rv-atsign      <atsign>  Set the default rendezvous atsign"
+	echo "  -l, --device-list    <names>   Set the device names for the quick picker script (comma separated)"
+	echo
+	echo "Note: only one of --region or --rv-atsign can be used"
+	echo
+	echo "Device Options:"
+	echo "  -c, --client-atsign  <atsign>  Set the client atSign"
+	echo "  -d, --device-atsign  <atsign>  Set the device atSign"
+	echo "  -n, --device-name    <name>    Set the device name"
+	echo "  --dt, --device-type  <type>    Set the device type (launchd, systemd, tmux, headless)"
+
 }
 
 parse_env() {
-    case "$(uname)" in
-    Darwin) platform_name='macos' ;;
-    Linux) platform_name='linux' ;;
-    *)
-        echo "Detected an unsupported platform: $(uname)"
-        echo "Please open an issue at: $repo_url"
-        echo "and provide the following information: $(uname -a)" exit 1
-        ;;
-    esac
+	case "$(uname)" in
+	Darwin) platform_name='macos' ;;
+	Linux) platform_name='linux' ;;
+	*)
+		echo "Detected an unsupported platform: $(uname)"
+		echo "Please open an issue at: $repo_url"
+		echo "and provide the following information: $(uname -a)" exit 1
+		;;
+	esac
 
-    case "$platform_name" in
-    macos) archive_ext="zip" ;;
-    linux) archive_ext="tgz" ;;
-    esac
+	case "$platform_name" in
+	macos) archive_ext="zip" ;;
+	linux) archive_ext="tgz" ;;
+	esac
 
-    case "$(uname -m)" in
-    x86_64 | amd64 | x64)
-        system_arch="x64"
-        ;;
-    arm64 | aarch64)
-        system_arch="arm64"
-        ;;
-    arm | armv7l)
-        system_arch="armv7"
-        ;;
-    riscv64)
-        system_arch="riscv64"
-        ;;
-    *)
-        echo "Detected an unsupported architecture: $(uname -m)"
-        echo "Please open an issue at: $repo_url"
-        echo "and provide the following information: $(uname -a)"
-        exit 1
-        ;;
-    esac
+	case "$(uname -m)" in
+	x86_64 | amd64 | x64)
+		system_arch="x64"
+		;;
+	arm64 | aarch64)
+		system_arch="arm64"
+		;;
+	arm | armv7l)
+		system_arch="armv7"
+		;;
+	riscv64)
+		system_arch="riscv64"
+		;;
+	*)
+		echo "Detected an unsupported architecture: $(uname -m)"
+		echo "Please open an issue at: $repo_url"
+		echo "and provide the following information: $(uname -a)"
+		exit 1
+		;;
+	esac
 
-    time_stamp=$(date +%s)
+	time_stamp=$(date +%s)
 
-    tmp_path="/tmp"
-    extract_path="$tmp_path/sshnp-$time_stamp"
-    archive_path="$extract_path.$archive_ext"
+	tmp_path="/tmp"
+	extract_path="$tmp_path/sshnp-$time_stamp"
+	archive_path="$extract_path.$archive_ext"
 
-    if is_root; then
-        as_root=true
-        bin_path="/usr/local/bin"
-        user=$(logname)
-    else
-        as_root=false
-        bin_path="$HOME/.local/bin"
-        user="$USER"
-    fi
+	if is_root; then
+		as_root=true
+		bin_path="/usr/local/bin"
+		user=$(logname)
+	else
+		as_root=false
+		bin_path="$HOME/.local/bin"
+		user="$USER"
+	fi
 }
 
 is_valid_source_mode() {
-    [ "$1" = "download" ] || [ "$1" = "local" ] || [ "$1" = "build" ]
+	[ "$1" = "download" ] || [ "$1" = "local" ] || [ "$1" = "build" ]
 }
 
 is_valid_install_type() {
-    [ "$1" = "device" ] || [ "$1" = "client" ] || [ "$1" = "both" ]
+	[ "$1" = "device" ] || [ "$1" = "client" ] || [ "$1" = "both" ]
 }
 
 norm_install_type() {
-    case "$1" in
-    d*)
-        echo "device"
-        ;;
-    c*)
-        echo "client"
-        ;;
-    b*)
-        echo "both"
-        ;;
-    *)
-        echo ""
-        ;;
-    esac
+	case "$1" in
+	d*)
+		echo "device"
+		;;
+	c*)
+		echo "client"
+		;;
+	b*)
+		echo "both"
+		;;
+	*)
+		echo ""
+		;;
+	esac
+}
+
+is_valid_device_type() {
+	[ "$1" = "launchd" ] || [ "$1" = "systemd" ] || [ "$1" = "tmux" ] || [ "$1" = "headless" ]
+}
+
+norm_device_type() {
+	case "$1" in
+	l*)
+		echo "launchd"
+		;;
+	s*)
+		echo "systemd"
+		;;
+	t*)
+		echo "tmux"
+		;;
+	h*)
+		echo "headless"
+		;;
+	*)
+		echo ""
+		;;
+	esac
 }
 
 parse_args() {
-    while [ $# -gt 0 ]; do
-        case "$1" in
-        -h | --help)
-            usage
-            exit 0
-            ;;
-        -v | --verbose)
-            verbose=true
-            set -x
-            ;;
-        --version)
-            version
-            exit 0
-            ;;
-        --temp-path)
-            shift
-            mkdir -p "$1"
-            tmp_path="$1"
-            ;;
-        -t | --type)
-            shift
-            if is_valid_install_type "$1"; then
-                install_type="$1"
-            else
-                echo "Invalid install type: $1"
-                echo "Valid options are: device, client" exit 1
-            fi
-            ;;
-        --local)
-            shift
-            if [ -f "$1" ]; then
-                local_archive="$1"
-            else
-                echo "Local archive not found: $1"
-                exit 1
-            fi
-            ;;
-        *)
-            echo "Unexpected option: $1"
-            exit 1
-            ;;
-        esac
-        shift
-    done
+	while [ $# -gt 0 ]; do
+		case "$1" in
+		-h | --help)
+			usage
+			exit 0
+			;;
+		-v | --verbose)
+			verbose=true
+			set -x
+			;;
+		--version)
+			version
+			exit 0
+			;;
+		--temp-path)
+			shift
+			mkdir -p "$1"
+			tmp_path="$1"
+			;;
+		-t | --type)
+			shift
+			install_type_input="$1"
+			install_type=$(norm_install_type "$install_type_input")
+			if ! is_valid_install_type "$install_type"; then
+				echo "Invalid install type: $install_type_input"
+				echo "Valid options are: (device, client, both)" exit 1
+			fi
+			;;
+		--local)
+			shift
+			if [ -f "$1" ]; then
+				local_archive="$1"
+			else
+				echo "Local archive not found: $1"
+				exit 1
+			fi
+			;;
+		-c | --client-atsign)
+			shift
+			client_atsign="$1"
+			;;
+		-d | --device-atsign)
+			shift
+			device_atsign="$1"
+			;;
+		-r | --region)
+			# notice that --region and --rv-atsign are basically the same under the hood,
+			# if region's input starts with an "@" it will be equivalent to using --rv-atsign
+			# without an "@", it will try to map to one of the @rv_XX regions
+			shift
+			host_atsign="$1"
+			;;
+		--rv-atsign)
+			shift
+			host_atsign="$(norm_atsign "$1")"
+			;;
+		-l | --device-list)
+			shift
+			devices="$1"
+			;;
+		-n | --device-name)
+			shift
+			device_name="$1"
+			;;
+		--dt | --device-type)
+			shift
+			device_type_input="$1"
+			device_type=$(norm_device_type "$device_type_input")
+			if ! is_valid_device_type "$device_type"; then
+				echo "Invalid device type: $device_type_input"
+				echo "Valid options are: (launchd, systemd, tmux, headless)" exit 1
+			fi
+			;;
+		*)
+			echo "Unexpected option: $1"
+			exit 1
+			;;
+		esac
+		shift
+	done
 }
 
 get_user_inputs() {
-    if [ -z "$install_type" ]; then
-        unset install_type_input
-        while [ -z "$install_type" ]; do
-            echo "Install type (device, client, both): " 1>&2
-            read -r install_type_input
-            install_type=$(norm_install_type "$install_type_input")
-        done
-    fi
+	if [ -z "$install_type" ]; then
+		unset install_type_input
+		while [ -z "$install_type" ]; do
+			echo "Install type (device, client, both): "
+			printf "$ "
+			read -r install_type_input
+			install_type=$(norm_install_type "$install_type_input")
+		done
+	fi
 }
 
 print_env() {
-    echo "Environment:"
-    echo "Platform Name: $platform_name"
-    echo "System Arch: $system_arch"
-    echo "Temporary Path: $tmp_path"
-    echo "As Root: $as_root"
-    echo "Binary Path: $bin_path"
-    echo "User: $user"
+	echo "Environment:"
+	echo "Platform Name: $platform_name"
+	echo "System Arch: $system_arch"
+	echo "Temporary Path: $tmp_path"
+	echo "As Root: $as_root"
+	echo "Binary Path: $bin_path"
+	echo "User: $user"
 }
 
 get_download_url() {
-    unset download_urls
-    download_urls=$(
-        curl -fsSL "https://api.github.com/repos/atsign-foundation/noports/releases/$(norm_version $sshnp_version)" |
-            grep browser_download_url |
-            cut -d\" -f4
-    )
+	unset download_urls
+	download_urls=$(
+		curl -fsSL "https://api.github.com/repos/atsign-foundation/noports/releases/$(norm_version $sshnp_version)" |
+			grep browser_download_url |
+			cut -d\" -f4
+	)
 
-    if [ -z "$download_urls" ]; then
-        echo "Failed to get download url for sshnoports"
-        exit 1
-    fi
+	if [ -z "$download_urls" ]; then
+		echo "Failed to get download url for sshnoports"
+		exit 1
+	fi
 
-    echo "$download_urls" |
-        grep "$platform_name" | grep "$system_arch" |
-        cut -d\" -f4
+	echo "$download_urls" |
+		grep "$platform_name" | grep "$system_arch" |
+		cut -d\" -f4
 }
 
 download_archive() {
-    read -r download_url
-    echo "Downloading archive from $download_url"
-    curl -sL "$download_url" -o "$archive_path"
-    if [ ! -f "$archive_path" ]; then
-        echo "Failed to download archive"
-        exit 1
-    fi
+	read -r download_url
+	echo "Downloading archive from $download_url"
+	curl -sL "$download_url" -o "$archive_path"
+	if [ ! -f "$archive_path" ]; then
+		echo "Failed to download archive"
+		exit 1
+	fi
 }
 
 unpack_archive() {
-    case "$archive_ext" in
-    zip)
-        unzip -qo "$archive_path" -d "$extract_path"
-        ;;
-    tgz | tar.gz)
-        mkdir -p "$extract_path"
-        tar -zxf "$archive_path" -C "$extract_path"
-        ;;
-    esac
+	case "$archive_ext" in
+	zip)
+		unzip -qo "$archive_path" -d "$extract_path"
+		;;
+	tgz | tar.gz)
+		mkdir -p "$extract_path"
+		tar -zxf "$archive_path" -C "$extract_path"
+		;;
+	esac
 }
 
 cleanup() {
-    # These should be in the tmp directory, attempt to remove them anyway
-    rm -f "$archive_path"
-    rm -rf "$extract_path"
+	# These should be in the tmp directory, attempt to remove them anyway
+	rm -f "$archive_path"
+	rm -rf "$extract_path"
 }
 
 write_metadata() {
-    start_line="# SCRIPT METADATA"
-    end_line="# END METADATA"
-    file=$1
-    variable=$2
-    value=$3
-    sedi "/$start_line/,/$end_line/s|$variable=\".*\"|$variable=\"$value\"|g " "$file"
+	start_line="# SCRIPT METADATA"
+	end_line="# END METADATA"
+	file=$1
+	variable=$2
+	value=$3
+	sedi "/$start_line/,/$end_line/s|$variable=\".*\"|$variable=\"$value\"|g " "$file"
 }
 
 write_metadata_array() {
-    # Takes a comma separated list and writes it into a bash array in the metadata of the script
-    start_line="# SCRIPT METADATA"
-    end_line="# END METADATA"
-    file=$1
-    variable=$2
-    value=$(echo "$3" | tr ',' ' ')
-    sedi "/$start_line/,/$end_line/s|$variable=(.*)|$variable=($value)|g" "$file"
+	# Takes a comma separated list and writes it into a bash array in the metadata of the script
+	start_line="# SCRIPT METADATA"
+	end_line="# END METADATA"
+	file=$1
+	variable=$2
+	value=$(echo "$3" | tr ',' ' ')
+	sedi "/$start_line/,/$end_line/s|$variable=(.*)|$variable=($value)|g" "$file"
 }
 
 write_program_arguments_plist() {
-    # Takes a comma separated list and writes it into a string array in the plist document
-    start_line="<key>ProgramArguments</key>"
-    second_line="<array>"
-    end_line="</array>"
-    file=$1
-    shift
-    string_array=""
-    while [ $# -gt 0 ]; do
-        string_array="$string_array\\
+	# Takes a comma separated list and writes it into a string array in the plist document
+	start_line="<key>ProgramArguments</key>"
+	second_line="<array>"
+	end_line="</array>"
+	file=$1
+	shift
+	string_array=""
+	while [ $# -gt 0 ]; do
+		string_array="$string_array\\
     <string>$1</string>"
-        shift
-    done
-    sedi "/<key>ProgramArguments<\\/key>/,/<\\/array>/c\\
+		shift
+	done
+	sedi "s|$end_line|\\
+    $end_line\\
+    |g" "$file" # make sure </array> is on a new line or we might delete something we shouldn't
+	sedi "/<key>ProgramArguments<\\/key>/,/<\\/array>/c\\
   $start_line\\
   $second_line$string_array\\
-  $end_line" "$file"
+  $end_line\\
+  " "$file"
+	sedi '/^[[:space:]]*$/d' "$file" # remove empty lines to keep things clean
 }
 
 write_systemd_environment() {
-    file=$1
-    variable=$2
-    value=$3
-    sedi "s|Environment=$variable=\".*\"|Environment=$variable=\"$value\"|g" "$file"
+	file=$1
+	variable=$2
+	value=$3
+	sedi "s|Environment=$variable=\".*\"|Environment=$variable=\"$value\"|g" "$file"
 }
 
 get_client_device_atsigns() {
-    while [ -z "$client_atsign" ]; do
-        echo "Enter client atSign:"
-        read -r client_atsign
-    done
+	while [ -z "$client_atsign" ]; do
+		echo "Enter client atSign:"
+		printf "$ "
+		read -r client_atsign
+	done
 
-    while [ -z "$device_atsign" ]; do
-        echo "Enter device atSign:"
-        read -r device_atsign
-    done
+	while [ -z "$device_atsign" ]; do
+		echo "Enter device atSign:"
+		printf "$ "
+		read -r device_atsign
+	done
 }
 
 # CLIENT INSTALLATION #
 client() {
-    magic_script="$bin_path"/@sshnp
-    # install the magic sshnp script
-    cp "$extract_path"/sshnp/magic/sshnp.sh "$magic_script"
-    chmod +x "$magic_script"
+	mkdir -p "$bin_path"
 
-    get_client_device_atsigns
-    if [ -z "$host_atsign" ]; then
-        echo Pick your default region:
-        echo "  am   : Americas"
-        echo "  ap   : Asia Pacific"
-        echo "  eu   : Europe"
-        echo "  @___ : Specify a custom region atSign"
-        echo "> "
-        read -r host_atsign
-    fi
+	# install the binaries
+	"$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" sshnp
+	"$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" npt
 
-    while ! echo "$host_atsign" | grep -Eq "@.*"; do
-        case "$host_atsign" in
-        [Aa][Mm]*)
-            host_atsign="@rv_am"
-            ;;
-        [Ee][Uu]*)
-            host_atsign="@rv_eu"
-            ;;
-        [Aa][Pp]*)
-            host_atsign="@rv_ap"
-            ;;
-        @*)
-            # Do nothing for custom region
-            ;;
-        *)
-            echo "Invalid region: $host_atsign"
-            echo "region: "
-            read -r host_atsign
-            ;;
-        esac
-    done
+	# install the magic sshnp script
+	magic_script="$bin_path"/@sshnp
+	cp "$extract_path"/sshnp/magic/sshnp.sh "$magic_script"
+	chmod +x "$magic_script"
 
-    done_input=false
+	# get the inputs for the magic script
+	get_client_device_atsigns
+	if [ -z "$host_atsign" ]; then
+		echo Pick your default region:
+		echo "  am   : Americas"
+		echo "  ap   : Asia Pacific"
+		echo "  eu   : Europe"
+		echo "  @___ : Specify a custom region atSign"
+		printf "$ "
+		read -r host_atsign
+	fi
 
-    echo "Enter the device names you would like to include in the magic script"
-    echo "/done to finish"
-    while [ "$done_input" = false ]; do
-        echo "device: "
-        read -r device_name
-        if [ "$device_name" = "/done" ]; then
-            done_input=true
-        else
-            devices="$devices,$device_name"
-        fi
-    done
+	while ! echo "$host_atsign" | grep -Eq "@.*"; do
+		case "$host_atsign" in
+		[Aa][Mm]*)
+			host_atsign="@rv_am"
+			;;
+		[Ee]*)
+			host_atsign="@rv_eu"
+			;;
+		[Aa][Pp]*)
+			host_atsign="@rv_ap"
+			;;
+		@*)
+			# Do nothing for custom region
+			;;
+		*)
+			echo "Invalid region: $host_atsign"
+			printf "$ "
+			read -r host_atsign
+			;;
+		esac
+	done
 
-    write_metadata "$magic_script" "client_atsign" "$(norm_atsign "$client_atsign")"
-    write_metadata "$magic_script" "device_atsign" "$(norm_atsign "$device_atsign")"
-    write_metadata "$magic_script" "host_atsign" "$(norm_atsign "$host_atsign")"
-    write_metadata_array "$magic_script" "devices" "$devices"
+	if [ -z "$devices" ]; then
+		done_input=false
+		echo "Installing a quick picker script to make it easy to connect to devices..."
+		echo "Enter the device names you would like to include in the quick picker script"
+		echo "/done to finish"
+		while [ "$done_input" = false ]; do
+			printf "$ "
+			read -r device_name
+			if [ "$device_name" = "/done" ]; then
+				done_input=true
+			else
+				devices="$devices,$device_name"
+			fi
+		done
+	fi
+
+	# write the metadata to the magic script
+	write_metadata "$magic_script" "client_atsign" "$(norm_atsign "$client_atsign")"
+	write_metadata "$magic_script" "device_atsign" "$(norm_atsign "$device_atsign")"
+	write_metadata "$magic_script" "host_atsign" "$(norm_atsign "$host_atsign")"
+	write_metadata_array "$magic_script" "devices" "$devices"
 }
 
 # DEVICE INSTALLATION #
 device() {
-    unset device_install_type
-    if is_darwin; then
-        device_install_type="launchd"
-    elif is_root; then
-        device_install_type="systemd"
-    elif command -v tmux >/dev/null 2>&1; then
-        device_install_type="tmux"
-    else
-        device_install_type="headless"
-    fi
+	unset device_install_type
+	if [ -z "$device_type" ]; then
+		if is_darwin; then
+			device_install_type="launchd"
+		elif is_root && is_systemd_available; then
+			device_install_type="systemd"
+		elif command -v tmux >/dev/null 2>&1; then
+			device_install_type="tmux"
+		else
+			device_install_type="headless"
+		fi
+	else
+		# override the device type if it is set
+		device_install_type=$device_type
+	fi
 
-    get_client_device_atsigns
+	get_client_device_atsigns
 
-    while [ -z "$device_name" ]; do
-        echo "Enter device name:"
-        read -r device_name
-    done
+	while [ -z "$device_name" ]; do
+		printf "Enter device name:\n$ "
+		read -r device_name
+	done
 
-    install_output=$("$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" "$device_install_type" sshnpd)
-    case "$device_install_type" in
-    launchd)
-        launchd_plist="$HOME/Library/LaunchAgents/com.atsign.sshnpd.plist"
-        write_program_arguments_plist "$launchd_plist" "$bin_path/sshnpd" "-f" "$(norm_atsign "$client_atsign")" "-t" "$(norm_atsign "$device_atsign")" "-d" "$device_name" "-su"
-        launchctl load "$launchd_plist"
-        launchctl start "$launchd_plist"
-        ;;
-    systemd)
-        systemd_service="/etc/systemd/system/sshnpd.service"
-        write_systemd_environment "$systemd_service" "manager_atsign" "$(norm_atsign "$client_atsign")"
-        write_systemd_environment "$systemd_service" "device_atsign" "$(norm_atsign "$device_atsign")"
-        write_systemd_environment "$systemd_service" "device_name" "$device_name"
-        systemctl enable sshnpd
-        systemctl start sshnpd
-        ;;
-    tmux | headless)
-        shell_script="$bin_path"/sshnpd.sh
-        write_metadata "$shell_script" "manager_atsign" "$(norm_atsign "$client_atsign")"
-        write_metadata "$shell_script" "device_atsign" "$(norm_atsign "$device_atsign")"
-        write_metadata "$shell_script" "device_name" "$device_name"
-        # split install output by lines, then grab the output after the line that says "To start immediately"
-        eval "$(echo "$install_output" | grep -A1 "To start .* immediately:" | tail -n1)"
-        ;;
-    esac
+	# run the device install script and capture the output
+	install_output=$("$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" "$device_install_type" sshnpd)
+
+	if [ "$verbose" = true ]; then
+		echo "$install_output"
+	fi
+
+	case "$device_install_type" in
+	launchd)
+		launchd_plist="$HOME/Library/LaunchAgents/com.atsign.sshnpd.plist"
+		write_program_arguments_plist "$launchd_plist" "$bin_path/sshnpd" "-m" "$(norm_atsign "$client_atsign")" "-a" "$(norm_atsign "$device_atsign")" "-d" "$device_name" "-su"
+		launchctl unload "$launchd_plist"
+		launchctl load "$launchd_plist"
+		;;
+	systemd)
+		systemd_service="/etc/systemd/system/sshnpd.service"
+		write_systemd_environment "$systemd_service" "manager_atsign" "$(norm_atsign "$client_atsign")"
+		write_systemd_environment "$systemd_service" "device_atsign" "$(norm_atsign "$device_atsign")"
+		write_systemd_environment "$systemd_service" "device_name" "$device_name"
+		systemctl enable sshnpd
+		systemctl start sshnpd
+		;;
+	tmux | headless)
+		shell_script="$bin_path"/sshnpd.sh
+		write_metadata "$shell_script" "manager_atsign" "$(norm_atsign "$client_atsign")"
+		write_metadata "$shell_script" "device_atsign" "$(norm_atsign "$device_atsign")"
+		write_metadata "$shell_script" "device_name" "$device_name"
+		# split install output by lines, then grab the output after the line that says "To start immediately"
+		eval "$(echo "$install_output" | grep -A1 "To start .* immediately:" | tail -n1)"
+		;;
+	esac
 }
 
 main() {
-    trap cleanup EXIT
-    set -eu
-    parse_env
-    parse_args "$@"
+	trap cleanup EXIT
+	set -eu
+	parse_env
+	parse_args "$@"
 
-    if [ $verbose = true ]; then print_env; fi
+	if [ $verbose = true ]; then print_env; fi
 
-    if [ -n "$local_archive" ]; then
-        echo "Using local archive: $local_archive"
-        cp "$local_archive" "$archive_path"
-    else
-        download_url=$(get_download_url)
-        echo "$download_url" | download_archive
-    fi
+	if [ -n "$local_archive" ]; then
+		echo "Using local archive: $local_archive"
+		cp "$local_archive" "$archive_path"
+	else
+		download_url=$(get_download_url)
+		echo "$download_url" | download_archive
+	fi
 
-    unpack_archive
+	unpack_archive
 
-    get_user_inputs
-    case "$install_type" in
-    client) client ;;
-    device) device ;;
-    both) client device ;;
-    esac
+	get_user_inputs
+	case "$install_type" in
+	client) client ;;
+	device) device ;;
+	both)
+		echo
+		echo "Installing device part..."
+		device
+		echo
+		echo "Installing client part..."
+		client
+		;;
+	esac
 }
 
 main "$@"

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -416,6 +416,12 @@ write_program_arguments_plist() {
 	sedi '/^[[:space:]]*$/d' "$file" # remove empty lines to keep things clean
 }
 
+write_systemd_user() {
+	file=$1
+	user=$2
+	sedi "s|<username>|$user|g" "$file"
+}
+
 write_systemd_environment() {
 	file=$1
 	variable=$2
@@ -554,6 +560,7 @@ device() {
 		;;
 	systemd)
 		systemd_service="/etc/systemd/system/sshnpd.service"
+        write_systemd_user "$systemd_service" "$user"
 		write_systemd_environment "$systemd_service" "manager_atsign" "$(norm_atsign "$client_atsign")"
 		write_systemd_environment "$systemd_service" "device_atsign" "$(norm_atsign "$device_atsign")"
 		write_systemd_environment "$systemd_service" "device_name" "$device_name"

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -454,7 +454,6 @@ main() {
         cp "$local_archive" "$archive_path"
     else
         download_url=$(get_download_url)
-        echo "Downloading archive from $download_url"
         echo "$download_url" | download_archive
     fi
 

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -432,9 +432,9 @@ device() {
 		;;
 	tmux | headless)
 		shell_script="$bin_path"/sshnpd.sh
-		metadata_write "$shell_script" "manager_atsign" "$(norm_atsign "$client_atsign")"
-		metadata_write "$shell_script" "device_atsign" "$(norm_atsign "$device_atsign")"
-		metadata_write "$shell_script" "device_name" "$device_name"
+		write_metadata "$shell_script" "manager_atsign" "$(norm_atsign "$client_atsign")"
+		write_metadata "$shell_script" "device_atsign" "$(norm_atsign "$device_atsign")"
+		write_metadata "$shell_script" "device_name" "$device_name"
 		# split install output by lines, then grab the output after the line that says "To start immediately"
 		eval "$(echo "$install_output" | grep -A1 "To start .* immediately:" | tail -n1)"
 		;;

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -526,6 +526,7 @@ client() {
   # install the binaries
   "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" sshnp
   "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" npt
+  "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" at_activate
 
   # install the magic sshnp script
   magic_script="$bin_path"/np.sh
@@ -635,6 +636,8 @@ device() {
     printf "Enter device name: "
     read -r device_name
   done
+
+  "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" at_activate
 
   # run the device install script and capture the output
   install_output=$("$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" "$device_install_type" sshnpd)

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -3,7 +3,7 @@
 # SCRIPT METADATA
 # DO NOT MODIFY/DELETE THIS BLOCK
 script_version="3.0.0"
-sshnp_version="5.1.0-rc.10"
+sshnp_version="5.1.0-rc.9"
 repo_url="https://github.com/atsign-foundation/sshnoports"
 # END METADATA
 
@@ -50,401 +50,404 @@ device_name=""
 device_type=""
 
 norm_atsign() {
-    # Prepend an @ to the front of the atsign if missing
-    atsign="@$(echo "$1" | sed -e 's/"//g' -e 's/^@//g')"
-    echo "$atsign"
+  # Prepend an @ to the front of the atsign if missing
+  atsign="@$(echo "$1" | sed -e 's/"//g' -e 's/^@//g')"
+  echo "$atsign"
 }
 
 norm_version() {
-    # Ensure the version is in the format "tags/vX.Y.Z" (github version tag)
-    version="tags/v$(echo "$1" | sed -e 's/"//g' -e 's/^tags\///g' -e 's/^v//g')"
-    echo "$version"
+  # Ensure the version is in the format "tags/vX.Y.Z" (github version tag)
+  version="tags/v$(echo "$1" | sed -e 's/"//g' -e 's/^tags\///g' -e 's/^v//g')"
+  echo "$version"
 }
 
 is_root() {
-    [ "$(id -u)" -eq 0 ]
+  [ "$(id -u)" -eq 0 ]
 }
 
 is_darwin() {
-    [ "$(uname)" = 'Darwin' ]
+  [ "$(uname)" = 'Darwin' ]
 }
 
 is_systemd_available() {
-    # https://superuser.com/questions/1017959/how-to-know-if-i-am-using-systemd-on-linux
-    [ -d /run/systemd/system ]
+  # https://superuser.com/questions/1017959/how-to-know-if-i-am-using-systemd-on-linux
+  [ -d /run/systemd/system ]
 }
 
 sedi() {
-    if is_darwin; then
-        sed -i '' "$@"
-    else
-        sed -i "$@"
-    fi
+  if is_darwin; then
+    sed -i '' "$@"
+  else
+    sed -i "$@"
+  fi
 }
 
 version() {
-    echo "Version: $script_version (Target: $sshnp_version)"
+  echo "Version: $script_version (Target: $sshnp_version)"
 }
 
 usage() {
-    if [ -z "$arg_zero" ]; then
-        arg_zero='install.sh'
-    fi
-    version
-    echo "Usage: $arg_zero [options]"
-    echo "  -h, --help                     Display help"
-    echo "  -v, --verbose                  Verbose tracing"
-    echo "      --version                  Display version"
-    echo "      --temp-path      <path>    Set the temporary path for downloads"
-    echo "  -t, --type           <type>    Set the install type (device, client, both)"
-    echo "      --local          <path>    Install from a local archive"
-    echo
-    echo "Client Options:"
-    echo "  -c, --client-atsign  <atsign>  Set the client atSign"
-    echo "  -d, --device-atsign  <atsign>  Set the device atSign"
-    echo "  -r, --region         <region>  Set the default rendezvous region (am, eu, ap)"
-    echo "      --rv-atsign      <atsign>  Set the default rendezvous atsign"
-    echo "  -l, --device-list    <names>   Set the device names for the quick picker script (comma separated)"
-    echo
-    echo "Note: only one of --region or --rv-atsign can be used"
-    echo
-    echo "Device Options:"
-    echo "  -c, --client-atsign  <atsign>  Set the client atSign"
-    echo "  -d, --device-atsign  <atsign>  Set the device atSign"
-    echo "  -n, --device-name    <name>    Set the device name"
-    echo "  --dt, --device-type  <type>    Set the device type (launchd, systemd, tmux, headless)"
+  if [ -z "$arg_zero" ]; then
+    arg_zero='install.sh'
+  fi
+  version
+  echo "Usage: $arg_zero [options]"
+  echo "  -h, --help                     Display help"
+  echo "  -v, --verbose                  Verbose tracing"
+  echo "      --version                  Display version"
+  echo "      --temp-path      <path>    Set the temporary path for downloads"
+  echo "  -t, --type           <type>    Set the install type (device, client, both)"
+  echo "      --local          <path>    Install from a local archive"
+  echo
+  echo "Client Options:"
+  echo "  -c, --client-atsign  <atsign>  Set the client atSign"
+  echo "  -d, --device-atsign  <atsign>  Set the device atSign"
+  echo "  -r, --region         <region>  Set the default rendezvous region (am, eu, ap)"
+  echo "      --rv-atsign      <atsign>  Set the default rendezvous atsign"
+  echo "  -l, --device-list    <names>   Set the device names for the quick picker script (comma separated)"
+  echo
+  echo "Note: only one of --region or --rv-atsign can be used"
+  echo
+  echo "Device Options:"
+  echo "  -c, --client-atsign  <atsign>  Set the client atSign"
+  echo "  -d, --device-atsign  <atsign>  Set the device atSign"
+  echo "  -n, --device-name    <name>    Set the device name"
+  echo "  --dt, --device-type  <type>    Set the device type (launchd, systemd, tmux, headless)"
 
 }
 
 parse_env() {
-    case "$(uname)" in
+  case "$(uname)" in
     Darwin) platform_name='macos' ;;
     Linux) platform_name='linux' ;;
     *)
-        echo "Detected an unsupported platform: $(uname)"
-        echo "Please open an issue at: $repo_url"
-        echo "and provide the following information: $(uname -a)" exit 1
-        ;;
-    esac
+      echo "Detected an unsupported platform: $(uname)"
+      echo "Please open an issue at: $repo_url"
+      echo "and provide the following information: $(uname -a)" exit 1
+      ;;
+  esac
 
-    case "$platform_name" in
+  case "$platform_name" in
     macos) archive_ext="zip" ;;
     linux) archive_ext="tgz" ;;
-    esac
+  esac
 
-    case "$(uname -m)" in
+  case "$(uname -m)" in
     x86_64 | amd64 | x64)
-        system_arch="x64"
-        ;;
+      system_arch="x64"
+      ;;
     arm64 | aarch64)
-        system_arch="arm64"
-        ;;
+      system_arch="arm64"
+      ;;
     arm | armv7l)
-        system_arch="armv7"
-        ;;
+      system_arch="armv7"
+      ;;
     riscv64)
-        system_arch="riscv64"
-        ;;
+      system_arch="riscv64"
+      ;;
     *)
-        echo "Detected an unsupported architecture: $(uname -m)"
-        echo "Please open an issue at: $repo_url"
-        echo "and provide the following information: $(uname -a)"
-        exit 1
-        ;;
-    esac
+      echo "Detected an unsupported architecture: $(uname -m)"
+      echo "Please open an issue at: $repo_url"
+      echo "and provide the following information: $(uname -a)"
+      exit 1
+      ;;
+  esac
 
-    time_stamp=$(date +%s)
+  time_stamp=$(date +%s)
 
-    tmp_path="/tmp"
-    extract_path="$tmp_path/sshnp-$time_stamp"
-    archive_path="$extract_path.$archive_ext"
-    user_home="$HOME"
-    if is_root; then
-        user="$SUDO_USER"
-        as_root=true
-        bin_path="/usr/local/bin"
-        if [ -z "$user" ]; then
-            user="root"
-        else
-            # we are root, but via sudo
-            # so get home directory of SUDO_USER
-            user_home=$(sudo -u "$user" sh -c 'echo $HOME')
-        fi
+  tmp_path="/tmp"
+  extract_path="$tmp_path/sshnp-$time_stamp"
+  archive_path="$extract_path.$archive_ext"
+  user_home="$HOME"
+  if is_root; then
+    user="$SUDO_USER"
+    as_root=true
+    bin_path="/usr/local/bin"
+    if [ -z "$user" ]; then
+      user="root"
     else
-        as_root=false
-        bin_path="$HOME/.local/bin"
-        user="$USER"
+      # we are root, but via sudo
+      # so get home directory of SUDO_USER
+      user_home=$(sudo -u "$user" sh -c 'echo $HOME')
     fi
-    user_bin_dir=$user_home/.local/bin/@sshnp
+  else
+    as_root=false
+    bin_path="$HOME/.local/bin"
+    user="$USER"
+  fi
+  user_bin_dir=$user_home/.local/bin/@sshnp
 }
 
 is_valid_source_mode() {
-    [ "$1" = "download" ] || [ "$1" = "local" ] || [ "$1" = "build" ]
+  [ "$1" = "download" ] || [ "$1" = "local" ] || [ "$1" = "build" ]
 }
 
 is_valid_install_type() {
-    [ "$1" = "device" ] || [ "$1" = "client" ] || [ "$1" = "both" ]
+  [ "$1" = "device" ] || [ "$1" = "client" ] || [ "$1" = "both" ]
 }
 
 norm_install_type() {
-    case "$1" in
+  case "$1" in
     d*)
-        echo "device"
-        ;;
+      echo "device"
+      ;;
     c*)
-        echo "client"
-        ;;
+      echo "client"
+      ;;
     b*)
-        echo "both"
-        ;;
+      echo "both"
+      ;;
     *)
-        echo ""
-        ;;
-    esac
+      echo ""
+      ;;
+  esac
 }
 
 is_valid_device_type() {
-    [ "$1" = "launchd" ] || [ "$1" = "systemd" ] || [ "$1" = "tmux" ] || [ "$1" = "headless" ]
+  [ "$1" = "launchd" ] || [ "$1" = "systemd" ] || [ "$1" = "tmux" ] || [ "$1" = "headless" ]
 }
 
 norm_device_type() {
-    case "$1" in
+  case "$1" in
     l*)
-        echo "launchd"
-        ;;
+      echo "launchd"
+      ;;
     s*)
-        echo "systemd"
-        ;;
+      echo "systemd"
+      ;;
     t*)
-        echo "tmux"
-        ;;
+      echo "tmux"
+      ;;
     h*)
-        echo "headless"
-        ;;
+      echo "headless"
+      ;;
     *)
-        echo ""
-        ;;
-    esac
+      echo ""
+      ;;
+  esac
 }
 
 parse_args() {
-    while [ $# -gt 0 ]; do
-        case "$1" in
-        -h | --help)
-            usage
-            exit 0
-            ;;
-        -v | --verbose)
-            verbose=true
-            set -x
-            ;;
-        --version)
-            version
-            exit 0
-            ;;
-        --temp-path)
-            shift
-            mkdir -p "$1"
-            tmp_path="$1"
-            ;;
-        -t | --type)
-            shift
-            install_type_input="$1"
-            install_type=$(norm_install_type "$install_type_input")
-            if ! is_valid_install_type "$install_type"; then
-                echo "Invalid install type: $install_type_input"
-                echo "Valid options are: (device, client, both)" exit 1
-            fi
-            ;;
-        --local)
-            shift
-            if [ -f "$1" ]; then
-                local_archive="$1"
-            else
-                echo "Local archive not found: $1"
-                exit 1
-            fi
-            ;;
-        -c | --client-atsign)
-            shift
-            client_atsign="$1"
-            ;;
-        -d | --device-atsign)
-            shift
-            device_atsign="$1"
-            ;;
-        -r | --region)
-            # notice that --region and --rv-atsign are basically the same under the hood,
-            # if region's input starts with an "@" it will be equivalent to using --rv-atsign
-            # without an "@", it will try to map to one of the @rv_XX regions
-            shift
-            host_atsign="$1"
-            ;;
-        --rv-atsign)
-            shift
-            host_atsign="$(norm_atsign "$1")"
-            ;;
-        -l | --device-list)
-            shift
-            devices="$1"
-            ;;
-        -n | --device-name)
-            shift
-            device_name="$1"
-            ;;
-        --dt | --device-type)
-            shift
-            device_type_input="$1"
-            device_type=$(norm_device_type "$device_type_input")
-            if ! is_valid_device_type "$device_type"; then
-                echo "Invalid device type: $device_type_input"
-                echo "Valid options are: (launchd, systemd, tmux, headless)" exit 1
-            fi
-            ;;
-        *)
-            echo "Unexpected option: $1"
-            exit 1
-            ;;
-        esac
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      -v | --verbose)
+        verbose=true
+        set -x
+        ;;
+      --version)
+        version
+        exit 0
+        ;;
+      --temp-path)
         shift
-    done
+        mkdir -p "$1"
+        tmp_path="$1"
+        ;;
+      -t | --type)
+        shift
+        install_type_input="$1"
+        install_type=$(norm_install_type "$install_type_input")
+        if ! is_valid_install_type "$install_type"; then
+          echo "Invalid install type: $install_type_input"
+          echo "Valid options are: (device, client, both)" exit 1
+        fi
+        ;;
+      --local)
+        shift
+        if [ -f "$1" ]; then
+          local_archive="$1"
+        else
+          echo "Local archive not found: $1"
+          exit 1
+        fi
+        ;;
+      -c | --client-atsign)
+        shift
+        client_atsign="$1"
+        ;;
+      -d | --device-atsign)
+        shift
+        device_atsign="$1"
+        ;;
+      -r | --region)
+        # notice that --region and --rv-atsign are basically the same under the hood,
+        # if region's input starts with an "@" it will be equivalent to using --rv-atsign
+        # without an "@", it will try to map to one of the @rv_XX regions
+        shift
+        host_atsign="$1"
+        ;;
+      --rv-atsign)
+        shift
+        host_atsign="$(norm_atsign "$1")"
+        ;;
+      -l | --device-list)
+        shift
+        devices="$1"
+        ;;
+      -n | --device-name)
+        shift
+        device_name="$1"
+        ;;
+      --dt | --device-type)
+        shift
+        device_type_input="$1"
+        device_type=$(norm_device_type "$device_type_input")
+        if ! is_valid_device_type "$device_type"; then
+          echo "Invalid device type: $device_type_input"
+          echo "Valid options are: (launchd, systemd, tmux, headless)" exit 1
+        fi
+        ;;
+      *)
+        echo "Unexpected option: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
 }
 
 get_user_inputs() {
-    if [ -z "$install_type" ]; then
-        unset install_type_input
-        while [ -z "$install_type" ]; do
-            printf "Install type (device, client, both):  "
-            read -r install_type_input
-            install_type=$(norm_install_type "$install_type_input")
-        done
-    fi
+  if [ -z "$install_type" ]; then
+    unset install_type_input
+    while [ -z "$install_type" ]; do
+      printf "Install type (device, client, both):  "
+      read -r install_type_input
+      install_type=$(norm_install_type "$install_type_input")
+    done
+  fi
 }
 
 print_env() {
-    echo "Environment:"
-    echo "Platform Name: $platform_name"
-    echo "System Arch: $system_arch"
-    echo "Temporary Path: $tmp_path"
-    echo "As Root: $as_root"
-    echo "Binary Path: $bin_path"
-    echo "User: $user"
+  cat <<EOL
+Environment:
+  Platform name: $platform_name
+  System arch: $system_arch
+  Temp path: $tmp_path
+  As root: $as_root
+  Binary path: $bin_path
+  User: $user
+  User home: $user_home
+EOL
 }
 
 get_download_url() {
-    unset download_urls
-    download_urls=$(
-        curl -fsSL "https://api.github.com/repos/atsign-foundation/noports/releases/$(norm_version $sshnp_version)" |
-            grep browser_download_url |
-            cut -d\" -f4
-    )
+  unset download_urls
+  download_urls=$(
+    curl -fsSL "https://api.github.com/repos/atsign-foundation/noports/releases/$(norm_version $sshnp_version)" |
+      grep browser_download_url |
+      cut -d\" -f4
+  )
 
-    if [ -z "$download_urls" ]; then
-        echo "Failed to get download url for sshnoports"
-        exit 1
-    fi
+  if [ -z "$download_urls" ]; then
+    echo "Failed to get download url for sshnoports"
+    exit 1
+  fi
 
-    echo "$download_urls" |
-        grep "$platform_name" | grep "$system_arch" |
-        cut -d\" -f4
+  echo "$download_urls" |
+    grep "$platform_name" | grep "$system_arch" |
+    cut -d\" -f4
 }
 
 download_archive() {
-    read -r download_url
-    echo "Downloading archive from $download_url"
-    curl -sL "$download_url" -o "$archive_path"
-    if [ ! -f "$archive_path" ]; then
-        echo "Failed to download archive"
-        exit 1
-    fi
+  read -r download_url
+  echo "Downloading archive from $download_url"
+  curl -sL "$download_url" -o "$archive_path"
+  if [ ! -f "$archive_path" ]; then
+    echo "Failed to download archive"
+    exit 1
+  fi
 }
 
 unpack_archive() {
-    case "$archive_ext" in
+  case "$archive_ext" in
     zip)
-        unzip -qo "$archive_path" -d "$extract_path"
-        ;;
+      unzip -qo "$archive_path" -d "$extract_path"
+      ;;
     tgz | tar.gz)
-        mkdir -p "$extract_path"
-        tar -zxf "$archive_path" -C "$extract_path"
-        ;;
-    esac
+      mkdir -p "$extract_path"
+      tar -zxf "$archive_path" -C "$extract_path"
+      ;;
+  esac
 }
 
 cleanup() {
-    # These should be in the tmp directory, attempt to remove them anyway
-    rm -f "$archive_path"
-    rm -rf "$extract_path"
+  # These should be in the tmp directory, attempt to remove them anyway
+  rm -f "$archive_path"
+  rm -rf "$extract_path"
 }
 
 write_metadata() {
-    start_line="# SCRIPT METADATA"
-    end_line="# END METADATA"
-    file=$1
-    variable=$2
-    value=$3
-    sedi "/$start_line/,/$end_line/s|$variable=\".*\"|$variable=\"$value\"|g " "$file"
+  start_line="# SCRIPT METADATA"
+  end_line="# END METADATA"
+  file=$1
+  variable=$2
+  value=$3
+  sedi "/$start_line/,/$end_line/s|$variable=\".*\"|$variable=\"$value\"|g " "$file"
 }
 
 write_metadata_array() {
-    # Takes a comma separated list and writes it into a bash array in the metadata of the script
-    start_line="# SCRIPT METADATA"
-    end_line="# END METADATA"
-    file=$1
-    variable=$2
-    value=$(echo "$3" | tr ',' ' ')
-    sedi "/$start_line/,/$end_line/s|$variable=(.*)|$variable=($value)|g" "$file"
+  # Takes a comma separated list and writes it into a bash array in the metadata of the script
+  start_line="# SCRIPT METADATA"
+  end_line="# END METADATA"
+  file=$1
+  variable=$2
+  value=$(echo "$3" | tr ',' ' ')
+  sedi "/$start_line/,/$end_line/s|$variable=(.*)|$variable=($value)|g" "$file"
 }
 
 write_program_arguments_plist() {
-    # Takes a comma separated list and writes it into a string array in the plist document
-    start_line="<key>ProgramArguments</key>"
-    second_line="<array>"
-    end_line="</array>"
-    file=$1
-    shift
-    string_array=""
-    while [ $# -gt 0 ]; do
-        string_array="$string_array\\
+  # Takes a comma separated list and writes it into a string array in the plist document
+  start_line="<key>ProgramArguments</key>"
+  second_line="<array>"
+  end_line="</array>"
+  file=$1
+  shift
+  string_array=""
+  while [ $# -gt 0 ]; do
+    string_array="$string_array\\
     <string>$1</string>"
-        shift
-    done
-    sedi "s|$end_line|\\
+    shift
+  done
+  sedi "s|$end_line|\\
     $end_line\\
     |g" "$file" # make sure </array> is on a new line or we might delete something we shouldn't
-    sedi "/<key>ProgramArguments<\\/key>/,/<\\/array>/c\\
+  sedi "/<key>ProgramArguments<\\/key>/,/<\\/array>/c\\
   $start_line\\
   $second_line$string_array\\
   $end_line\\
   " "$file"
-    sedi '/^[[:space:]]*$/d' "$file" # remove empty lines to keep things clean
+  sedi '/^[[:space:]]*$/d' "$file" # remove empty lines to keep things clean
 }
 
 write_systemd_user() {
-    file=$1
-    user=$2
-    sedi "s|<username>|$user|g" "$file"
+  file=$1
+  user=$2
+  sedi "s|<username>|$user|g" "$file"
 }
 
 write_systemd_environment() {
-    file=$1
-    variable=$2
-    value=$3
-    sedi "s|Environment=$variable=\".*\"|Environment=$variable=\"$value\"|g" "$file"
+  file=$1
+  variable=$2
+  value=$3
+  sedi "s|Environment=$variable=\".*\"|Environment=$variable=\"$value\"|g" "$file"
 }
 
 get_client_atsign() {
-    while [ -z "$client_atsign" ]; do
-        printf "Enter client atSign: "
-        read -r client_atsign
-    done
+  while [ -z "$client_atsign" ]; do
+    printf "Enter client atSign: "
+    read -r client_atsign
+  done
 }
 
 get_device_atsign() {
-    while [ -z "$device_atsign" ]; do
-        printf "Enter device atSign: "
-        read -r device_atsign
-    done
+  while [ -z "$device_atsign" ]; do
+    printf "Enter device atSign: "
+    read -r device_atsign
+  done
 }
 
 get_installed_atsigns() {
@@ -496,211 +499,210 @@ get_installed_atsigns() {
 }
 
 suggest_sudo() {
-    echo
-    echo "Systemd is present but this script is not running with sudo"
-    echo "It is suggested that you exit and rerun:"
-    echo
-    echo "sudo sh universal.sh"
-    echo
-    echo "If you'd rather (P)roceed with a non systemd installation"
-    echo "then enter p or P, otherwise this script will exit."
-    printf "(P)roceed? "
-    read -r proceed
-    case $proceed in
-    p|P)
-        return
-        ;;
+  echo
+  echo "Systemd is present but this script is not running with sudo"
+  echo "It is suggested that you exit and rerun:"
+  echo
+  echo "sudo sh universal.sh"
+  echo
+  echo "If you'd rather (P)roceed with a non systemd installation"
+  echo "then enter p or P, otherwise this script will exit."
+  printf "(P)roceed? "
+  read -r proceed
+  case $proceed in
+    p | P)
+      return
+      ;;
     *)
-        exit 0
-        ;;
-    esac
+      exit 0
+      ;;
+  esac
 }
 
 # CLIENT INSTALLATION #
 client() {
-    mkdir -p "$bin_path"
+  mkdir -p "$bin_path"
 
-    # install the binaries
-    "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" sshnp
-    "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" npt
+  # install the binaries
+  "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" sshnp
+  "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" npt
 
-    # install the magic sshnp script
-    magic_script="$bin_path"/np.sh
-    cp "$extract_path"/sshnp/magic/sshnp.sh "$magic_script"
-    chmod +x "$magic_script"
-    if is_root && [ -f "$bin_path"/np.sh ]; then
-        ln -sf "$bin_path"/np.sh "$user_bin_dir"/np.sh
-        if [ $verbose = true ]; then
-            echo "=> Linked $user_bin_dir/np.sh to $bin_path/np.sh"
-        fi
+  # install the magic sshnp script
+  magic_script="$bin_path"/np.sh
+  cp "$extract_path"/sshnp/magic/sshnp.sh "$magic_script"
+  chmod +x "$magic_script"
+  if is_root && [ -f "$bin_path"/np.sh ]; then
+    ln -sf "$bin_path"/np.sh "$user_bin_dir"/np.sh
+    if [ $verbose = true ]; then
+      echo "=> Linked $user_bin_dir/np.sh to $bin_path/np.sh"
     fi
+  fi
 
-    # get the inputs for the magic script
-    if [ -z "$client_atsign" ]; then
-        get_installed_atsigns
-        client_atsign="$selectedatsign"
-        get_client_atsign
-    fi
+  # get the inputs for the magic script
+  if [ -z "$client_atsign" ]; then
+    get_installed_atsigns
+    client_atsign="$selectedatsign"
+    get_client_atsign
+  fi
 
-    get_device_atsign
+  get_device_atsign
 
-    if [ -z "$host_atsign" ]; then
-        echo Pick your default region:
-        echo "  am   : Americas"
-        echo "  ap   : Asia Pacific"
-        echo "  eu   : Europe"
-        echo "  @___ : Specify a custom region atSign"
-        printf "Region: "
+  if [ -z "$host_atsign" ]; then
+    echo Pick your default region:
+    echo "  am   : Americas"
+    echo "  ap   : Asia Pacific"
+    echo "  eu   : Europe"
+    echo "  @___ : Specify a custom region atSign"
+    printf "Region: "
+    read -r host_atsign
+  fi
+
+  while ! echo "$host_atsign" | grep -Eq "@.*"; do
+    case "$host_atsign" in
+      [Aa][Mm]*)
+        host_atsign="@rv_am"
+        ;;
+      [Ee]*)
+        host_atsign="@rv_eu"
+        ;;
+      [Aa][Pp]*)
+        host_atsign="@rv_ap"
+        ;;
+      @*)
+        # Do nothing for custom region
+        ;;
+      *)
+        printf "Invalid region: %s: " "$host_atsign"
         read -r host_atsign
-    fi
+        ;;
+    esac
+  done
 
-    while ! echo "$host_atsign" | grep -Eq "@.*"; do
-        case "$host_atsign" in
-        [Aa][Mm]*)
-            host_atsign="@rv_am"
-            ;;
-        [Ee]*)
-            host_atsign="@rv_eu"
-            ;;
-        [Aa][Pp]*)
-            host_atsign="@rv_ap"
-            ;;
-        @*)
-            # Do nothing for custom region
-            ;;
-        *)
-            printf "Invalid region: %s: " "$host_atsign"
-            read -r host_atsign
-            ;;
-        esac
+  if [ -z "$devices" ]; then
+    done_input=false
+    echo "Installing a quick picker script to make it easy to connect to devices..."
+    echo "Enter the device names you would like to include in the quick picker script"
+    echo "/done to finish"
+    while [ "$done_input" = false ]; do
+      printf "Device name: "
+      read -r device_name
+      if [ "$device_name" = "/done" ]; then
+        done_input=true
+      else
+        devices="$devices,$device_name"
+      fi
     done
+  fi
 
-    if [ -z "$devices" ]; then
-        done_input=false
-        echo "Installing a quick picker script to make it easy to connect to devices..."
-        echo "Enter the device names you would like to include in the quick picker script"
-        echo "/done to finish"
-        while [ "$done_input" = false ]; do
-            printf "Device name: "
-            read -r device_name
-            if [ "$device_name" = "/done" ]; then
-                done_input=true
-            else
-                devices="$devices,$device_name"
-            fi
-        done
-    fi
+  # write the metadata to the magic script
+  write_metadata "$magic_script" "client_atsign" "$(norm_atsign "$client_atsign")"
+  write_metadata "$magic_script" "device_atsign" "$(norm_atsign "$device_atsign")"
+  write_metadata "$magic_script" "host_atsign" "$(norm_atsign "$host_atsign")"
+  write_metadata_array "$magic_script" "devices" "$devices"
 
-    # write the metadata to the magic script
-    write_metadata "$magic_script" "client_atsign" "$(norm_atsign "$client_atsign")"
-    write_metadata "$magic_script" "device_atsign" "$(norm_atsign "$device_atsign")"
-    write_metadata "$magic_script" "host_atsign" "$(norm_atsign "$host_atsign")"
-    write_metadata_array "$magic_script" "devices" "$devices"
-
-    echo "Run np.sh to get your quick pick of devices to connect to."
+  echo "Run np.sh to get your quick pick of devices to connect to."
 }
 
 # DEVICE INSTALLATION #
 device() {
-    unset device_install_type
-    if [ -z "$device_type" ]; then
-        if is_darwin; then
-            device_install_type="launchd"
-        elif is_root && is_systemd_available; then
-            device_install_type="systemd"
-        elif is_systemd_available; then
-            suggest_sudo
-        elif command -v tmux >/dev/null 2>&1; then
-            device_install_type="tmux"
-        else
-            device_install_type="headless"
-        fi
+  unset device_install_type
+  if [ -z "$device_type" ]; then
+    if is_darwin; then
+      device_install_type="launchd"
+    elif is_root && is_systemd_available; then
+      device_install_type="systemd"
+    elif is_systemd_available; then
+      suggest_sudo
+    elif command -v tmux >/dev/null 2>&1; then
+      device_install_type="tmux"
     else
-        # override the device type if it is set
-        device_install_type=$device_type
+      device_install_type="headless"
     fi
+  else
+    # override the device type if it is set
+    device_install_type=$device_type
+  fi
 
-    get_client_atsign
+  get_client_atsign
 
-    if [ -z "$device_atsign" ]; then
-        get_installed_atsigns
-        device_atsign="$selectedatsign"
-        get_device_atsign
-    fi
+  if [ -z "$device_atsign" ]; then
+    get_installed_atsigns
+    device_atsign="$selectedatsign"
+    get_device_atsign
+  fi
 
-    while [ -z "$device_name" ]; do
-        printf "Enter device name: "
-        read -r device_name
-    done
+  while [ -z "$device_name" ]; do
+    printf "Enter device name: "
+    read -r device_name
+  done
 
-    # run the device install script and capture the output
-    install_output=$("$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" "$device_install_type" sshnpd)
+  # run the device install script and capture the output
+  install_output=$("$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" "$device_install_type" sshnpd)
 
-    if [ "$verbose" = true ]; then
-        echo "$install_output"
-    fi
+  if [ "$verbose" = true ]; then
+    echo "$install_output"
+  fi
 
-    case "$device_install_type" in
+  case "$device_install_type" in
     launchd)
-        launchd_plist="$HOME/Library/LaunchAgents/com.atsign.sshnpd.plist"
-        write_program_arguments_plist "$launchd_plist" "$bin_path/sshnpd" "-m" "$(norm_atsign "$client_atsign")" "-a" "$(norm_atsign "$device_atsign")" "-d" "$device_name" "-su"
-        launchctl unload "$launchd_plist"
-        launchctl load "$launchd_plist"
-        echo "sshnpd installed with launchd"
-        ;;
+      launchd_plist="$HOME/Library/LaunchAgents/com.atsign.sshnpd.plist"
+      write_program_arguments_plist "$launchd_plist" "$bin_path/sshnpd" "-m" "$(norm_atsign "$client_atsign")" "-a" "$(norm_atsign "$device_atsign")" "-d" "$device_name" "-su"
+      launchctl unload "$launchd_plist"
+      launchctl load "$launchd_plist"
+      echo "sshnpd installed with launchd"
+      ;;
     systemd)
-        systemd_service="/etc/systemd/system/sshnpd.service"
-        write_systemd_user "$systemd_service" "$user"
-        write_systemd_environment "$systemd_service" "manager_atsign" "$(norm_atsign "$client_atsign")"
-        write_systemd_environment "$systemd_service" "device_atsign" "$(norm_atsign "$device_atsign")"
-        write_systemd_environment "$systemd_service" "device_name" "$device_name"
-        systemctl enable sshnpd
-        systemctl start sshnpd
-        echo "sshnpd installed with systemd. To see logs use:"
-        echo "journalctl -u sshnpd.service -f"
-        ;;
+      systemd_service="/etc/systemd/system/sshnpd.service"
+      write_systemd_user "$systemd_service" "$user"
+      write_systemd_environment "$systemd_service" "manager_atsign" "$(norm_atsign "$client_atsign")"
+      write_systemd_environment "$systemd_service" "device_atsign" "$(norm_atsign "$device_atsign")"
+      write_systemd_environment "$systemd_service" "device_name" "$device_name"
+      systemctl enable sshnpd
+      systemctl start sshnpd
+      echo "sshnpd installed with systemd. To see logs use:"
+      echo "journalctl -u sshnpd.service -f"
+      ;;
     tmux | headless)
-        shell_script="$bin_path"/sshnpd.sh
-        write_metadata "$shell_script" "manager_atsign" "$(norm_atsign "$client_atsign")"
-        write_metadata "$shell_script" "device_atsign" "$(norm_atsign "$device_atsign")"
-        write_metadata "$shell_script" "device_name" "$device_name"
-        # split install output by lines, then grab the output after the line that says "To start immediately"
-        eval "$(echo "$install_output" | grep -A1 "To start .* immediately:" | tail -n1)"
-        ;;
-    esac
+      shell_script="$bin_path"/sshnpd.sh
+      write_metadata "$shell_script" "manager_atsign" "$(norm_atsign "$client_atsign")"
+      write_metadata "$shell_script" "device_atsign" "$(norm_atsign "$device_atsign")"
+      write_metadata "$shell_script" "device_name" "$device_name"
+      # split install output by lines, then grab the output after the line that says "To start immediately"
+      eval "$(echo "$install_output" | grep -A1 "To start .* immediately:" | tail -n1)"
+      ;;
+  esac
 }
 
 main() {
-    trap cleanup EXIT
-    set -eu
-    parse_env
-    parse_args "$@"
+  trap cleanup EXIT
+  set -eu
+  parse_env
+  print_env
+  parse_args "$@"
 
-    if [ $verbose = true ]; then print_env; fi
+  if [ -n "$local_archive" ]; then
+    echo "Using local archive: $local_archive"
+    cp "$local_archive" "$archive_path"
+  else
+    download_url=$(get_download_url)
+    echo "$download_url" | download_archive
+  fi
 
-    if [ -n "$local_archive" ]; then
-        echo "Using local archive: $local_archive"
-        cp "$local_archive" "$archive_path"
-    else
-        download_url=$(get_download_url)
-        echo "$download_url" | download_archive
-    fi
+  unpack_archive
 
-    unpack_archive
-
-    get_user_inputs
-    case "$install_type" in
+  get_user_inputs
+  case "$install_type" in
     client) client ;;
     device) device ;;
     both)
-        echo
-        echo "Installing device part..."
-        device
-        echo
-        echo "Installing client part..."
-        client
-        ;;
-    esac
+      echo
+      echo "Installing device part..."
+      device
+      echo
+      echo "Installing client part..."
+      client
+      ;;
+  esac
 }
 
 main "$@"

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.1.0-rc.10';
+const packageVersion = '5.1.0-rc.11';

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.1.0-rc.6';
+const packageVersion = '5.1.0-rc.7';

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.1.0-rc.8';
+const packageVersion = '5.1.0-rc.9';

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.1.0-rc.7';
+const packageVersion = '5.1.0-rc.8';

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.1.0-rc.11';
+const packageVersion = '5.1.0';

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.1.0-rc.9';
+const packageVersion = '5.1.0-rc.10';

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.1.0-rc.9
+version: 5.1.0-rc.10
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.1.0-rc.8
+version: 5.1.0-rc.9
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.1.0-rc.10
+version: 5.1.0-rc.11
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.1.0-rc.6
+version: 5.1.0-rc.7
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.1.0-rc.7
+version: 5.1.0-rc.8
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.1.0-rc.11
+version: 5.1.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/dart/sshnoports/tools/Dockerfile
+++ b/packages/dart/sshnoports/tools/Dockerfile
@@ -11,7 +11,7 @@ RUN \
   set -eux ; \
   mkdir -p ${BINARYDIR} ; \
   cd ${PACKAGEDIR}; \
-  dart pub get ; \
+  dart pub get --enforce-lockfile; \
   dart run build_runner build --delete-conflicting-outputs ; \
   dart compile exe bin/sshnpd.dart -o ${BINARYDIR}/sshnpd ; \
   dart compile exe bin/srv.dart -o ${BINARYDIR}/srv

--- a/packages/dart/sshnoports/tools/Dockerfile.activate
+++ b/packages/dart/sshnoports/tools/Dockerfile.activate
@@ -10,7 +10,7 @@ RUN \
   set -eux ; \
   mkdir -p ${BINARYDIR} ; \
   cd ${PACKAGEDIR}; \
-  dart pub get ; \
+  dart pub get --enforce-lockfile; \
   dart run build_runner build --delete-conflicting-outputs ; \
   dart compile exe bin/activate_cli.dart -o ${BINARYDIR}/at_activate
 

--- a/packages/dart/sshnoports/tools/Dockerfile.package
+++ b/packages/dart/sshnoports/tools/Dockerfile.package
@@ -19,6 +19,7 @@ RUN set -eux; \
   dart run build_runner build --delete-conflicting-outputs; \
   dart compile exe bin/activate_cli.dart -v -o sshnp/at_activate; \
   dart compile exe bin/sshnp.dart -v -o sshnp/sshnp; \
+  dart compile exe bin/npt.dart -v -o sshnp/npt; \
   dart compile exe bin/sshnpd.dart -v -o sshnp/sshnpd; \
   dart compile exe bin/srv.dart -v -o sshnp/srv; \
   dart compile exe bin/srvd.dart -v -o sshnp/srvd; \

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
@@ -28,14 +28,13 @@ RUN \
   mkdir -p ${BINARYDIR} ; \
   # build sshnpd
   cd ${WORKDIR}/${PACKAGEDIR}; \
-  dart pub get ; \
-  dart pub update ; \
+  dart pub get --enforce-lockfile ; \
   dart compile exe bin/sshnpd.dart -o ${BINARYDIR}/sshnpd ; \
   dart compile exe bin/srv.dart -o ${BINARYDIR}/srv ; \
   # create atsign account
   addgroup --gid $GROUP_ID atsign ; \
   useradd --system --uid $USER_ID --gid $GROUP_ID --shell /bin/bash \
-    --home $HOMEDIR atsign ; \
+  --home $HOMEDIR atsign ; \
   chown -R atsign:atsign $HOMEDIR ; \
   # build static openssh binaries
   apt update && apt install -y curl gcc make autoconf ; \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
fixed #906 
closes #912 

**- What I did**

- Fixed the launchd installation
- Changed the artifact name in multibuild so it is unique across builds
- Added an extra print statement for clarity to the magic script
- cleaned up remaining bugs and input stuff in universal.sh

**- How I did it**

**- How to verify it**

If you get stuck please run with -v and send me the logs.
I will sort out the rest from there.
 
Places tested:

- [x] @xavierchanth's m1 macbook (client, device, both)
- [x] Ubuntu 22.04 VM (client, device, both) - using interactive prompts
- [x] Ubuntu 22.04 VM (client, device, both) - using command line flags
- [x] AL2023 VM (device) - using interactive prompts
- [x] AL2023 VM (device) - using command line flags


v5.1.0-rc.11 tests (with macbook fixes & new multi atkeys selector for @gkc):
- [x] m1 macbook - (device - many atkeys files available)
- [x] m1 macbook - (device - single atkeys file available)
- [x] Ubuntu 22.04 - (device - 2 atkeys files)
- [x] Ubuntu 22.04 - (device - 1 atkeys files)

**- Description for the changelog**
fix: the rest of universal installer
