### PR TITLE
fix: locked up session can now be closed

### DIFF
--- a/packages/dart/sshnp_flutter/lib/src/presentation/widgets/terminal_screen_widgets/terminal_screen_desktop_view.dart
+++ b/packages/dart/sshnp_flutter/lib/src/presentation/widgets/terminal_screen_widgets/terminal_screen_desktop_view.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:developer';
 
 import 'package:at_onboarding_flutter/at_onboarding_flutter.dart';
@@ -54,30 +55,46 @@ class _TerminalScreenDesktopViewState extends ConsumerState<TerminalScreenDeskto
 
             final keyPair = privateKeyManager.toAtSshKeyPair();
 
-            final sshnp = Sshnp.dartPure(
-              params: SshnpParams.merge(
-                shellInfo['params'],
-                SshnpPartialParams(
-                  verbose: kDebugMode,
-                  idleTimeout: 30,
+            Sshnp? sshnp;
+            SshnpResult? result = await runZonedGuarded<Future<SshnpResult?>>(() async {
+              sshnp = Sshnp.dartPure(
+                params: SshnpParams.merge(
+                  shellInfo['params'],
+                  SshnpPartialParams(
+                    verbose: kDebugMode,
+                    idleTimeout: 30,
+                  ),
                 ),
-              ),
-              atClient: atClient,
-              identityKeyPair: keyPair,
-            );
-            sshnp.progressStream?.listen((progress) {
-              sessionController.write(progress);
-              log(progress);
-            });
+                atClient: atClient,
+                identityKeyPair: keyPair,
+              );
 
-            final result = await sshnp.run();
+              sshnp!.progressStream?.listen((progress) {
+                sessionController.write(progress);
+                log(progress);
+              });
+
+              return await sshnp!.run().catchError((e) {
+                CustomSnackBar.error(content: e.toString());
+                throw 'Failed to start session';
+              });
+            }, (error, stack) {
+              log('Error: $error', error: error, stackTrace: stack);
+              sshnp = null;
+              CustomSnackBar.error(content: 'Failed to initialize SSH No Ports');
+              throw error.toString();
+            });
+            if (sshnp == null || result == null) {
+              throw 'Failed to initialize SSH No Ports';
+            }
+            log(result.toString());
             if (result is SshnpError) {
               throw result;
             }
 
             if (result is SshnpCommand) {
-              if (sshnp.canRunShell) {
-                SshnpRemoteProcess shell = await sshnp.runShell();
+              if (sshnp!.canRunShell) {
+                SshnpRemoteProcess shell = await sshnp!.runShell();
 
                 sessionController.startSession(
                   shell,
@@ -86,11 +103,12 @@ class _TerminalScreenDesktopViewState extends ConsumerState<TerminalScreenDeskto
               }
             }
           } catch (e) {
+            log('catch called');
             sessionController.dispose();
 
+            log('error: ${e.toString()}');
             if (mounted) {
-              log('error: ${e.toString()}');
-
+              log('mounted called');
               CustomSnackBar.error(content: e.toString());
             }
           }

--- a/packages/dart/sshnp_flutter/pubspec.lock
+++ b/packages/dart/sshnp_flutter/pubspec.lock
@@ -792,10 +792,11 @@ packages:
   noports_core:
     dependency: "direct main"
     description:
-      path: "../noports_core"
-      relative: true
-    source: path
-    version: "6.0.5"
+      name: noports_core
+      sha256: "616afc599117dd9881aaf59893cbaacf1234a4e2e16e415e3a08b2d4b45eac05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.2"
   openssh_ed25519:
     dependency: transitive
     description:
@@ -1008,10 +1009,10 @@ packages:
     dependency: transitive
     description:
       name: posix
-      sha256: a0117dc2167805aa9125b82eee515cc891819bac2f538c83646d355b16f58b9a
+      sha256: "3ad26924254fd2354b0e2b95fc8b45ac392ad87434f8e64807b3a1ac077f2256"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.1"
+    version: "5.0.0"
   process:
     dependency: transitive
     description:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Used try/catch to log errors from shell so the user can close the session successfully. The error is logged
- Added Zoned Guarded to handle errors when no ports failed to initialize. This can occur when the internet connection is lost. The use is shown a snackbar message and there error is logged.

This a work around to #977
This PR closes #790 
**- How I did it**

**- How to verify it**

1. Launch the app
2. Onboard
3. Turn off your internet
4. ssh into your remote device, you should see a snackbar message indication the session failed to initialize
5. Close the session
6. Turn on your internet
7. ssh into your remote device
8. Turn off your internet
9. Close the session: The terminal will not respond to you keyboard entries but you should be able to close the session

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Handle the erros throw when tunnel session closes 
Show user a snack bar message when no ports fails to initilize.