### PR TITLE
build(deps): Remove Python examples directory from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,9 +31,7 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "pip"
-    directories:
-      - "/examples/automations/python/"
-      - "/packages/python/sshnpd/"
+    directory: "/packages/python/sshnpd/"
     schedule:
       interval: "daily"
     groups:


### PR DESCRIPTION
Dependabot is failing on Python right now as it's looking in the (now) removed examples for a requirements.txt

**- What I did**

Removed example directory

**- How to verify it**

Dependabot will run on merge - check in insights.

**- Description for the changelog**

build(deps): Remove Python examples directory from Dependabot
