### PR TITLE
fix: make the user own local/bin with sudo

### DIFF
--- a/packages/dart/sshnoports/bundles/shell/install.sh
+++ b/packages/dart/sshnoports/bundles/shell/install.sh
@@ -148,9 +148,14 @@ install_single_binary() {
     is_root &
     ! [ -f "$user_bin_dir/$1" ]
   then
-    mkdir -p "$user_bin_dir"
+    if ! [ -d "$user_bin_dir" ]; then
+      mkdir -p "$user_bin_dir"
+      chown -R $user:$user "$user_bin_dir"
+    fi
+
     if [ -f "$dest/$1" ]; then
       ln -sf "$dest/$1" "$user_bin_dir/$1"
+      chown $user:$user "$user_bin_dir/$1"
       echo "=> Linked $user_bin_dir/$1 to $dest/$1"
     else
       echo "Failed to link $user_bin_dir/$1 to $dest/$1:"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

closes #1013 

**- What I did**

- chown the ~/.local/bin dir & links inside if we are root


**- How I did it**

**- How to verify it**

- Not tested, please try these changes in the environments you encountered the issue @cconstab @cpswan 

**- Description for the changelog**
fix: make the user own local/bin with sudo
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
