### PR TITLE
ci: Add SBOMs and SLSA attestation to Dart and Python releases

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -219,18 +219,32 @@ jobs:
 
   github-release:
     name: >-
-      Sign the binary tarballs with Sigstore
-      and upload them to GitHub Release
+      Upload artifacts and generate SBOMs and checksums for provenance
     needs: [main_build, other_build, universal_sh]
     runs-on: ubuntu-latest
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     permissions:
       contents: write  # Mandatory for making GitHub Releases
       id-token: write  # Mandatory for sigstore
+      attestations: write
     steps:
+    - name: Checkout pubspec.lock
+      uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      with:
+        sparse-checkout: packages/dart/sshnoports/pubspec.lock
+        sparse-checkout-cone-mode: false
+    - name: Install Syft
+      uses: anchore/sbom-action/download-syft@7ccf588e3cf3cc2611714c2eeae48550fbc17552 # v0.15.11
     - name: Download all the tarballs
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
       with:
         path: tarballs/
+    - name: Generate SBOMs
+      run: |
+        syft scan file:./packages/dart/sshnoports/pubspec.lock \
+          -o 'spdx-json=tarballs/dart_sshnoports_sbom.spdx.json' \
+          -o 'cyclonedx-json=tarballs/dart_sshnoports_sbom.cyclonedx.json'
     - name: Move packages for signing
       run: |
         cd tarballs
@@ -238,23 +252,38 @@ jobs:
         mv */*.tgz .
         mv */*.zip .
         rm -Rf -- */
