### PR TITLE
feat(sshnpd): deprecate -u in favor of -h

### DIFF
--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
@@ -75,7 +75,7 @@ class SshnpdParams {
     }
     bool makeDeviceInfoVisible = r['un-hide'];
     if (r.wasParsed('hide')) {
-      makeDeviceInfoVisible = r['hide'];
+      makeDeviceInfoVisible = !r['hide'];
     }
     return SshnpdParams(
       device: r['device'],

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
@@ -147,6 +147,7 @@ class SshnpdParams {
     parser.addFlag(
       'hide',
       abbr: 'h',
+      negatable: false,
       defaultsTo: false,
       help: 'Hides the device from advertising its information to the manager'
           ' atSign. Even with this enabled, sshnpd will still respond to ping'

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
@@ -73,7 +73,10 @@ class SshnpdParams {
     if (invalidDeviceName(device)) {
       throw ArgumentError(invalidDeviceNameMsg);
     }
-
+    bool makeDeviceInfoVisible = r['un-hide'];
+    if (r.wasParsed('hide')) {
+      makeDeviceInfoVisible = r['hide'];
+    }
     return SshnpdParams(
       device: r['device'],
       username: getUserName(throwIfNull: true)!,
@@ -83,7 +86,7 @@ class SshnpdParams {
           getDefaultAtKeysFilePath(homeDirectory, deviceAtsign),
       deviceAtsign: deviceAtsign,
       verbose: r['verbose'],
-      makeDeviceInfoVisible: r['un-hide'],
+      makeDeviceInfoVisible: makeDeviceInfoVisible,
       addSshPublicKeys: r['sshpublickey'],
       sshClient: sshClient,
       rootDomain: r['root-domain'],
@@ -142,12 +145,26 @@ class SshnpdParams {
           ' to include public key sent by manager',
     );
     parser.addFlag(
+      'hide',
+      abbr: 'h',
+      defaultsTo: false,
+      help: 'Hides the device from advertising its information to the manager'
+          ' atSign. Even with this enabled, sshnpd will still respond to ping'
+          ' requests from the manager. (This takes priority over -u / --un-hide)',
+    );
+    parser.addFlag(
       'un-hide',
       abbr: 'u',
       aliases: const ['username'],
-      defaultsTo: false,
-      help: 'When set, makes various information visible'
-          ' to the manager atSign - e.g. username, version, etc',
+      defaultsTo: true,
+      hide: true,
+      callback: (bool unhide) {
+        if (unhide) {
+          stderr.writeln(
+              "[WARN] -u, --un-hide is deprecated, since it is now on by default."
+              " Use --hide if you want to disable device information sharing.");
+        }
+      },
     );
     parser.addFlag(
       'verbose',


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Made -u hidden from usage, and defaults to true.
- sshnpd first parses the value of -u, then checks if -h was parsed, and overrides the value of `makeDeviceInfoVisible` if it was parsed.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
feat(sshnpd): deprecate -u in favor of -h
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
