### PR TITLE
fix: tweak buildBinaries for consistency

### DIFF
--- a/packages/dart/sshnoports/buildBinaries
+++ b/packages/dart/sshnoports/buildBinaries
@@ -9,7 +9,7 @@ echo "Compiling sshnpd"; dart compile exe --verbosity error bin/sshnpd.dart -o b
 echo "Compiling srvd"; dart compile exe --verbosity error bin/srvd.dart -o bin/srvd &
 echo "Compiling sshnp"; dart compile exe --verbosity error bin/sshnp.dart -o bin/sshnp &
 echo "Compiling npt"; dart compile exe --verbosity error bin/npt.dart -o bin/npt &
-echo "Compiling demo/npa_always_deny"; dart compile exe --verbosity error bin/demo/npa_always_deny.dart -o bin/demo/sshnpa_always_deny &
+echo "Compiling demo/npa_always_deny"; dart compile exe --verbosity error bin/demo/npa_always_deny.dart -o bin/demo/npa_always_deny &
 echo "Compiling demo/npa_cli"; dart compile exe --verbosity error bin/demo/npa_cli.dart -o bin/demo/npa_cli &
 
 wait


### PR DESCRIPTION
**- What I did**
fix: change buildBinaries so it compiles bin/demo/sshnpa_always_deny.dart to a binary called npa_always_deny (used to be sshnpa_always_deny)
