### PR TITLE
feat: Include allowed services in ping

### DIFF
--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -107,6 +107,7 @@ class SshnpdImpl implements Sshnpd {
         DaemonFeature.acceptsPublicKeys.name: addSshPublicKeys,
         DaemonFeature.supportsPortChoice.name: true,
       },
+      'allowedServices': permitOpen,
     };
   }
 

--- a/packages/dart/sshnoports/bin/sshnp.dart
+++ b/packages/dart/sshnoports/bin/sshnp.dart
@@ -168,7 +168,7 @@ void main(List<String> args) async {
       // Run List Devices Operation
       if (params.listDevices) {
         stderr.writeln('Searching for devices...');
-        var deviceList = await sshnp.listDevices();
+        SshnpDeviceList deviceList = await sshnp.listDevices();
         printDevices(deviceList);
         exitProgram();
       }

--- a/packages/dart/sshnoports/lib/src/print_devices.dart
+++ b/packages/dart/sshnoports/lib/src/print_devices.dart
@@ -22,12 +22,16 @@ void printDeviceList(Iterable<String> devices, Map<String, dynamic> info) {
   for (var device in devices) {
     stderr.writeln('  $device - v${info[device]?['version']}'
         ' (core v${info[device]?['corePackageVersion']})');
+
     if (info[device]['allowedServices'] != null &&
-        (info[device]['allowedServices'] is List<String>) &&
-        (info[device]['allowedServices'] as List<String>).isNotEmpty) {
+        (info[device]['allowedServices'] is List) &&
+        (info[device]['allowedServices'] as List).isNotEmpty) {
+      // allowedServices should be a List<String> but casting from json means it's actually a List<dynamic>
+      // It's an unnecessary pain to bother going through casting hell for,
+      // since all json types should have a .toString() which is reasonable to print as output
       stderr.write("  - allowedServices:");
       for (String service in info[device]['allowedServices']) {
-        stderr.write(' $service');
+        stderr.write(' ${service.toString()}');
       }
       stderr.writeln();
     }

--- a/packages/dart/sshnoports/lib/src/print_devices.dart
+++ b/packages/dart/sshnoports/lib/src/print_devices.dart
@@ -5,10 +5,6 @@ import 'package:noports_core/sshnp_foundation.dart';
 void printDevices(SshnpDeviceList deviceList) {
   if (deviceList.activeDevices.isEmpty && deviceList.inactiveDevices.isEmpty) {
     stderr.writeln('[X] No devices found\n');
-    stderr.writeln(
-        'Note: only devices with sshnpd version 3.4.0 or higher are supported by this command.');
-    stderr.writeln(
-        'Please update your devices to sshnpd version >= 3.4.0 and try again.');
     exit(0);
   }
 
@@ -26,5 +22,14 @@ void printDeviceList(Iterable<String> devices, Map<String, dynamic> info) {
   for (var device in devices) {
     stderr.writeln('  $device - v${info[device]?['version']}'
         ' (core v${info[device]?['corePackageVersion']})');
+    if (info[device]['allowedServices'] != null &&
+        (info[device]['allowedServices'] is List<String>) &&
+        (info[device]['allowedServices'] as List<String>).isNotEmpty) {
+      stderr.write("  - allowedServices:");
+      for (String service in info[device]['allowedServices']) {
+        stderr.write(' $service');
+      }
+      stderr.writeln();
+    }
   }
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Added 'allowedServices' as a `List<String>` to the device info map which is published as a part of the ping / list devices, this maps directly to `--permit-open`.
- Updated the output of `sshnp --list-devices` to include availableServices on a line below it's associated device name & version.

**- How I did it**

**- How to verify it**

Output from tests:

```
Searching for devices...
Active Devices:
  charon - v5.1.0 (core v6.0.6)
  hermes - v5.1.0 (core v6.0.6)
  test1 - v5.1.0 (core v6.0.6)
  - allowedServices: localhost:22 localhost:3389
  test2 - v5.1.0 (core v6.0.6)
  - allowedServices: localhost:22 localhost:3389
  test3 - v5.1.0 (core v6.0.6)
  - allowedServices: localhost:22 localhost:3389
  test4 - v5.1.0 (core v6.0.6)
  - allowedServices: some.thing.different.com:7878
Inactive Devices:
  asdf - v5.0.2 (core v6.0.2)
  foo1 - v5.1.0-rc.11 (core v6.0.6)
  foo2 - v5.1.0-rc.11 (core v6.0.6)
  hermeslaunchd - v5.0.2 (core v6.0.2)
  mar28 - v5.0.2 (core v6.0.2)
  mar282 - v5.0.2 (core v6.0.2)
  mar2828 - v5.0.2 (core v6.0.2)
```

Daemon commands:
```
parallel -j 3 -i sh -c "echo starting {}; sshnpd -a @xchan -m @xavierchanth -d {} --storage-path $HOME/.sshnp/@xchan-{}/storage -u" -- test1 test2 test3
```

```
sshnpd -a @xchan -m @xavierchanth -d test4 --storage-path $HOME/.sshnp/@xchan-test
4/storage -u
```


Client command:
```
dart run packages/dart/sshnoports/bin/sshnp.dart -f @xavierchanth -t @xchan -h @xchan_8286 --list-devices
```

**- Description for the changelog**
feat: Include allowed services in ping
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
