### PR TITLE
fix: Working directory for PyPI README diff

### DIFF
--- a/.github/workflows/python-sshnpd-build-publish.yml
+++ b/.github/workflows/python-sshnpd-build-publish.yml
@@ -7,6 +7,8 @@ on:
       - 'p*.*.*'
     branches:
       - trunk
+    paths:
+      - 'packages/python/sshnpd/**'
 
 permissions:  # added using https://github.com/step-security/secure-repo
   contents: read

--- a/.github/workflows/python-sshnpd-build-publish.yml
+++ b/.github/workflows/python-sshnpd-build-publish.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install Poetry
       uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439 # v3.0.0
       with:
-        poetry-version: '1.8.2'
+        poetry-version: '1.8.3'
 
     # The dark mode and light mode Atsign logos in the GitHub README don't
     # show properly on PyPI so we have a copy of the README.md in

--- a/.github/workflows/python-sshnpd-build-publish.yml
+++ b/.github/workflows/python-sshnpd-build-publish.yml
@@ -34,6 +34,7 @@ jobs:
     # README.PyPI.md with just the light mode logo.
     # This step checks that we don't have drift between the docs.
     - name: Check that READMEs are in sync
+      working-directory: packages/python/sshnpd
       run: |
         diff <(tail -n +2 README.md) <(tail -n +2 README.PyPI.md)
 

--- a/.github/workflows/python_tests.yaml
+++ b/.github/workflows/python_tests.yaml
@@ -4,6 +4,9 @@ on:
     paths:
       - 'packages/python/**'
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   ruff:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_python_requirements.yml
+++ b/.github/workflows/update_python_requirements.yml
@@ -5,12 +5,15 @@ on:
       - 'packages/python/sshnpd/pyproject.toml'
   workflow_dispatch:
 
-permissions:
-  pull-requests: write
+# Declare default permissions as read only.
+permissions: read-all
 
 jobs:
   bump_requirements:
     runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
 
     steps:
     - name: Checkout this repo

--- a/.github/workflows/update_python_requirements.yml
+++ b/.github/workflows/update_python_requirements.yml
@@ -34,7 +34,7 @@ jobs:
       if: ${{ github.actor == 'dependabot[bot]' }}
       uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439 # v3.0.0
       with:
-        poetry-version: '1.8.2'
+        poetry-version: '1.8.3'
 
     - name: Bump sshnpd Python dependencies
       working-directory: packages/python/sshnpd


### PR DESCRIPTION
Python releases broken by doing diff in wrong directory

**- What I did**

* Added working directory so diff happens in right place
* Minimised token permissions

**- How to verify it**

I'll redo the p0.4.8 release

**- Description for the changelog**

fix: Working directory for PyPI README diff