### PR TITLE
build(deps): Add groups to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,21 +6,37 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     directories:
       - "/packages/dart/sshnoports/tools/"
       - "/tests/end2end_tests/image/"
     schedule:
       interval: "daily"
+    groups:
+      docker:
+        patterns:
+          - "*"
   - package-ecosystem: "pub"
     directories:
       - "/packages/dart/sshnoports/"
       - "/packages/dart/sshnp_flutter/"
     schedule:
       interval: "daily"
+    groups:
+      pub:
+        patterns:
+          - "*"
   - package-ecosystem: "pip"
     directories:
       - "/examples/automations/python/"
       - "/packages/python/sshnpd/"
     schedule:
       interval: "daily"
+    groups:
+      pip:
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot is presently creating individual PRs for each change it finds. This config change should group them together, which should also (hopefully) deal with the issue that individual directories get a single PR (per scan) for a given change.

**- What I did**

Added groups to each package manager

**- How I did it**

Based on https://github.com/dart-lang/dart-docker/pull/191/files

**- How to verify it**

Will have to wait for some deps to be bumped and see which PRs are created.

**- Description for the changelog**
build(deps): Add groups to dependabot.yml