### PR TITLE
feat: set a 1-minute ttln (notification time-to-live)

### DIFF
--- a/packages/dart/noports_core/lib/src/common/mixins/at_client_bindings.dart
+++ b/packages/dart/noports_core/lib/src/common/mixins/at_client_bindings.dart
@@ -11,9 +11,11 @@ mixin AtClientBindings {
     String value, {
     required bool checkForFinalDeliveryStatus,
     required bool waitForFinalDeliveryStatus,
+    required Duration ttln,
   }) async {
     await atClient.notificationService.notify(
-      NotificationParams.forUpdate(atKey, value: value),
+      NotificationParams.forUpdate(atKey,
+          value: value, notificationExpiry: ttln),
       checkForFinalDeliveryStatus: checkForFinalDeliveryStatus,
       waitForFinalDeliveryStatus: waitForFinalDeliveryStatus,
       onSuccess: (NotificationResult notification) {

--- a/packages/dart/noports_core/lib/src/npt/npt.dart
+++ b/packages/dart/noports_core/lib/src/npt/npt.dart
@@ -236,6 +236,7 @@ class _NptImpl extends NptBase
           ).toJson()),
       checkForFinalDeliveryStatus: false,
       waitForFinalDeliveryStatus: false,
+      ttln: Duration(minutes: 1),
     );
 
     /// Wait for a response from sshnpd

--- a/packages/dart/noports_core/lib/src/srvd/srvd_impl.dart
+++ b/packages/dart/noports_core/lib/src/srvd/srvd_impl.dart
@@ -183,7 +183,8 @@ class SrvdImpl implements Srvd {
 
     try {
       await atClient.notificationService.notify(
-          NotificationParams.forUpdate(atKey, value: data),
+          NotificationParams.forUpdate(atKey,
+              value: data, notificationExpiry: Duration(minutes: 1)),
           waitForFinalDeliveryStatus: false,
           checkForFinalDeliveryStatus: false);
     } catch (e) {

--- a/packages/dart/noports_core/lib/src/sshnp/impl/sshnp_dart_pure_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/impl/sshnp_dart_pure_impl.dart
@@ -86,6 +86,7 @@ class SshnpDartPureImpl extends SshnpCore
           ).toJson()),
       checkForFinalDeliveryStatus: false,
       waitForFinalDeliveryStatus: false,
+      ttln: Duration(minutes: 1),
     );
 
     /// Wait for a response from sshnpd

--- a/packages/dart/noports_core/lib/src/sshnp/impl/sshnp_openssh_local_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/impl/sshnp_openssh_local_impl.dart
@@ -78,6 +78,7 @@ class SshnpOpensshLocalImpl extends SshnpCore
           ).toJson()),
       checkForFinalDeliveryStatus: false,
       waitForFinalDeliveryStatus: false,
+      ttln: Duration(minutes: 1),
     );
 
     /// Wait for a response from sshnpd

--- a/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/srvd_channel.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/srvd_channel.dart
@@ -194,6 +194,7 @@ abstract class SrvdChannel<T> with AsyncInitialization, AtClientBindings {
       rvdRequestValue,
       checkForFinalDeliveryStatus: false,
       waitForFinalDeliveryStatus: false,
+      ttln: Duration(minutes: 1),
     );
 
     int counter = 1;

--- a/packages/dart/noports_core/lib/src/sshnp/util/sshnpd_channel/sshnpd_channel.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/sshnpd_channel/sshnpd_channel.dart
@@ -139,6 +139,7 @@ abstract class SshnpdChannel with AsyncInitialization, AtClientBindings {
       publicKeyContents,
       checkForFinalDeliveryStatus: false,
       waitForFinalDeliveryStatus: false,
+      ttln: Duration(minutes: 1),
     ).onError((e, st) {
       throw SshnpError('Error sending ssh public key to sshnpd: $e');
     }));
@@ -245,6 +246,7 @@ abstract class SshnpdChannel with AsyncInitialization, AtClientBindings {
       'ping',
       checkForFinalDeliveryStatus: false,
       waitForFinalDeliveryStatus: false,
+      ttln: Duration(minutes: 1),
     );
 
     return completer.future;
@@ -354,6 +356,7 @@ abstract class SshnpdChannel with AsyncInitialization, AtClientBindings {
         'ping',
         checkForFinalDeliveryStatus: false,
         waitForFinalDeliveryStatus: false,
+        ttln: Duration(minutes: 1),
       ));
     }
 

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -378,6 +378,7 @@ class SshnpdImpl implements Sshnpd {
         value: jsonEncode(pingResponse),
         checkForFinalDeliveryStatus: false,
         waitForFinalDeliveryStatus: false,
+        ttln: Duration(minutes: 1),
       ),
     );
   }
@@ -458,6 +459,7 @@ class SshnpdImpl implements Sshnpd {
         sessionId: req.sessionId,
         checkForFinalDeliveryStatus: false,
         waitForFinalDeliveryStatus: false,
+        ttln: Duration(minutes: 1),
       );
 
       return;
