### PR TITLE
feat: feedback email added to support screen

### DIFF
--- a/packages/dart/sshnp_flutter/lib/src/presentation/widgets/custom_list_tile.dart
+++ b/packages/dart/sshnp_flutter/lib/src/presentation/widgets/custom_list_tile.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:at_app_flutter/at_app_flutter.dart';
 import 'package:at_contacts_flutter/services/contact_service.dart';
 import 'package:at_onboarding_flutter/at_onboarding_flutter.dart';
@@ -83,6 +85,13 @@ class CustomListTile extends StatelessWidget {
       this.type = CustomListTileType.resetAtsign,
       this.tileColor = kProfileBackgroundColor,
       super.key});
+  const CustomListTile.feedback(
+      {this.iconData = Icons.feedback_outlined,
+      this.title = 'Feedback',
+      this.subtitle = 'Send us your feedback',
+      this.type = CustomListTileType.feedback,
+      this.tileColor = kProfileBackgroundColor,
+      super.key});
 
   final IconData iconData;
   final String title;
@@ -159,8 +168,54 @@ class CustomListTile extends StatelessWidget {
               context.goNamed(AppRoute.onboarding.name);
             }
           }
-
           break;
+
+        case CustomListTileType.feedback:
+          // late final Uri emailUri;
+          // BetterFeedback.of(context).show(
+          //   (UserFeedback feedback) async {
+          // final Email email = Email(
+          //   body: '''
+          //   Hi, I would like to provide feedback on the SSH No Ports Desktop app. Here are my thoughts:
+
+          //   ${feedback.text}''',
+          //   subject: 'SSH No Ports Desktop Feedback',
+          //   recipients: ['info@noports.com'],
+          //   attachmentPaths: [await writeImageToStorage(feedback.screenshot)],
+          //   isHTML: false,
+          // );
+
+          // String platformResponse;
+
+          // try {
+          //   await FlutterEmailSender.send(email);
+          //   platformResponse = 'success';
+          // } catch (error) {
+          //   print(error);
+          //   platformResponse = error.toString();
+          // }
+
+          // if (!context.mounted) return;
+
+          // ScaffoldMessenger.of(context).showSnackBar(
+          //   SnackBar(
+          //     content: Text(platformResponse),
+          //   ),
+          // );
+
+          final emailUri = Uri(
+            scheme: 'mailto',
+            path: 'info@noports.com',
+            query: 'subject=SSH No Ports Desktop Feedback',
+          );
+
+          if (!await launchUrl(emailUri)) {
+            CustomSnackBar.notification(content: 'No email client available');
+          }
+          //   },
+          // );
+
+          log('about to send email');
       }
     }
 
@@ -205,4 +260,5 @@ enum CustomListTileType {
   switchAtsign,
   backupYourKey,
   resetAtsign,
+  feedback
 }

--- a/packages/dart/sshnp_flutter/lib/src/presentation/widgets/custom_list_tile.dart
+++ b/packages/dart/sshnp_flutter/lib/src/presentation/widgets/custom_list_tile.dart
@@ -1,5 +1,3 @@
-import 'dart:developer';
-
 import 'package:at_app_flutter/at_app_flutter.dart';
 import 'package:at_contacts_flutter/services/contact_service.dart';
 import 'package:at_onboarding_flutter/at_onboarding_flutter.dart';
