### PR TITLE
fix: Correct prefix for temp branch

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -40,7 +40,7 @@ jobs:
             git commit -m 'ci: Updated version to tag'
           fi
       - name: Push changes to branch
-        run: git push --set-upstream origin robo-${{github.run_number}}
+        run: git push --set-upstream origin multibuild-${{github.run_number}}
 
   main_build:
     needs: verify_tags


### PR DESCRIPTION
Wrong branch prefix copied in from testing repo

**- What I did**

Fixed prefix name

**- How to verify it**

I'll do another attempt at 5.2.0-rc1 once merged.

**- Description for the changelog**

fix: Correct prefix for temp branch