@@ -476,6 +478,7 @@ class SshnpdImpl implements Sshnpd {
         sessionId: req.sessionId,
         checkForFinalDeliveryStatus: false,
         waitForFinalDeliveryStatus: false,
+        ttln: Duration(minutes: 1),
       );
 
       return;
@@ -571,6 +574,7 @@ class SshnpdImpl implements Sshnpd {
         checkForFinalDeliveryStatus: false,
         waitForFinalDeliveryStatus: false,
         sessionId: req.sessionId,
+        ttln: Duration(minutes: 1),
       );
     } catch (e) {
       logger.severe('startNpt failed with unexpected error : $e');
@@ -583,6 +587,7 @@ class SshnpdImpl implements Sshnpd {
         sessionId: req.sessionId,
         checkForFinalDeliveryStatus: false,
         waitForFinalDeliveryStatus: false,
+        ttln: Duration(minutes: 1),
       );
     }
   }
@@ -822,6 +827,7 @@ class SshnpdImpl implements Sshnpd {
         checkForFinalDeliveryStatus: false,
         waitForFinalDeliveryStatus: false,
         sessionId: sessionId,
+        ttln: Duration(minutes: 1),
       );
 
       /// - start a timer to remove the ephemeral key from `authorized_keys`
@@ -839,6 +845,7 @@ class SshnpdImpl implements Sshnpd {
         sessionId: sessionId,
         checkForFinalDeliveryStatus: false,
         waitForFinalDeliveryStatus: false,
+        ttln: Duration(minutes: 1),
       );
     }
   }
@@ -894,6 +901,7 @@ class SshnpdImpl implements Sshnpd {
           sessionId: sessionId,
           checkForFinalDeliveryStatus: false,
           waitForFinalDeliveryStatus: false,
+          ttln: Duration(minutes: 1),
         );
       } else {
         /// Notify sshnp that the connection has been made
@@ -904,6 +912,7 @@ class SshnpdImpl implements Sshnpd {
           sessionId: sessionId,
           checkForFinalDeliveryStatus: false,
           waitForFinalDeliveryStatus: false,
+          ttln: Duration(minutes: 1),
         );
       }
     } catch (e) {
@@ -916,6 +925,7 @@ class SshnpdImpl implements Sshnpd {
         sessionId: sessionId,
         checkForFinalDeliveryStatus: false,
         waitForFinalDeliveryStatus: false,
+        ttln: Duration(minutes: 1),
       );
     }
   }