@@ -171,38 +169,6 @@ class CustomListTile extends StatelessWidget {
           break;
 
         case CustomListTileType.feedback:
-          // late final Uri emailUri;
-          // BetterFeedback.of(context).show(
-          //   (UserFeedback feedback) async {
-          // final Email email = Email(
-          //   body: '''
-          //   Hi, I would like to provide feedback on the SSH No Ports Desktop app. Here are my thoughts:
-
-          //   ${feedback.text}''',
-          //   subject: 'SSH No Ports Desktop Feedback',
-          //   recipients: ['info@noports.com'],
-          //   attachmentPaths: [await writeImageToStorage(feedback.screenshot)],
-          //   isHTML: false,
-          // );
-
-          // String platformResponse;
-
-          // try {
-          //   await FlutterEmailSender.send(email);
-          //   platformResponse = 'success';
-          // } catch (error) {
-          //   print(error);
-          //   platformResponse = error.toString();
-          // }
-
-          // if (!context.mounted) return;
-
-          // ScaffoldMessenger.of(context).showSnackBar(
-          //   SnackBar(
-          //     content: Text(platformResponse),
-          //   ),
-          // );
-
           final emailUri = Uri(
             scheme: 'mailto',
             path: 'info@noports.com',
@@ -212,10 +178,6 @@ class CustomListTile extends StatelessWidget {
           if (!await launchUrl(emailUri)) {
             CustomSnackBar.notification(content: 'No email client available');
           }
-          //   },
-          // );
-
-          log('about to send email');
       }
     }
 

--- a/packages/dart/sshnp_flutter/lib/src/presentation/widgets/settings_screen_widgets/settings_screen_mobile.dart
+++ b/packages/dart/sshnp_flutter/lib/src/presentation/widgets/settings_screen_widgets/settings_screen_mobile.dart
@@ -22,8 +22,7 @@ class SettingsMobileView extends StatelessWidget {
         style: Theme.of(context).textTheme.headlineLarge,
       )),
       body: Padding(
-        padding: const EdgeInsets.only(
-            left: Sizes.p36, right: Sizes.p36, top: Sizes.p21),
+        padding: const EdgeInsets.only(left: Sizes.p36, right: Sizes.p36, top: Sizes.p21),
         child: ListView(
           children: [
             Text(

--- a/packages/dart/sshnp_flutter/lib/src/presentation/widgets/support_screen_widgets/support_screen_desktop_view.dart
+++ b/packages/dart/sshnp_flutter/lib/src/presentation/widgets/support_screen_widgets/support_screen_desktop_view.dart
@@ -50,6 +50,7 @@ class SupportScreenDesktopView extends StatelessWidget {
                   const Row(
                     children: [
                       Flexible(child: CustomListTile.discord()),
+                      gapW12,
                       Flexible(child: CustomListTile.email()),
                     ],
                   ),
@@ -61,9 +62,22 @@ class SupportScreenDesktopView extends StatelessWidget {
                   const Row(
                     children: [
                       Flexible(child: CustomListTile.faq()),
+                      gapW12,
                       Flexible(child: CustomListTile.privacyPolicy()),
                     ],
-                  )
+                  ),
+                  gapH20,
+                  const Divider(
+                    color: kProfileFormFieldColor,
+                  ),
+                  gapH20,
+                  const Row(
+                    children: [
+                      Flexible(child: CustomListTile.feedback()),
+                      gapW12,
+                      Flexible(child: gap0),
+                    ],
+                  ),
                 ],
               ),
             ),

--- a/packages/dart/sshnp_flutter/pubspec.lock
+++ b/packages/dart/sshnp_flutter/pubspec.lock
@@ -862,7 +862,7 @@ packages:
     source: hosted
     version: "1.0.1"
   path_provider:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: path_provider
       sha256: b27217933eeeba8ff24845c34003b003b2b22151de3c908d0e679e8fe1aa078b

--- a/packages/dart/sshnp_flutter/pubspec.yaml
+++ b/packages/dart/sshnp_flutter/pubspec.yaml
@@ -38,7 +38,6 @@ dependencies:
   package_info_plus: ^5.0.1
   page_transition: ^2.0.9
   path: ^1.8.3
-  path_provider: ^2.1.1
   shared_preferences: ^2.2.2
   socket_connector: ^2.0.1
   url_launcher: ^6.1.14


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added an Email Launcher Button that opens the user default email app so they can email us their feedback.
**- How I did it**

**- How to verify it**
Press the feedback list tile on the support screen and your default email app should open.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Users can email their feedback about ssh no ports desktop