### PR TITLE
chore: Bump python package version to 0.4.11 for a patch release

### DIFF
--- a/packages/python/sshnpd/pyproject.toml
+++ b/packages/python/sshnpd/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sshnpd"
-version = "0.4.10"
+version = "0.4.11"
 description = "Python implementation of SSH No Ports daemon"
 authors = ["Xavier Lin <xavier.lin@atsign.com >"]
 maintainers = ["Chris Swan <chris@atsign.com>"]


### PR DESCRIPTION
After #1097 we need to do a patch release

**- What I did**

Bumped patch version

**- How to verify it**

A new release will happen to TestPyPI on merge

**- Description for the changelog**

chore: Bump python package version to 0.4.11 for a patch release
