### PR TITLE
feat: add --quiet flag to the sshnp and npt CLIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pubspec_overrides.yaml
 
 # Binaries build from dart/sshnoports
 packages/dart/sshnoports/bin/activate_cli
+packages/dart/sshnoports/bin/at_activate
 packages/dart/sshnoports/bin/demo/npa_cli
 packages/dart/sshnoports/bin/demo/sshnpa_always_deny
 packages/dart/sshnoports/bin/npt
@@ -15,6 +16,8 @@ packages/dart/sshnoports/bin/srv
 packages/dart/sshnoports/bin/srvd
 packages/dart/sshnoports/bin/sshnp
 packages/dart/sshnoports/bin/sshnpd
+
+packages/dart/sshnoports/build/
 
 # Jetbrains
 .idea/*

--- a/packages/dart/noports_core/lib/src/common/default_args.dart
+++ b/packages/dart/noports_core/lib/src/common/default_args.dart
@@ -8,6 +8,7 @@ class DefaultArgs {
   static const SupportedSshAlgorithm sshAlgorithm =
       SupportedSshAlgorithm.ed25519;
   static const bool verbose = false;
+  static const bool quiet = false;
   static const String rootDomain = 'root.atsign.org';
   static const SrvGenerator srvGenerator = Srv.exec;
   static const int remoteSshdPort = 22;

--- a/packages/dart/sshnoports/bin/npt.dart
+++ b/packages/dart/sshnoports/bin/npt.dart
@@ -11,6 +11,7 @@ import 'package:at_utils/at_logger.dart';
 import 'package:at_cli_commons/at_cli_commons.dart' as cli;
 import 'package:noports_core/npt.dart';
 import 'package:noports_core/sshnp_foundation.dart';
+import 'package:sshnoports/src/extended_arg_parser.dart';
 
 // local packages
 import 'package:sshnoports/src/print_version.dart';
@@ -148,7 +149,7 @@ void main(List<String> args) async {
         help: 'More logging',
       );
       parser.addFlag(
-        'quiet',
+        quietFlag,
         abbr: 'q',
         defaultsTo: DefaultArgs.quiet,
         negatable: false,
@@ -186,7 +187,7 @@ void main(List<String> args) async {
       perSessionStorage = parsedArgs['per-session-storage'];
       int localPort = int.parse(parsedArgs['local-port']);
       bool inline = !parsedArgs['exit-when-connected'];
-      bool quiet = parsedArgs['quiet'];
+      bool quiet = parsedArgs[quietFlag];
 
       // Windows will not let us delete files in use so
       // We will point storage to temp directory and let OS clean up

--- a/packages/dart/sshnoports/bin/npt.dart
+++ b/packages/dart/sshnoports/bin/npt.dart
@@ -147,6 +147,13 @@ void main(List<String> args) async {
         negatable: false,
         help: 'More logging',
       );
+      parser.addFlag(
+        'quiet',
+        abbr: 'q',
+        defaultsTo: DefaultArgs.quiet,
+        negatable: false,
+        help: 'Minimal logging',
+      );
       parser.addFlag('help',
           defaultsTo: false, negatable: false, help: 'Print usage');
 
@@ -179,6 +186,7 @@ void main(List<String> args) async {
       perSessionStorage = parsedArgs['per-session-storage'];
       int localPort = int.parse(parsedArgs['local-port']);
       bool inline = !parsedArgs['exit-when-connected'];
+      bool quiet = parsedArgs['quiet'];
 
       // Windows will not let us delete files in use so
       // We will point storage to temp directory and let OS clean up
@@ -248,9 +256,10 @@ void main(List<String> args) async {
 
       // A listen progress listener for the CLI
       // Will only log if verbose is false, since if verbose is true
-      // there will already be a boatload of log messages
+      // there will already be a boatload of log messages.
+      // However, will NOT log if the quiet flag has been set.
       void logProgress(String s) {
-        if (!verbose) {
+        if (!verbose && !quiet) {
           stderr.writeln('${DateTime.now()} : $s');
         }
       }

--- a/packages/dart/sshnoports/bin/sshnp.dart
+++ b/packages/dart/sshnoports/bin/sshnp.dart
@@ -109,7 +109,7 @@ void main(List<String> args) async {
         ),
       );
 
-      if (! argResults.wasParsed(SshnpArg.deviceArg.name)) {
+      if (!argResults.wasParsed(SshnpArg.deviceArg.name)) {
         stderr.write(chalk.red('Warning: '));
         stderr.writeln('Using default value of "${params.device}"'
             ' for optional arg "--${SshnpArg.deviceArg.name}".'
@@ -165,9 +165,10 @@ void main(List<String> args) async {
 
       // A listen progress listener for the CLI
       // Will only log if verbose is false, since if verbose is true
-      // there will already be a boatload of log messages
+      // there will already be a boatload of log messages.
+      // However, will NOT log if the quiet flag has been set.
       void logProgress(String s) {
-        if (!(params?.verbose ?? true)) {
+        if (params?.verbose == false && argResults[quietFlag] == false) {
           stderr.writeln('${DateTime.now()} : $s');
         }
       }

--- a/packages/dart/sshnoports/buildArchive
+++ b/packages/dart/sshnoports/buildArchive
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Run this in order to create a local archive that can be used when testing universal.sh
+scriptName=$(basename -- "$0")
+cd "$(dirname -- "$0")" || exit 1
+packageDir=$(pwd)
+
+echo "$(date) : Starting compilation"
+echo
+
+rm -rf build/sshnp
+mkdir -p build/sshnp
+
+echo "Compiling at_activate"; dart compile exe --verbosity error bin/activate_cli.dart -o build/sshnp/at_activate &
+echo "Compiling srv"; dart compile exe --verbosity error bin/srv.dart -o build/sshnp/srv &
+echo "Compiling sshnpd"; dart compile exe --verbosity error bin/sshnpd.dart -o build/sshnp/sshnpd &
+echo "Compiling srvd"; dart compile exe --verbosity error bin/srvd.dart -o build/sshnp/srvd &
+echo "Compiling sshnp"; dart compile exe --verbosity error bin/sshnp.dart -o build/sshnp/sshnp &
+echo "Compiling npt"; dart compile exe --verbosity error bin/npt.dart -o build/sshnp/npt &
+
+wait
+
+echo
+echo "$(date) : Compilation complete"
+
+
+echo "$(date) : Copying bundles"
+cp -r bundles/core/* build/sshnp/
+cp -r bundles/shell/* build/sshnp/
+cp LICENSE build/sshnp
+
+cd build
+
+case "$(uname)" in
+  Darwin)
+    echo "$(date) : Creating zip"
+    ditto -c -k --keepParent sshnp sshnp.zip
+    echo "$(date) : Created $packageDir/build/sshnp.zip"
+    ;;
+  Linux)
+    echo "$(date) : Creating tgz"
+    tar -cvzf sshnp.tgz sshnp
+    echo "$(date) : Created $packageDir/build/sshnp.tgz"
+    ;;
+  *)
+    echo "buildLocalTarballs does not support this platform: $(uname)"
+    ;;
+esac
+

--- a/packages/dart/sshnoports/buildBinaries
+++ b/packages/dart/sshnoports/buildBinaries
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-echo Starting at `date`
+echo Starting at $(date)
 echo
 
-echo "Compiling activate_cli"; dart compile exe --verbosity error bin/activate_cli.dart -o bin/activate_cli &
+echo "Compiling at_activate"; dart compile exe --verbosity error bin/activate_cli.dart -o bin/at_activate &
 echo "Compiling srv"; dart compile exe --verbosity error bin/srv.dart -o bin/srv &
 echo "Compiling sshnpd"; dart compile exe --verbosity error bin/sshnpd.dart -o bin/sshnpd &
 echo "Compiling srvd"; dart compile exe --verbosity error bin/srvd.dart -o bin/srvd &
@@ -15,4 +15,4 @@ echo "Compiling demo/npa_cli"; dart compile exe --verbosity error bin/demo/npa_c
 wait
 
 echo 
-echo Finished at `date`
+echo Finished at $(date)

--- a/packages/dart/sshnoports/lib/src/extended_arg_parser.dart
+++ b/packages/dart/sshnoports/lib/src/extended_arg_parser.dart
@@ -6,10 +6,12 @@ const sshClients = ['openssh', 'dart'];
 class DefaultExtendedArgs {
   static const sshClient = SupportedSshClient.openssh;
   static const outputExecutionCommand = false;
+  static const quiet = false;
 }
 
 const sshClientOption = 'ssh-client';
 const outputExecutionCommandFlag = 'output-execution-command';
+const quietFlag = 'quiet';
 
 class ExtendedArgParser {
   static ArgParser createArgParser({int? usageLineLength}) {
@@ -30,6 +32,14 @@ class ExtendedArgParser {
       abbr: 'x',
       help: 'Output the command that would be executed, and exit',
       defaultsTo: DefaultExtendedArgs.outputExecutionCommand,
+      negatable: false,
+    );
+
+    parser.addFlag(
+      quietFlag,
+      abbr: 'q',
+      help: 'Minimal logging',
+      defaultsTo: DefaultExtendedArgs.quiet,
       negatable: false,
     );
 

--- a/packages/dart/sshnoports/lib/src/extended_arg_parser.dart
+++ b/packages/dart/sshnoports/lib/src/extended_arg_parser.dart
@@ -89,6 +89,11 @@ class ExtendedArgParser {
       coreArgs.removeWhere((element) => element == '-x');
     }
 
+    if (results!.wasParsed(quietFlag)) {
+      coreArgs.removeWhere((element) => element == '--$quietFlag');
+      coreArgs.removeWhere((element) => element == '-q');
+    }
+
     return coreArgs;
   }
 }

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -907,4 +907,4 @@ packages:
     source: hosted
     version: "0.2.3"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"

--- a/packages/dart/sshnp_flutter/pubspec.lock
+++ b/packages/dart/sshnp_flutter/pubspec.lock
@@ -675,26 +675,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -747,10 +747,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -1207,10 +1207,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   tutorial_coach_mark:
     dependency: transitive
     description:
@@ -1343,10 +1343,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
**- What I did**
- feat: add --quiet flag to the sshnp and npt CLIs

Other stuff, not directly related to the feature
- build: updated pubspec.lock files via dart run melos bootstrap
- fix: Modify buildBinaries script so it produces a binary called at_activate, as our actual build processes do. And add it to .gitignore
- feat: In order to make local testing of the installer easier, add a buildArchive script which creates a zip or tgz in the same way as our gh actions do for releases. The script creates a build/ directory in the packages/dart/sshnoports directory; add that build/ directory to .gitignore

**- How I did it**
See commits

**- How to verify it**
Tests pass

