### PR TITLE
chore: bump version v5.1.1-rc.1

### DIFF
--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -3,7 +3,7 @@
 # SCRIPT METADATA
 # DO NOT MODIFY/DELETE THIS BLOCK
 script_version="3.0.0"
-sshnp_version="5.1.0"
+sshnp_version="5.1.1.rc.1"
 repo_url="https://github.com/atsign-foundation/sshnoports"
 # END METADATA
 

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.1.0';
+const packageVersion = '5.1.1-rc.1';

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.1.0
+version: 5.1.1-rc.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

@cpswan not sure why we are protecting `release-` branches now... all noports releases are tied to tags.

There are always last minute things that need to be added to before we release, hence the workflow has been: create release- branch, push changes to that branch, tag it, and then release.

Unit tests are also not running, yet required...
![CleanShot 2024-04-12 at 11 48 32](https://github.com/atsign-foundation/noports/assets/33691921/f6c70145-4274-4b1a-a325-42c888476dc2)


**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: bump version v5.1.1-rc.1
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