@@ -1150,10 +1160,12 @@ class SshnpdImpl implements Sshnpd {
     required String value,
     required bool checkForFinalDeliveryStatus,
     required bool waitForFinalDeliveryStatus,
+    required Duration ttln,
     String sessionId = '',
   }) async {
     await atClient.notificationService.notify(
-      NotificationParams.forUpdate(atKey, value: value),
+      NotificationParams.forUpdate(atKey,
+          value: value, notificationExpiry: ttln),
       checkForFinalDeliveryStatus: checkForFinalDeliveryStatus,
       waitForFinalDeliveryStatus: waitForFinalDeliveryStatus,
       onSuccess: (notification) {
@@ -1192,7 +1204,12 @@ class SshnpdImpl implements Sshnpd {
         try {
           logger.info('Sharing username $username with $managerAtsign');
           await atClient.notificationService.notify(
-            NotificationParams.forUpdate(atKey, value: username),
+            NotificationParams.forUpdate(
+              atKey,
+              value: username,
+              // notification can expire rapidly, the info is being cached
+              notificationExpiry: Duration(minutes: 1),
+            ),
             waitForFinalDeliveryStatus: false,
             checkForFinalDeliveryStatus: false,
             onSuccess: (notification) {

--- a/packages/dart/noports_core/test/sshnp/sshnp_mocks.dart
+++ b/packages/dart/noports_core/test/sshnp/sshnp_mocks.dart
@@ -17,6 +17,7 @@ abstract class NotifyCaller {
     String value, {
     required bool checkForFinalDeliveryStatus,
     required bool waitForFinalDeliveryStatus,
+    required Duration ttln,
   });
 }
 

--- a/packages/dart/noports_core/test/sshnp/util/srvd_channel/srvd_channel_mocks.dart
+++ b/packages/dart/noports_core/test/sshnp/util/srvd_channel/srvd_channel_mocks.dart
@@ -30,6 +30,7 @@ class StubbedSrvdChannel<T> extends SrvdChannel<T> {
     String, {
     required bool checkForFinalDeliveryStatus,
     required bool waitForFinalDeliveryStatus,
+    required Duration ttln,
   })? _notify;
   final Stream<AtNotification> Function({String? regex, bool shouldDecrypt})?
       _subscribe;
@@ -44,6 +45,7 @@ class StubbedSrvdChannel<T> extends SrvdChannel<T> {
       String, {
       required bool checkForFinalDeliveryStatus,
       required bool waitForFinalDeliveryStatus,
+      required Duration ttln,
     })? notify,
     Stream<AtNotification> Function({String? regex, bool shouldDecrypt})?
         subscribe,
@@ -56,12 +58,14 @@ class StubbedSrvdChannel<T> extends SrvdChannel<T> {
     String value, {
     required bool checkForFinalDeliveryStatus,
     required bool waitForFinalDeliveryStatus,
+    required Duration ttln,
   }) async {
     return _notify?.call(
       atKey,
       value,
       checkForFinalDeliveryStatus: checkForFinalDeliveryStatus,
       waitForFinalDeliveryStatus: waitForFinalDeliveryStatus,
+      ttln: ttln,
     );
   }
 

--- a/packages/dart/noports_core/test/sshnp/util/srvd_channel/srvd_channel_test.dart
+++ b/packages/dart/noports_core/test/sshnp/util/srvd_channel/srvd_channel_test.dart
@@ -33,6 +33,7 @@ void main() {
           checkForFinalDeliveryStatus:
               any(named: 'checkForFinalDeliveryStatus'),
           waitForFinalDeliveryStatus: any(named: 'waitForFinalDeliveryStatus'),
+          ttln: any(named: 'ttln'),
         );
     subscribeInvocation() => subscribeStub(
           regex: any(named: 'regex'),
@@ -65,6 +66,7 @@ void main() {
       );
 
       registerFallbackValue(AtKey());
+      registerFallbackValue(Duration(minutes: 1));
       registerFallbackValue(NotificationParams.forUpdate(AtKey()));
 
       // Create an AtChops instance for testing
@@ -166,6 +168,7 @@ void main() {
                   any(named: 'checkForFinalDeliveryStatus'),
               waitForFinalDeliveryStatus:
                   any(named: 'waitForFinalDeliveryStatus'),
+              ttln: any(named: 'ttln'),
             ),
       ]);
 

--- a/packages/dart/noports_core/test/sshnp/util/sshnpd_channel/sshnpd_channel_mocks.dart
+++ b/packages/dart/noports_core/test/sshnp/util/sshnpd_channel/sshnpd_channel_mocks.dart
@@ -15,6 +15,7 @@ class StubbedSshnpdChannel extends SshnpdChannel {
     String, {
     required bool checkForFinalDeliveryStatus,
     required bool waitForFinalDeliveryStatus,
+    required Duration ttln,
   })? _notify;
   final Stream<AtNotification> Function({String? regex, bool shouldDecrypt})?
       _subscribe;
@@ -31,6 +32,7 @@ class StubbedSshnpdChannel extends SshnpdChannel {
       String, {
       required bool checkForFinalDeliveryStatus,
       required bool waitForFinalDeliveryStatus,
+      required Duration ttln,
     })? notify,
     Stream<AtNotification> Function({String? regex, bool shouldDecrypt})?
         subscribe,
@@ -52,12 +54,14 @@ class StubbedSshnpdChannel extends SshnpdChannel {
     String value, {
     required bool checkForFinalDeliveryStatus,
     required bool waitForFinalDeliveryStatus,
+    required Duration ttln,
   }) async {
     return _notify?.call(
       atKey,
       value,
       checkForFinalDeliveryStatus: checkForFinalDeliveryStatus,
       waitForFinalDeliveryStatus: waitForFinalDeliveryStatus,
+      ttln: ttln,
     );
   }
 

--- a/packages/dart/noports_core/test/sshnp/util/sshnpd_channel/sshnpd_channel_test.dart
+++ b/packages/dart/noports_core/test/sshnp/util/sshnpd_channel/sshnpd_channel_test.dart
@@ -32,6 +32,7 @@ void main() {
           checkForFinalDeliveryStatus:
               any(named: 'checkForFinalDeliveryStatus'),
           waitForFinalDeliveryStatus: any(named: 'waitForFinalDeliveryStatus'),
+          ttln: any(named: 'ttln'),
         );
     subscribeInvocation() => subscribeStub(
           regex: any(named: 'regex'),
@@ -64,6 +65,7 @@ void main() {
       );
 
       registerFallbackValue(AtKey());
+      registerFallbackValue(Duration(minutes: 1));
       registerFallbackValue(AtNotification.empty());
     });
 
@@ -223,6 +225,7 @@ void main() {
                 any(named: 'checkForFinalDeliveryStatus'),
             waitForFinalDeliveryStatus:
                 any(named: 'waitForFinalDeliveryStatus'),
+            ttln: any(named: 'ttln'),
           ),
         ).thenAnswer((_) async {});
 
@@ -242,6 +245,7 @@ void main() {
                 any(named: 'checkForFinalDeliveryStatus'),
             waitForFinalDeliveryStatus:
                 any(named: 'waitForFinalDeliveryStatus'),
+            ttln: any(named: 'ttln'),
           ),
         ).called(1);
       }); // test sharePublicKeyIfRequired


### PR DESCRIPTION
**- What I did**
- feat: set a 1-minute ttln (notification time-to-live) on all NoPorts notifications. Note that when using notifications to send info which is to be cached at the destination, the ttl on the value is separate from the ttln on the notification.
- closes #1091

**- How I did it**
See commits and diff comments

**- How to verify it**
Tests pass

