### PR TITLE
feat: Key Bindings to navigate between terminal tabs and change terminal font size

### DIFF
--- a/packages/dart/sshnp_flutter/lib/src/presentation/widgets/terminal_screen_widgets/terminal_screen_desktop_view.dart
+++ b/packages/dart/sshnp_flutter/lib/src/presentation/widgets/terminal_screen_widgets/terminal_screen_desktop_view.dart
@@ -250,13 +250,12 @@ class _TerminalScreenDesktopViewState extends ConsumerState<TerminalScreenDeskto
                                 }),
                                 LogicalKeySet(
                                   LogicalKeyboardKey.control,
-                                  LogicalKeyboardKey.shift,
-                                  LogicalKeyboardKey.add,
+                                  LogicalKeyboardKey.equal,
                                 ): VoidCallbackIntent(() {
                                   increaseFontSize();
                                 }),
-                                LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.shift,
-                                    LogicalKeyboardKey.underscore): VoidCallbackIntent(() {
+                                LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.minus):
+                                    VoidCallbackIntent(() {
                                   decreaseFontSize();
                                 }),
                               },

--- a/packages/dart/sshnp_flutter/lib/src/presentation/widgets/terminal_screen_widgets/terminal_screen_desktop_view.dart
+++ b/packages/dart/sshnp_flutter/lib/src/presentation/widgets/terminal_screen_widgets/terminal_screen_desktop_view.dart
@@ -113,6 +113,47 @@ class _TerminalScreenDesktopViewState extends ConsumerState<TerminalScreenDeskto
     controller.dispose();
   }
 
+  void exitCallback(String sessionId) {
+    log('exit intent called');
+    closeSession(sessionId);
+  }
+
+  void nextTabCallback(TabController tabController, List<String> terminalList, int currentIndex) {
+    log('next tab called');
+    log(tabController.index.toString());
+    log(terminalList.length.toString());
+    if (tabController.index < (terminalList.length - 1)) {
+      ref.read(terminalSessionController.notifier).setSession(terminalList[tabController.index + 1]);
+      tabController.index++;
+      log('current index is $currentIndex');
+      log(tabController.index.toString());
+    }
+  }
+
+  void previousTabCallback(TabController tabController, List<String> terminalList, int currentIndex) {
+    log('previous tab called');
+    log(tabController.index.toString());
+    if (tabController.index > 0) {
+      ref.read(terminalSessionController.notifier).setSession(terminalList[tabController.index - 1]);
+
+      log(tabController.index.toString());
+    }
+  }
+
+  void increaseFontSize() {
+    log('a tab called');
+    setState(() {
+      terminalFontSize++;
+    });
+  }
+
+  void decreaseFontSize() {
+    log('a tab called');
+    setState(() {
+      terminalFontSize--;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final strings = AppLocalizations.of(context)!;
@@ -179,56 +220,44 @@ class _TerminalScreenDesktopViewState extends ConsumerState<TerminalScreenDeskto
                                   LogicalKeyboardKey.control,
                                   LogicalKeyboardKey.keyQ,
                                 ): VoidCallbackIntent(() {
-                                  log('exit intent called');
-
-                                  closeSession(sessionId);
+                                  exitCallback(sessionId);
                                 }),
                                 LogicalKeySet(
                                   LogicalKeyboardKey.control,
                                   LogicalKeyboardKey.shift,
                                   LogicalKeyboardKey.arrowRight,
                                 ): VoidCallbackIntent(() {
-                                  log('next tab called');
-                                  log(tabController.index.toString());
-                                  if (currentIndex < terminalList.length - 1) {
-                                    ref
-                                        .read(terminalSessionController.notifier)
-                                        .setSession(terminalList[tabController.index + 1]);
-
-                                    log(tabController.index.toString());
-                                  }
+                                  nextTabCallback(tabController, terminalList, currentIndex);
+                                }),
+                                LogicalKeySet(
+                                  LogicalKeyboardKey.control,
+                                  LogicalKeyboardKey.keyL,
+                                ): VoidCallbackIntent(() {
+                                  nextTabCallback(tabController, terminalList, currentIndex);
                                 }),
                                 LogicalKeySet(
                                   LogicalKeyboardKey.control,
                                   LogicalKeyboardKey.shift,
                                   LogicalKeyboardKey.arrowLeft,
                                 ): VoidCallbackIntent(() {
-                                  log('next tab called');
-                                  log(tabController.index.toString());
-                                  if (currentIndex > 0) {
-                                    ref
-                                        .read(terminalSessionController.notifier)
-                                        .setSession(terminalList[tabController.index - 1]);
-
-                                    log(tabController.index.toString());
-                                  }
+                                  previousTabCallback(tabController, terminalList, currentIndex);
+                                }),
+                                LogicalKeySet(
+                                  LogicalKeyboardKey.control,
+                                  LogicalKeyboardKey.keyH,
+                                ): VoidCallbackIntent(() {
+                                  previousTabCallback(tabController, terminalList, currentIndex);
                                 }),
                                 LogicalKeySet(
                                   LogicalKeyboardKey.control,
                                   LogicalKeyboardKey.shift,
                                   LogicalKeyboardKey.add,
                                 ): VoidCallbackIntent(() {
-                                  log('a tab called');
-                                  setState(() {
-                                    terminalFontSize++;
-                                  });
+                                  increaseFontSize();
                                 }),
                                 LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.shift,
                                     LogicalKeyboardKey.underscore): VoidCallbackIntent(() {
-                                  log('a tab called');
-                                  setState(() {
-                                    terminalFontSize--;
-                                  });
+                                  decreaseFontSize();
                                 }),
                               },
 