-    - name: Sign the tarballs with Sigstore
-      uses: sigstore/gh-action-sigstore-python@61f6a500bbfdd9a2a339cf033e5421951fbc1cd2 # v2.1.1
-      with:
-        inputs: >-
-          ./tarballs/*.sh
-          ./tarballs/*.tgz
-          ./tarballs/*.zip
-    - name: Upload artifact signatures to GitHub Release
+    - name: Generate SHA256 checksums
+      working-directory: tarballs
+      run: sha256sum * > checksums.txt
+    - name: Upload artifacts to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}
       # Upload to GitHub Release using the `gh` CLI.
       # `tarballs/` contains the built packages, and the
-      # sigstore-produced signatures and certificates.
+      # Syft produced SBOMs
       run: >-
         gh release upload
         '${{ github.ref_name }}' tarballs/**
         --repo '${{ github.repository }}'
+    - id: hash
+      name: Pass artifact hashes for SLSA provenance
+      working-directory: tarballs
+      run: |
+        echo "hashes=$(cat checksums.txt | base64 -w0)" >> "$GITHUB_OUTPUT"
+    - uses: actions/attest-build-provenance@f8d5ea8082b0d9f5ab855907be308fbd7eefb155 # v1.1.0
+      with:
+        subject-path: 'tarballs/**'
+
+  provenance:
+    needs: [github-release]
+    permissions:
+      actions: read # Needed for detection of GitHub Actions environment.
+      id-token: write # Needed for provenance signing and ID
+      contents: write # Needed for release uploads
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0 # 5a775b367a56d5bd118a224a811bba288150a563
+    with:
+      base64-subjects: "${{ needs.github-release.outputs.hashes }}"
+      upload-assets: true
 
   cleanup:
     name: Clean up temporary branch

--- a/.github/workflows/python-sshnpd-build-publish.yml
+++ b/.github/workflows/python-sshnpd-build-publish.yml
@@ -101,36 +101,63 @@ jobs:
       uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # v1.8.14
 
   github-release:
-    name: >-
-      Sign the Python distribution with Sigstore
-      and upload them to GitHub Release
+    name: Attest Python distribution artifacts and upload them to the GitHub Release
     needs:
     - publish-to-pypi
     runs-on: ubuntu-latest
-
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
       id-token: write  # IMPORTANT: mandatory for sigstore
-
+      attestations: write
     steps:
+    - name: Checkout requirements.txt
+      uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      with:
+        sparse-checkout: packages/python/sshnpd/requirements.txt
+        sparse-checkout-cone-mode: false
     - name: Download all the dists
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
       with:
         name: sshnpd-python-package
         path: dist/
-    - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@61f6a500bbfdd9a2a339cf033e5421951fbc1cd2 # v2.1.1
+    - name: Install Syft
+      uses: anchore/sbom-action/download-syft@7ccf588e3cf3cc2611714c2eeae48550fbc17552 # v0.15.11
+    - name: Generate SBOMs
+      run: |
+        syft scan file:./packages/python/sshnpd/requirements.txt \
+          -o 'spdx-json=dist/python_sshnpd_sbom.spdx.json' \
+          -o 'cyclonedx-json=dist/python_sshnpd_sbom.cyclonedx.json'
+    - name: Generate SHA256 checksums
+      working-directory: dist
+      run: sha256sum * > checksums.txt
+    - id: hash
+      name: Pass artifact hashes for SLSA provenance
+      working-directory: dist
+      run: |
+        echo "hashes=$(cat checksums.txt | base64 -w0)" >> "$GITHUB_OUTPUT"
+    - name: Attest the release artifacts
+      uses: actions/attest-build-provenance@f8d5ea8082b0d9f5ab855907be308fbd7eefb155 # v1.1.0
       with:
-        inputs: >-
-          ./dist/*.tar.gz
-          ./dist/*.whl
+        subject-path: 'dist/**'
     - name: Upload artifact signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}
       # Upload to GitHub Release using the `gh` CLI.
-      # `dist/` contains the built packages, and the
-      # sigstore-produced signatures and certificates.
+      # `dist/` contains the built packages
       run: >-
         gh release upload
         '${{ github.ref_name }}' dist/**
         --repo '${{ github.repository }}'
+
+  provenance:
+    needs: [github-release]
+    permissions:
+      actions: read # Needed for detection of GitHub Actions environment.
+      id-token: write # Needed for provenance signing and ID
+      contents: write # Needed for release uploads
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0 # 5a775b367a56d5bd118a224a811bba288150a563
+    with:
+      base64-subjects: "${{ needs.github-release.outputs.hashes }}"
+      upload-assets: true

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![GitHub License](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/noports/badge)](https://securityscorecards.dev/viewer/?uri=github.com/atsign-foundation/noports&sort_by=check-score&sort_direction=desc)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8102/badge)](https://www.bestpractices.dev/projects/8102)
+[![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 
 # noports
 This repo contains the open source code of the Atsign's No Ports suite. Check out our product site at [noports.com](https://noports.com).

--- a/packages/dart/sshnoports/README.md
+++ b/packages/dart/sshnoports/README.md
@@ -2,6 +2,7 @@
 
 [![GitHub License](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/noports/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/noports)
+[![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 
 # SSH! No ports
 

--- a/packages/python/sshnpd/README.md
+++ b/packages/python/sshnpd/README.md
@@ -2,6 +2,7 @@
 
 [![GitHub License](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)
 [![PyPI version](https://badge.fury.io/py/sshnpd.svg)](https://badge.fury.io/py/sshnpd)
+[![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 
 # SSHNPD Python (beta)
 


### PR DESCRIPTION
Progresses https://github.com/atsign-foundation/operations/issues/133 and https://github.com/atsign-foundation/operations/issues/139

**- What I did**

* Added SBOMs
* GitHub attestation for artifacts
* SLSA attestation
* Removed .sigstore

**- How I did it**

Dart: Ran some tests in my [release_automation](https://github.com/cpswan/release_automation) repo and copied the working YAML back into multibuild

Python: Based on the work in at_python

**- How to verify it**

We'll have to do some (pre) releases

**- Description for the changelog**

ci: Add SBOMs and SLSA attestation to Dart and Python releases