### PR TITLE
fix: Ownership should be applied to .atsign rather than keys subdirectory

### DIFF
--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -500,7 +500,7 @@ get_atsign() {
     fi
   else
     mkdir -p "$user_home"/.atsign/keys
-    chown -R $user:$user "$user_home"/.atsign/keys
+    chown -R $user:$user "$user_home"/.atsign
     echo "$HOME/.atsign/keys directory created"
     echo "Since we did not detect any atkeys on this machine, please enter the $clientOrDevice atSign manually."
     get_atsign_manually


### PR DESCRIPTION
Fixes #996 

**- What I did**

Truncated chown operation

**- How to verify it**

Manually tested on test vm

**- Description for the changelog**

fix: Ownership should be applied to .atsign rather than keys subdirectory