--- a/packages/dart/sshnp_flutter/lib/src/presentation/widgets/terminal_screen_widgets/terminal_screen_desktop_view.dart
+++ b/packages/dart/sshnp_flutter/lib/src/presentation/widgets/terminal_screen_widgets/terminal_screen_desktop_view.dart
@@ -1,8 +1,9 @@
 import 'dart:developer';
 
-import 'package:at_onboarding_flutter/at_onboarding_flutter.dart';
+import 'package:at_onboarding_flutter/at_onboarding_flutter.dart' hide Intent;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -27,6 +28,7 @@ class TerminalScreenDesktopView extends ConsumerStatefulWidget {
 
 class _TerminalScreenDesktopViewState extends ConsumerState<TerminalScreenDesktopView> with TickerProviderStateMixin {
   final terminalController = TerminalController();
+  double terminalFontSize = 14.0;
 
   @override
   void initState() {
@@ -172,6 +174,63 @@ class _TerminalScreenDesktopViewState extends ConsumerState<TerminalScreenDeskto
                               controller: terminalController,
                               autofocus: true,
                               autoResize: true,
+                              shortcuts: <ShortcutActivator, VoidCallbackIntent>{
+                                LogicalKeySet(
+                                  LogicalKeyboardKey.control,
+                                  LogicalKeyboardKey.keyQ,
+                                ): VoidCallbackIntent(() {
+                                  log('exit intent called');
+
+                                  closeSession(sessionId);
+                                }),
+                                LogicalKeySet(
+                                  LogicalKeyboardKey.control,
+                                  LogicalKeyboardKey.shift,
+                                  LogicalKeyboardKey.arrowRight,
+                                ): VoidCallbackIntent(() {
+                                  log('next tab called');
+                                  log(tabController.index.toString());
+                                  if (currentIndex < terminalList.length - 1) {
+                                    ref
+                                        .read(terminalSessionController.notifier)
+                                        .setSession(terminalList[tabController.index + 1]);
+
+                                    log(tabController.index.toString());
+                                  }
+                                }),
+                                LogicalKeySet(
+                                  LogicalKeyboardKey.control,
+                                  LogicalKeyboardKey.shift,
+                                  LogicalKeyboardKey.arrowLeft,
+                                ): VoidCallbackIntent(() {
+                                  log('next tab called');
+                                  log(tabController.index.toString());
+                                  if (currentIndex > 0) {
+                                    ref
+                                        .read(terminalSessionController.notifier)
+                                        .setSession(terminalList[tabController.index - 1]);
+
+                                    log(tabController.index.toString());
+                                  }
+                                }),
+                                LogicalKeySet(
+                                  LogicalKeyboardKey.control,
+                                  LogicalKeyboardKey.shift,
+                                  LogicalKeyboardKey.add,
+                                ): VoidCallbackIntent(() {
+                                  log('a tab called');
+                                  setState(() {
+                                    terminalFontSize++;
+                                  });
+                                }),
+                                LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.shift,
+                                    LogicalKeyboardKey.underscore): VoidCallbackIntent(() {
+                                  log('a tab called');
+                                  setState(() {
+                                    terminalFontSize--;
+                                  });
+                                }),
+                              },
 
                               // textStyle:
                               //     TerminalStyle.fromTextStyle(const TextStyle(fontFamily: '0xProtoNerdFontMono')),
@@ -180,7 +239,7 @@ class _TerminalScreenDesktopViewState extends ConsumerState<TerminalScreenDeskto
                               //   // fontSize: 14,
                               // )),
                               textStyle: TerminalStyle.fromTextStyle(
-                                  const TextStyle(fontFamily: 'IosevkaTermNerdFontPropo', fontSize: 14
+                                  TextStyle(fontFamily: 'IosevkaTermNerdFontPropo', fontSize: terminalFontSize
                                       // fontSize: 14,
                                       )),
                             );

--- a/packages/dart/sshnp_flutter/lib/src/utility/intents.dart
+++ b/packages/dart/sshnp_flutter/lib/src/utility/intents.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+class ExitIntent extends VoidCallbackIntent {
+  final void Function() onExit;
+  const ExitIntent(this.onExit) : super(onExit);
+  // modify this class to call on exit
+}

--- a/packages/dart/sshnp_flutter/pubspec.lock
+++ b/packages/dart/sshnp_flutter/pubspec.lock
@@ -792,10 +792,11 @@ packages:
   noports_core:
     dependency: "direct main"
     description:
-      path: "../noports_core"
-      relative: true
-    source: path
-    version: "6.0.5"
+      name: noports_core
+      sha256: "616afc599117dd9881aaf59893cbaacf1234a4e2e16e415e3a08b2d4b45eac05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.2"
   openssh_ed25519:
     dependency: transitive
     description:
@@ -1008,10 +1009,10 @@ packages:
     dependency: transitive
     description:
       name: posix
-      sha256: a0117dc2167805aa9125b82eee515cc891819bac2f538c83646d355b16f58b9a
+      sha256: "3ad26924254fd2354b0e2b95fc8b45ac392ad87434f8e64807b3a1ac077f2256"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.1"
+    version: "5.0.0"
   process:
     dependency: transitive
     description:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
closes #706 
Added the following shortcuts to the terminal tabs
1. Navigate to next terminal tab using 
    - Control + Shift + Right Arrow key 
    - Control + L

2. Navigate to previous terminal tab using 
    - Control + Shift + Left Arrow Key
    - Control + H

3. Increase terminal font size
    - Control + =

4. Decrease terminal font size
    - Control + -

**- How I did it**
Added shortcuts to the terminal view shortcuts property.
**- How to verify it**

1. Run the desktop app
2. ssh into two remote devices
3. press the aforementioned shortcut keys to get the navigation and font size actions

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

- Control + Shift + Right Arrow key or Control + L to navigate to the next terminal tab
- Control + Shift + Left Arrow Key or Control + H to navigate to the previous terminal tab
- Control + = to increase terminal font size
- Control + - to decrease font size
