### PR TITLE
ci: Add cppcheck for static analysis of C packages

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,27 @@
+name: Cppcheck
+on:
+  workflow_dispatch:
+  push:
+    branches: [trunk]
+    paths:
+      - '/packages/c/**'
+  pull_request:
+    branches: [trunk]
+    paths:
+      - '/packages/c/**'
+
+permissions:
+  contents: read
+
+jobs:
+  cppcheck:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./packages/c
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Cppcheck
+        run: |
+          sudo apt install -y cppcheck
+          cppcheck .


### PR DESCRIPTION
Ensuring that we have static analysis for all packages

**- What I did**

Added a cppcheck workflow that will run on PRs and pushes to the C packages

**- How I did it**

Copied from at_c and modified to match this repo's layout

**- How to verify it**

Will run when we make changes to c sshnpd

**- Description for the changelog**

ci: Add cppcheck for static analysis of C packages