### PR TITLE
chore: Consolidate dependabot directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,26 +7,20 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "docker"
-    directory: "/packages/dart/sshnoports/tools/"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "docker"
-    directory: "/tests/end2end_tests/image/"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "pub"
-    directory: "/packages/dart/sshnoports/"
+    directories:
+      - "/packages/dart/sshnoports/tools/"
+      - "/tests/end2end_tests/image/"
     schedule:
       interval: "daily"
   - package-ecosystem: "pub"
-    directory: "/packages/dart/sshnp_flutter/"
+    directories:
+      - "/packages/dart/sshnoports/"
+      - "/packages/dart/sshnp_flutter/"
     schedule:
       interval: "daily"
   - package-ecosystem: "pip"
-    directory: "/examples/automations/python/"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "pip"
-    directory: "/packages/python/sshnpd/"
+    directories:
+      - "/examples/automations/python/"
+      - "/packages/python/sshnpd/"
     schedule:
       interval: "daily"

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,16 @@ pubspec_overrides.yaml
 .dart_tool/
 .packages
 
+# Binaries build from dart/sshnoports
+packages/dart/sshnoports/bin/activate_cli
+packages/dart/sshnoports/bin/demo/npa_cli
+packages/dart/sshnoports/bin/demo/sshnpa_always_deny
+packages/dart/sshnoports/bin/npt
+packages/dart/sshnoports/bin/srv
+packages/dart/sshnoports/bin/srvd
+packages/dart/sshnoports/bin/sshnp
+packages/dart/sshnoports/bin/sshnpd
+
 # Jetbrains
 .idea/*
 


### PR DESCRIPTION
Following the pattern established by https://github.com/atsign-foundation/at_server/pull/1934 this makes use of the new [Dependabot multi-directory configuration public beta now available](https://github.blog/changelog/2024-04-29-dependabot-multi-directory-configuration-public-beta-now-available/) and should reduce the number of PRs and save us from having to do rollups quite so often.

**- What I did**

Move individual `directory` entries into `directories`

Also added binaries to .gitignore so they don't accidentally get pushed here (by me or anybody else).

**- How to verify it**

Insights - Dependency Graph - Dependabot should highlight that the new YAML is valid.

**- Description for the changelog**

chore: Consolidate dependabot directories