### PR TITLE
fix: Working directory for README generation

### DIFF
--- a/.github/workflows/python-sshnpd-build-publish.yml
+++ b/.github/workflows/python-sshnpd-build-publish.yml
@@ -37,6 +37,7 @@ jobs:
     # That README is generated here from a stub header line plus the rest
     # of the main README.md
     - name: Generate README for PyPI
+      working-directory: packages/python/sshnpd
       run: |
         mv README.PyPI.md.stub README.PyPI.md
         tail -n +2 README.md >> README.PyPI.md


### PR DESCRIPTION
YAML block was missing `working-directory`

**- What I did**

Added back working-directory

**- How I did it**

Copied it over from git history

**- How to verify it**

python build-publish workflow should run OK this time

**- Description for the changelog**

fix: Working directory for README generation