### PR TITLE
feat: make daemon storage location map to its device name

### DIFF
--- a/packages/dart/noports_core/lib/src/common/default_args.dart
+++ b/packages/dart/noports_core/lib/src/common/default_args.dart
@@ -4,6 +4,7 @@ import 'package:noports_core/srv.dart';
 
 class DefaultArgs {
   static const String namespace = 'sshnp';
+  @Deprecated("No longer used")
   static const String storagePathSubDirectory = '.sshnp';
   static const SupportedSshAlgorithm sshAlgorithm =
       SupportedSshAlgorithm.ed25519;

--- a/packages/dart/noports_core/lib/src/common/file_system_utils.dart
+++ b/packages/dart/noports_core/lib/src/common/file_system_utils.dart
@@ -1,6 +1,21 @@
 import 'package:noports_core/src/common/io_types.dart';
 import 'package:path/path.dart' as path;
 
+/// $homeDirectory/.atsign/storage/$atSign/.$progName/$uniqueID
+String standardAtClientStoragePath({
+  required String homeDirectory,
+  required String atSign,
+  required String progName, // e.g. npt, sshnp, sshnpd, srvd etc
+  required String uniqueID,
+}) {
+  return path.normalize('$homeDirectory'
+      '/.atsign'
+      '/storage'
+      '/$atSign'
+      '/.$progName'
+      '/$uniqueID');
+}
+
 /// Get the home directory or null if unknown.
 String? getHomeDirectory({bool throwIfNull = false}) {
   String? homeDir;

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
@@ -24,7 +24,7 @@ class SshnpdParams {
   final String ephemeralPermissions;
   final SupportedSshAlgorithm sshAlgorithm;
   final String deviceGroup;
-  final String? storagePath;
+  final String storagePath;
   final String permitOpen;
 
   // Non param variables
@@ -121,7 +121,12 @@ class SshnpdParams {
       ephemeralPermissions: r['ephemeral-permissions'],
       sshAlgorithm: SupportedSshAlgorithm.fromString(r['ssh-algorithm']),
       deviceGroup: r['device-group'],
-      storagePath: r['storage-path'],
+      storagePath: r['storage-path'] ??
+          standardAtClientStoragePath(
+              homeDirectory: homeDirectory,
+              atSign: deviceAtsign,
+              progName: '.sshnpd',
+              uniqueID: r['device']),
       permitOpen: r['permit-open'],
     );
   }
@@ -275,7 +280,7 @@ class SshnpdParams {
       'storage-path',
       mandatory: false,
       help: 'Directory for local storage.'
-          r' Defaults to $HOME/.sshnp/${atSign}/storage',
+          r' Defaults to $HOME/.atsign/storage/$atSign/.npd/$deviceName/',
     );
 
     parser.addOption(

--- a/packages/dart/sshnoports/bin/npt.dart
+++ b/packages/dart/sshnoports/bin/npt.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 
 // other packages
 import 'package:args/args.dart';
-import 'package:path/path.dart' as path;
 
 // atPlatform packages
 import 'package:at_utils/at_logger.dart';
@@ -193,24 +192,26 @@ void main(List<String> args) async {
       // We will point storage to temp directory and let OS clean up
       var clientAtSign = parsedArgs['from'];
 
-      late String storageDirLastPart;
+      late String uniqueID;
       if (perSessionStorage) {
-        storageDirLastPart = DateTime.now().millisecondsSinceEpoch.toString();
+        uniqueID = DateTime.now().millisecondsSinceEpoch.toString();
       } else {
-        storageDirLastPart = 'single';
+        uniqueID = 'single';
       }
       if (Platform.isWindows) {
-        storageDir = Directory(path.normalize('${Platform.environment['TEMP']}'
-            '/${DefaultArgs.storagePathSubDirectory}'
-            '/$clientAtSign'
-            '/storage'
-            '/$storageDirLastPart'));
+        storageDir = Directory(standardAtClientStoragePath(
+          homeDirectory: Platform.environment['TEMP']!,
+          atSign: clientAtSign,
+          progName: '.npt',
+          uniqueID: uniqueID,
+        ));
       } else {
-        storageDir = Directory(path.normalize('$homeDirectory'
-            '/${DefaultArgs.storagePathSubDirectory}'
-            '/$clientAtSign'
-            '/storage'
-            '/$storageDirLastPart'));
+        storageDir = Directory(standardAtClientStoragePath(
+          homeDirectory: homeDirectory,
+          atSign: clientAtSign,
+          progName: '.npt',
+          uniqueID: uniqueID,
+        ));
       }
       storageDir?.createSync(recursive: true);
 

--- a/packages/dart/sshnoports/bin/srvd.dart
+++ b/packages/dart/sshnoports/bin/srvd.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'package:at_utils/at_logger.dart';
 import 'package:noports_core/srvd.dart';
+import 'package:noports_core/utils.dart';
 import 'package:sshnoports/src/create_at_client_cli.dart';
 import 'package:sshnoports/src/print_version.dart';
 import 'package:sshnoports/src/service_factories.dart';
@@ -15,8 +16,11 @@ void main(List<String> args) async {
     srvd = await Srvd.fromCommandLineArgs(
       args,
       atClientGenerator: (SrvdParams p) => createAtClientCli(
-        homeDirectory: p.homeDirectory,
-        subDirectory: '.srvd',
+        storagePath: standardAtClientStoragePath(
+            homeDirectory: p.homeDirectory,
+            atSign: p.atSign,
+            progName: '.srvd',
+            uniqueID: 'single'),
         atsign: p.atSign,
         atKeysFilePath: p.atKeysFilePath,
         namespace: Srvd.namespace,

--- a/packages/dart/sshnoports/bin/sshnp.dart
+++ b/packages/dart/sshnoports/bin/sshnp.dart
@@ -5,7 +5,6 @@ import 'dart:typed_data';
 
 // other packages
 import 'package:chalkdart/chalk.dart';
-import 'package:path/path.dart' as path;
 import 'package:dartssh2/dartssh2.dart';
 
 // atPlatform packages
@@ -120,17 +119,19 @@ void main(List<String> args) async {
       // Windows will not let us delete files in use so
       // We will point storage to temp directory and let OS clean up
       if (Platform.isWindows) {
-        storageDir = Directory(path.normalize('${Platform.environment['TEMP']}'
-            '/${DefaultArgs.storagePathSubDirectory}'
-            '/${params.clientAtSign}'
-            '/storage'
-            '/${DateTime.now().millisecondsSinceEpoch}'));
+        storageDir = Directory(standardAtClientStoragePath(
+          homeDirectory: Platform.environment['TEMP']!,
+          atSign: params.clientAtSign,
+          progName: '.sshnp',
+          uniqueID: '${DateTime.now().millisecondsSinceEpoch}',
+        ));
       } else {
-        storageDir = Directory(path.normalize('$homeDirectory'
-            '/${DefaultArgs.storagePathSubDirectory}'
-            '/${params.clientAtSign}'
-            '/storage'
-            '/${DateTime.now().millisecondsSinceEpoch}'));
+        storageDir = Directory(standardAtClientStoragePath(
+          homeDirectory: homeDirectory,
+          atSign: params.clientAtSign,
+          progName: '.sshnp',
+          uniqueID: '${DateTime.now().millisecondsSinceEpoch}',
+        ));
       }
       storageDir!.createSync(recursive: true);
       final sigintListener = ProcessSignal.sigint.watch().listen((signal) {
@@ -146,12 +147,12 @@ void main(List<String> args) async {
       final sshnp = await createSshnp(
         params,
         atClientGenerator: (SshnpParams params) => createAtClientCli(
-          homeDirectory: homeDirectory,
           atsign: params.clientAtSign,
           atKeysFilePath: params.atKeysFilePath ??
               getDefaultAtKeysFilePath(homeDirectory, params.clientAtSign),
           rootDomain: params.rootDomain,
           storagePath: storageDir!.path,
+          namespace: DefaultArgs.namespace,
           atServiceFactory: ServiceFactoryWithNoOpSyncService(),
         ),
         sshClient:

--- a/packages/dart/sshnoports/bin/sshnpd.dart
+++ b/packages/dart/sshnoports/bin/sshnpd.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'package:at_utils/at_logger.dart';
+import 'package:noports_core/sshnp_foundation.dart';
 import 'package:noports_core/sshnpd.dart';
 import 'package:sshnoports/src/create_at_client_cli.dart';
 import 'package:sshnoports/src/print_version.dart';
@@ -16,11 +17,11 @@ void main(List<String> args) async {
     sshnpd = await Sshnpd.fromCommandLineArgs(
       args,
       atClientGenerator: (SshnpdParams p) => createAtClientCli(
-        homeDirectory: p.homeDirectory,
         atsign: p.deviceAtsign,
         atKeysFilePath: p.atKeysFilePath,
         rootDomain: p.rootDomain,
         storagePath: p.storagePath,
+        namespace: DefaultArgs.namespace,
         atServiceFactory: ServiceFactoryWithNoOpSyncService(),
       ),
       usageCallback: (e, s) {

--- a/packages/dart/sshnoports/lib/npa_bootstrapper.dart
+++ b/packages/dart/sshnoports/lib/npa_bootstrapper.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'package:at_utils/at_logger.dart';
 import 'package:noports_core/npa.dart';
+import 'package:noports_core/utils.dart';
 import 'package:sshnoports/src/create_at_client_cli.dart';
 import 'package:sshnoports/src/print_version.dart';
 import 'package:sshnoports/src/service_factories.dart';
@@ -17,11 +18,16 @@ Future<void> run(
       commandLineArgs,
       handler: handler,
       atClientGenerator: (NPAParams p) => createAtClientCli(
-        homeDirectory: p.homeDirectory,
         atsign: p.authorizerAtsign,
         atKeysFilePath: p.atKeysFilePath,
         rootDomain: p.rootDomain,
         atServiceFactory: ServiceFactoryWithNoOpSyncService(),
+        namespace: DefaultArgs.namespace,
+        storagePath: standardAtClientStoragePath(
+            homeDirectory: p.homeDirectory,
+            atSign: p.authorizerAtsign,
+            progName: '.${DefaultArgs.namespace}',
+            uniqueID: 'single'),
       ),
       usageCallback: (e, s) {
         printVersion();

--- a/packages/dart/sshnoports/lib/src/create_at_client_cli.dart
+++ b/packages/dart/sshnoports/lib/src/create_at_client_cli.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:at_client/at_client.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
 import 'package:noports_core/utils.dart';
@@ -6,27 +5,19 @@ import 'package:version/version.dart';
 import 'package:path/path.dart' as path;
 
 Future<AtClient> createAtClientCli({
-  required String homeDirectory,
   required String atsign,
   required String atKeysFilePath,
   required AtServiceFactory atServiceFactory,
-  String? storagePath,
-  String? pathExtension,
-  String subDirectory = DefaultArgs.storagePathSubDirectory,
-  String namespace = DefaultArgs.namespace,
+  required String storagePath,
+  required String namespace,
   String rootDomain = DefaultArgs.rootDomain,
 }) async {
   // Now on to the atPlatform startup
   //onboarding preference builder can be used to set onboardingService parameters
-  String pathBase = '$homeDirectory/$subDirectory/$atsign/';
-  if (pathExtension != null) {
-    pathBase += '$pathExtension${Platform.pathSeparator}';
-  }
-  storagePath ??= path.normalize('$pathBase/storage');
   AtOnboardingPreference atOnboardingConfig = AtOnboardingPreference()
     ..hiveStoragePath = storagePath
     ..namespace = namespace
-    ..downloadPath = path.normalize('$homeDirectory/$subDirectory/files')
+    ..downloadPath = path.normalize('$storagePath/downloads')
     ..isLocalStoreRequired = true
     ..commitLogPath = path.normalize('$storagePath/commitLog')
     ..fetchOfflineNotifications = false


### PR DESCRIPTION
**- What I did**
- feat: make daemon storage location map to its device name
- Closes #1038 

**- How I did it**
Modified a bunch of code related to generating a canonical AtClient storage path / creating an AtClient using that storage path

**- How to verify it**
Tests pass
