### PR TITLE
fix: a bunch of small universal.sh bugs

### DIFF
--- a/packages/dart/sshnoports/bundles/shell/install.sh
+++ b/packages/dart/sshnoports/bundles/shell/install.sh
@@ -110,6 +110,7 @@ usage() {
 setup_authorized_keys() {
   mkdir -p "$user_ssh_dir"
   touch "$user_ssh_dir/authorized_keys"
+  chown $user:$user "$user_ssh_dir/authorized_keys"
   chmod 644 "$user_ssh_dir/authorized_keys"
 }
 

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -178,7 +178,7 @@ parse_env() {
     bin_path="$HOME/.local/bin"
     user="$USER"
   fi
-  user_bin_dir=$user_home/.local/bin/@sshnp
+  user_bin_dir=$user_home/.local/bin
 }
 
 is_valid_source_mode() {

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -581,12 +581,12 @@ client() {
   if [ -z "$devices" ]; then
     done_input=false
     echo "Installing a quick picker script to make it easy to connect to devices..."
-    echo "Enter the device names you would like to include in the quick picker script"
-    echo "/done to finish"
+    echo "Type a device name and press enter to submit it."
+    echo "Press enter once more to finish."
     while [ "$done_input" = false ]; do
       printf "Device name: "
       read -r device_name
-      if [ "$device_name" = "/done" ]; then
+      if [ -z "$device_name" ]; then
         done_input=true
       else
         devices="$devices,$device_name"

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -500,6 +500,7 @@ get_atsign() {
     fi
   else
     mkdir -p "$user_home"/.atsign/keys
+    chown -R $user:$user "$user_home"/.atsign/keys
     echo "$HOME/.atsign/keys directory created"
     echo "Since we did not detect any atkeys on this machine, please enter the $clientOrDevice atSign manually."
     get_atsign_manually

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -98,7 +98,7 @@ usage() {
   echo "  -v, --verbose                  Verbose tracing"
   echo "      --version                  Display version"
   echo "      --temp-path      <path>    Set the temporary path for downloads"
-  echo "  -t, --type           <type>    Set the install type (device, client, both)"
+  echo "  -t, --type           <type>    Set the install type (device, client)"
   echo "      --local          <path>    Install from a local archive"
   echo
   echo "Client Options:"
@@ -186,7 +186,7 @@ is_valid_source_mode() {
 }
 
 is_valid_install_type() {
-  [ "$1" = "device" ] || [ "$1" = "client" ] || [ "$1" = "both" ]
+  [ "$1" = "device" ] || [ "$1" = "client" ]
 }
 
 norm_install_type() {
@@ -196,9 +196,6 @@ norm_install_type() {
       ;;
     c*)
       echo "client"
-      ;;
-    b*)
-      echo "both"
       ;;
     *)
       echo ""
@@ -256,7 +253,7 @@ parse_args() {
         install_type=$(norm_install_type "$install_type_input")
         if ! is_valid_install_type "$install_type"; then
           echo "Invalid install type: $install_type_input"
-          echo "Valid options are: (device, client, both)" exit 1
+          echo "Valid options are: (device, client)" exit 1
         fi
         ;;
       --local)
@@ -320,7 +317,7 @@ get_user_inputs() {
   if [ -z "$install_type" ]; then
     unset install_type_input
     while [ -z "$install_type" ]; do
-      printf "Install type (device, client, both):  "
+      printf "Install type (device, client):  "
       read -r install_type_input
       install_type=$(norm_install_type "$install_type_input")
     done
@@ -709,14 +706,6 @@ main() {
   case "$install_type" in
     client) client ;;
     device) device ;;
-    both)
-      echo
-      echo "Installing device part..."
-      device
-      echo
-      echo "Installing client part..."
-      client
-      ;;
   esac
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

closes #984 
closes #974 


**- What I did**

Fixes:
- removed the `@sshnp` path segment in the path for np.sh
  - The path should be `~/.local/bin/np.sh` now
- instead of entering "/done" to enter the devices, just enter an empty line
  - This is arguably worse for people who don't read, but if they didn't read to setup the np.sh script, they probably didn't read how to use it either.
- Make sure that authorized_keys file is owned by the correct user
- Make sure that ~/.atsign/keys is owned by the correct user

Chores:
- Better atSign input overall, make sure people know which atSign they are entering at all times. See commit 0db36f699ae382cc9e4563e5f8532f72792dc3ab

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: a bunch of small universal.sh bugs
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
