### PR TITLE
fix: include .ps1 for signing

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -264,6 +264,7 @@ jobs:
       run: |
         cd tarballs
         mv */*.sh .
+        mv */*.ps1 .
         mv */*.tgz .
         mv */*.zip .
         rm -Rf -- */


### PR DESCRIPTION
**- What I did**
.ps1 extension is missing when moving artifacts to sign
**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: include .ps1 for signing