### PR TITLE
fix: C SSHNPD memory leaks before SSH connection established

### DIFF
--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -3,7 +3,7 @@ if(NOT atsdk_FOUND)
   FetchContent_Declare(
     atsdk
     GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-    GIT_TAG f1beb2dd28edd2584290e6916609e7c84c269f18
+    GIT_TAG 6149f13cf6491358a6fcfa9ddbb72d717d0561a9
   )
   FetchContent_MakeAvailable(atsdk)
   install(TARGETS atclient atchops atlogger)

--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -3,7 +3,7 @@ if(NOT atsdk_FOUND)
   FetchContent_Declare(
     atsdk
     GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-    GIT_TAG 6b6f1e0338e2f5de3b6b4c800104711ffa794c72
+    GIT_TAG 620e217f7f2123f96a1539958bca9156ad1ff687
   )
   FetchContent_MakeAvailable(atsdk)
   install(TARGETS atclient atchops atlogger)

--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -3,7 +3,7 @@ if(NOT atsdk_FOUND)
   FetchContent_Declare(
     atsdk
     GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-    GIT_TAG 21e195721a757637c487c00d73106901d434186f
+    GIT_TAG 6b6f1e0338e2f5de3b6b4c800104711ffa794c72
   )
   FetchContent_MakeAvailable(atsdk)
   install(TARGETS atclient atchops atlogger)

--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -3,7 +3,7 @@ if(NOT atsdk_FOUND)
   FetchContent_Declare(
     atsdk
     GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-    GIT_TAG 620e217f7f2123f96a1539958bca9156ad1ff687
+    GIT_TAG f1beb2dd28edd2584290e6916609e7c84c269f18
   )
   FetchContent_MakeAvailable(atsdk)
   install(TARGETS atclient atchops atlogger)

--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -3,7 +3,7 @@ if(NOT atsdk_FOUND)
   FetchContent_Declare(
     atsdk
     GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-    GIT_TAG 6149f13cf6491358a6fcfa9ddbb72d717d0561a9
+    GIT_TAG dcda1141adc18b8be6608d2849de833c4f959005
   )
   FetchContent_MakeAvailable(atsdk)
   install(TARGETS atclient atchops atlogger)

--- a/packages/c/sshnpd/include/sshnpd/handle_ssh_request.h
+++ b/packages/c/sshnpd/include/sshnpd/handle_ssh_request.h
@@ -5,6 +5,6 @@
 #include <pthread.h>
 
 void handle_ssh_request(atclient *atclient, pthread_mutex_t *atclient_lock, sshnpd_params *params,
-                        atclient_monitor_message *message, char *home_dir, FILE *authkeys_file, char *authkeys_filename,
-                        atchops_rsakey_privatekey signing_key);
+                        bool *is_child_process, atclient_monitor_message *message, char *home_dir, FILE *authkeys_file,
+                        char *authkeys_filename, atchops_rsakey_privatekey signing_key);
 #endif

--- a/packages/c/sshnpd/include/sshnpd/run_srv_process.h
+++ b/packages/c/sshnpd/include/sshnpd/run_srv_process.h
@@ -5,9 +5,7 @@
 #include <cJSON.h>
 #include <stdio.h>
 
-// This function should only be called from a child fork.
-// It finishes by calling exit, and doesn't cleanup allocated memory
-void run_srv_process(sshnpd_params *params, cJSON *host, cJSON *port, bool authenticate_to_rvd, char *rvd_auth_string,
-                     bool encrypt_rvd_traffic, unsigned char *session_aes_key_encrypted,
-                     unsigned char *session_iv_encrypted, FILE *authkeys_file, char *authkeys_filename);
+int run_srv_process(sshnpd_params *params, cJSON *host, cJSON *port, bool authenticate_to_rvd, char *rvd_auth_string,
+                    bool encrypt_rvd_traffic, unsigned char *session_aes_key_encrypted,
+                    unsigned char *session_iv_encrypted, FILE *authkeys_file, char *authkeys_filename);
 #endif

--- a/packages/c/sshnpd/src/handle_ping.c
+++ b/packages/c/sshnpd/src/handle_ping.c
@@ -30,7 +30,7 @@ void handle_ping(sshnpd_params *params, atclient_monitor_message *message, char 
 
   atclient_notify_params notify_params;
   atclient_notify_params_init(&notify_params);
-  notify_params.key = pingkey;
+  notify_params.atkey = &pingkey;
   notify_params.value = ping_response;
   notify_params.operation = ATCLIENT_NOTIFY_OPERATION_UPDATE;
 

--- a/packages/c/sshnpd/src/handle_ssh_request.c
+++ b/packages/c/sshnpd/src/handle_ssh_request.c
@@ -381,11 +381,13 @@ void handle_ssh_request(atclient *atclient, pthread_mutex_t *atclient_lock, sshn
   // - session_aes_key_base64 (if free_session_base64 == true)
   // - session_iv_base64 (if free_session_base64 == true)
 
-  pid_t pid, pid2;
-  int status, status2;
-  pid = fork();
+  pid_t pid = fork();
+  int status;
+  bool free_envelope = true;
+
   if (pid == 0) {
     // child process
+
     // free this immediately, we don't need it on the child fork
     free(envelope);
     if (free_session_base64) {
@@ -393,11 +395,9 @@ void handle_ssh_request(atclient *atclient, pthread_mutex_t *atclient_lock, sshn
       free(session_iv_base64);
     }
 
-    run_srv_process(params, host, port, authenticate_to_rvd, rvd_auth_string, encrypt_rvd_traffic, session_aes_key,
-                    session_iv, authkeys_file, authkeys_filename);
-    if (authenticate_to_rvd) {
-      free(rvd_auth_string);
-    }
+    int res = run_srv_process(params, host, port, authenticate_to_rvd, rvd_auth_string, encrypt_rvd_traffic,
+                              session_aes_key, session_iv, authkeys_file, authkeys_filename);
+    exit(res);
     // end of child process
   } else if (pid > 0) {
 

--- a/packages/c/sshnpd/src/handle_ssh_request.c
+++ b/packages/c/sshnpd/src/handle_ssh_request.c
@@ -23,8 +23,8 @@
 #define BYTES(x) (sizeof(unsigned char) * x)
 
 void handle_ssh_request(atclient *atclient, pthread_mutex_t *atclient_lock, sshnpd_params *params,
-                        atclient_monitor_message *message, char *home_dir, FILE *authkeys_file, char *authkeys_filename,
-                        atchops_rsakey_privatekey signing_key) {
+                        bool *is_child_process, atclient_monitor_message *message, char *home_dir, FILE *authkeys_file,
+                        char *authkeys_filename, atchops_rsakey_privatekey signing_key) {
   int res = 0;
   char *requesting_atsign = message->notification.from;
 
@@ -132,6 +132,7 @@ void handle_ssh_request(atclient *atclient, pthread_mutex_t *atclient_lock, sshn
     }
 
     cJSON *rvd_auth_payload = cJSON_CreateObject();
+    // FIXME: leaks : these 3 calls
     cJSON_AddItemReferenceToObject(rvd_auth_payload, "sessionId", session_id);
     cJSON_AddItemReferenceToObject(rvd_auth_payload, "clientNonce", client_nonce);
     cJSON_AddItemReferenceToObject(rvd_auth_payload, "rvdNonce", rvd_nonce);
@@ -397,7 +398,12 @@ void handle_ssh_request(atclient *atclient, pthread_mutex_t *atclient_lock, sshn
 
     int res = run_srv_process(params, host, port, authenticate_to_rvd, rvd_auth_string, encrypt_rvd_traffic,
                               session_aes_key, session_iv, authkeys_file, authkeys_filename);
-    exit(res);
+    *is_child_process = true;
+
+    if (authenticate_to_rvd) {
+      free(rvd_auth_string);
+    }
+    return;
     // end of child process
   } else if (pid > 0) {
 

--- a/packages/c/sshnpd/src/handle_ssh_request.c
+++ b/packages/c/sshnpd/src/handle_ssh_request.c
@@ -468,7 +468,7 @@ void handle_ssh_request(atclient *atclient, pthread_mutex_t *atclient_lock, sshn
 
     atclient_notify_params notify_params;
     atclient_notify_params_init(&notify_params);
-    notify_params.key = final_res_atkey;
+    notify_params.atkey = &final_res_atkey;
     notify_params.value = final_res_value;
     notify_params.operation = ATCLIENT_NOTIFY_OPERATION_UPDATE;
 

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -155,8 +155,7 @@ int main(int argc, char **argv) {
   }
 
   // 5.3 create a key copy for signing
-  atchops_rsakey_privatekey_init(&signingkey);
-  memcpy(&signingkey, &atkeys.encryptprivatekey, sizeof(atchops_rsakey_privatekey));
+  atchops_rsakey_privatekey_clone(&signingkey, &atkeys.encryptprivatekey);
 
   // 6. Get atServer address
   res = atclient_utils_find_atserver_address(params.root_domain, ROOT_PORT, params.atsign, &atserver_host,

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -99,7 +99,8 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  // 3.  Configure the Logger
+  // 3.  Configure the Logger - at this point atlogger_free must be called
+  // before the program exits
   if (params.verbose) {
     printf("Verbose mode enabled\n");
     atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_DEBUG);
@@ -346,6 +347,7 @@ exit:
   free(params.permitopen);
   free(params.permitopen_str);
 
+  atlogger_free();
   exit(exit_res);
 }
 

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -134,37 +134,20 @@ int main(int argc, char **argv) {
   }
 
   // 5.  Load the atKeys
-  atclient_atkeysfile atkeysfile;
-  atclient_atkeysfile_init(&atkeysfile);
-
-  // 5.1 Read the atKeys file
+  atclient_atkeys_init(&atkeys);
   if (params.key_file == NULL) {
     char filename[FILENAME_BUFFER_SIZE];
     snprintf(filename, FILENAME_BUFFER_SIZE, "%s/.atsign/keys/%s_key.atKeys", home_dir, params.atsign);
-    res = atclient_atkeysfile_read(&atkeysfile, filename);
+    res = atclient_atkeys_populate_from_path(&atkeys, filename);
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Using atkeysfile: %s\n", filename);
   } else {
-    res = atclient_atkeysfile_read(&atkeysfile, (const char *)params.key_file);
+    res = atclient_atkeys_populate_from_path(&atkeys, (const char *)params.key_file);
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Using atkeysfile: %s\n", (const char *)params.key_file);
   }
 
   if (res != 0 || !should_run) {
     if (res != 0) {
-      atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Unable to read the key file\n");
-    }
-    atclient_atkeysfile_free(&atkeysfile);
-    exit_res = res;
-    goto exit;
-  }
-
-  // 5.2 Read the atKeysFile into the atKeys struct
-  atclient_atkeys_init(&atkeys);
-
-  res = atclient_atkeys_populate_from_atkeysfile(&atkeys, atkeysfile);
-  atclient_atkeysfile_free(&atkeysfile);
-  if (res != 0 || !should_run) {
-    if (res != 0) {
-      atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Unable to parse the key file\n");
+      atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Unable to load the atkeys file\n");
     }
     atclient_atkeys_free(&atkeys);
     exit_res = res;
@@ -333,7 +316,7 @@ cancel_refresh:
   free(regex);
   atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Joining device entry refresh thread\n");
   should_run = 0;
-  if (pthread_join(refresh_tid, NULL) != 0) {
+  if (!is_child_process && pthread_join(refresh_tid, NULL) != 0) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN, "Failed to join device entry refresh thread\n");
   } else {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Joined device entry refresh thread\n");
@@ -343,12 +326,16 @@ cancel_atclient:
   if (!free_ping_response) {
     free(ping_response);
   }
-  atclient_connection_disconnect(&worker.atserver_connection);
-  atclient_free(&worker);
+  if (!is_child_process) {
+    atclient_connection_disconnect(&worker.atserver_connection);
+    atclient_free(&worker);
+  }
 
 cancel_monitor_ctx:
-  atclient_connection_disconnect(&monitor_ctx.atserver_connection);
-  atclient_free(&monitor_ctx);
+  if (!is_child_process) {
+    atclient_connection_disconnect(&monitor_ctx.atserver_connection);
+    atclient_free(&monitor_ctx);
+  }
   free(atserver_host);
 
 clean_atkeys:
@@ -487,8 +474,13 @@ void main_loop() {
           break;
         case NK_SSH_REQUEST:
           atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Executing handle_ssh_request\n");
-          handle_ssh_request(&worker, &atclient_lock, &params, &message, home_dir, authkeys_file, authkeys_filename,
-                             signingkey);
+          handle_ssh_request(&worker, &atclient_lock, &params, &is_child_process, &message, home_dir, authkeys_file,
+                             authkeys_filename, signingkey);
+          if (is_child_process) {
+            atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Exiting child process\n");
+            atclient_monitor_message_free(&message);
+            return;
+          }
           break;
         case NK_NPT_REQUEST:
           atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Executing handle_npt_request\n");

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -99,7 +99,7 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  // 3.  Configure the Logger - at this point atlogger_free must be called
+  // 3.  Configure the Logger
   // before the program exits
   if (params.verbose) {
     printf("Verbose mode enabled\n");
@@ -347,7 +347,6 @@ exit:
   free(params.permitopen);
   free(params.permitopen_str);
 
-  atlogger_free();
   exit(exit_res);
 }
 

--- a/packages/c/sshnpd/src/params.c
+++ b/packages/c/sshnpd/src/params.c
@@ -62,7 +62,7 @@ int parse_sshnpd_params(sshnpd_params *params, int argc, const char **argv) {
   }
 
   if (permitopen == NULL) {
-    params->permitopen_str = malloc(sizeof(char) * (strlen(default_permitopen) + 1));
+    params->permitopen_str = malloc(sizeof(char) * (strlen(default_permitopen) + 1)); // FIXME: leaks
     if (params->permitopen_str == NULL) {
       printf("Failed to allocate memory for default permitopen string\n");
       return 1;
@@ -106,7 +106,7 @@ int parse_sshnpd_params(sshnpd_params *params, int argc, const char **argv) {
   }
 
   // malloc pointers to each string, but don't malloc any more memory for individual char storage
-  params->manager_list = malloc((sep_count + 1) * sizeof(char *));
+  params->manager_list = malloc((sep_count + 1) * sizeof(char *)); // FIXME: leak
   if (params->manager_list == NULL) {
     printf("Failed to allocate memory for manager list\n");
     free(params->permitopen_str);
@@ -145,7 +145,7 @@ int parse_sshnpd_params(sshnpd_params *params, int argc, const char **argv) {
   }
 
   // malloc pointers to each string, but don't malloc any more memory for individual char storage
-  params->permitopen = malloc((sep_count + 1) * sizeof(char *));
+  params->permitopen = malloc((sep_count + 1) * sizeof(char *)); // FIXME  leak
   if (params->permitopen == NULL) {
     printf("Failed to allocate memory for permitopen\n");
     free(params->manager_list);

--- a/packages/c/sshnpd/src/run_srv_process.c
+++ b/packages/c/sshnpd/src/run_srv_process.c
@@ -12,9 +12,9 @@
 
 #define LOGGER_TAG "RUN SRV"
 
-void run_srv_process(sshnpd_params *params, cJSON *host, cJSON *port, bool authenticate_to_rvd, char *rvd_auth_string,
-                     bool encrypt_rvd_traffic, unsigned char *session_aes_key_encrypted,
-                     unsigned char *session_iv_encrypted, FILE *authkeys_file, char *authkeys_filename) {
+int run_srv_process(sshnpd_params *params, cJSON *host, cJSON *port, bool authenticate_to_rvd, char *rvd_auth_string,
+                    bool encrypt_rvd_traffic, unsigned char *session_aes_key_encrypted,
+                    unsigned char *session_iv_encrypted, FILE *authkeys_file, char *authkeys_filename) {
   int res = 0;
 
   char *streaming_host = cJSON_GetStringValue(host);
@@ -89,5 +89,5 @@ void run_srv_process(sshnpd_params *params, cJSON *host, cJSON *port, bool authe
   free(argv);
   free(streaming_port_str);
 
-  exit(res);
+  return res;
 }

--- a/packages/c/sshnpd/src/run_srv_process.c
+++ b/packages/c/sshnpd/src/run_srv_process.c
@@ -18,7 +18,7 @@ int run_srv_process(sshnpd_params *params, cJSON *host, cJSON *port, bool authen
   int res = 0;
 
   char *streaming_host = cJSON_GetStringValue(host);
-  char *streaming_port = cJSON_Print(port);
+  char *streaming_port = cJSON_Print(port); // FIXME: leak
   long local_port_len = long_strlen(params->local_sshd_port);
 
   size_t argc = 9 + authenticate_to_rvd + encrypt_rvd_traffic;

--- a/packages/c/sshnpd/sshnpd.supp
+++ b/packages/c/sshnpd/sshnpd.supp
@@ -1,4 +1,6 @@
 # key allocation & free is a known false positive
+# TODO: I couldn't see anything wrong with how we are doing it, but need to get 
+# a second set of eyes on this issue - @XavierChanth
 {
   atchops_rsakey_privatekey_init
     Memcheck:Leak

--- a/packages/c/sshnpd/sshnpd.supp
+++ b/packages/c/sshnpd/sshnpd.supp
@@ -1,0 +1,148 @@
+# key allocation & free is a known false positive
+{
+  atchops_rsakey_privatekey_init
+    Memcheck:Leak
+    match-leak-kinds: definite
+    fun:malloc
+    fun:atchops_rsakey_privatekey_init
+    fun:main
+}
+{
+  atchops_rsakey_privatekey_free
+    Memcheck:Free
+    fun:free
+    fun:atchops_rsakey_privatekey_free
+    fun:atclient_atkeys_free
+    fun:main
+}
+# Things to fix
+{
+  FIXME cJSON_PrintUnformatted
+    Memcheck:Leak
+    match-leak-kinds: reachable
+    fun:realloc
+    fun:print
+    fun:cJSON_PrintUnformatted
+    fun:main
+}
+{
+  FIXME atlogger_get_instance
+    Memcheck:Leak
+    match-leak-kinds: reachable
+    fun:malloc
+    fun:atlogger_get_instance
+    fun:atlogger_set_logging_level
+    fun:main
+}
+{
+  FIXME atclient_atsign_init
+    Memcheck:Leak
+    match-leak-kinds: definite
+    fun:malloc
+    fun:atclient_atsign_init
+    fun:atclient_put
+    fun:refresh_device_entry
+    fun:start_thread
+    fun:clone
+}
+{
+  FIXME atclient_connection_enable_hooks
+    Memcheck:Leak
+    match-leak-kinds: definite
+    fun:malloc
+    fun:atclient_connection_enable_hooks
+    fun:set_worker_hooks
+    fun:main
+}
+
+# ignore libc
+{
+  idk
+    Memcheck:Leak
+    match-leak-kinds: reachable
+    fun:calloc
+    fun:UnknownInlinedFun
+    fun:_dl_new_object
+    fun:_dl_map_object_from_fd
+    fun:_dl_map_object
+    fun:dl_open_worker_begin
+    fun:_dl_catch_exception
+    fun:dl_open_worker
+    fun:_dl_catch_exception
+    fun:_dl_open
+    fun:do_dlopen
+    fun:_dl_catch_exception
+    fun:_dl_catch_error
+}
+{
+  idk2
+    Memcheck:Leak
+    match-leak-kinds: reachable
+    fun:malloc
+    fun:malloc
+    fun:strdup
+    fun:_dl_load_cache_lookup
+    fun:_dl_map_object
+    fun:dl_open_worker_begin
+    fun:_dl_catch_exception
+    fun:dl_open_worker
+    fun:_dl_catch_exception
+    fun:_dl_open
+    fun:do_dlopen
+    fun:_dl_catch_exception
+    fun:_dl_catch_error
+}
+{
+  idk3
+    Memcheck:Leak
+    match-leak-kinds: reachable
+    fun:malloc
+    fun:UnknownInlinedFun
+    fun:_dl_new_object
+    fun:_dl_map_object_from_fd
+    fun:_dl_map_object
+    fun:dl_open_worker_begin
+    fun:_dl_catch_exception
+    fun:dl_open_worker
+    fun:_dl_catch_exception
+    fun:_dl_open
+    fun:do_dlopen
+    fun:_dl_catch_exception
+    fun:_dl_catch_error
+}
+{
+  idk4
+    Memcheck:Leak
+    match-leak-kinds: definite
+    fun:malloc
+    fun:UnknownInlinedFun
+    fun:_dl_map_object_deps
+    fun:dl_open_worker_begin
+    fun:_dl_catch_exception
+    fun:dl_open_worker
+    fun:_dl_catch_exception
+    fun:_dl_open
+    fun:do_dlopen
+    fun:_dl_catch_exception
+    fun:_dl_catch_error
+    fun:dlerror_run
+    fun:__libc_dlopen_mode
+}
+{
+  idk5
+    Memcheck:Leak
+    match-leak-kinds: reachable
+    fun:calloc
+    fun:UnknownInlinedFun
+    fun:_dl_check_map_versions
+    fun:dl_open_worker_begin
+    fun:_dl_catch_exception
+    fun:dl_open_worker
+    fun:_dl_catch_exception
+    fun:_dl_open
+    fun:do_dlopen
+    fun:_dl_catch_exception
+    fun:_dl_catch_error
+    fun:dlerror_run
+    fun:__libc_dlopen_mode
+}

--- a/packages/c/sshnpd/sshnpd.supp
+++ b/packages/c/sshnpd/sshnpd.supp
@@ -1,23 +1,4 @@
-# key allocation & free is a known false positive
-# TODO: I couldn't see anything wrong with how we are doing it, but need to get 
-# a second set of eyes on this issue - @XavierChanth
-{
-  atchops_rsakey_privatekey_init
-    Memcheck:Leak
-    match-leak-kinds: definite
-    fun:malloc
-    fun:atchops_rsakey_privatekey_init
-    fun:main
-}
-{
-  atchops_rsakey_privatekey_free
-    Memcheck:Free
-    fun:free
-    fun:atchops_rsakey_privatekey_free
-    fun:atclient_atkeys_free
-    fun:main
-}
-# Things to fix
+# Things to fix only main process
 {
   FIXME cJSON_PrintUnformatted
     Memcheck:Leak
@@ -39,21 +20,343 @@
 {
   FIXME atclient_atsign_init
     Memcheck:Leak
-    match-leak-kinds: definite
     fun:malloc
     fun:atclient_atsign_init
-    fun:atclient_put
-    fun:refresh_device_entry
-    fun:start_thread
-    fun:clone
 }
 {
   FIXME atclient_connection_enable_hooks
     Memcheck:Leak
-    match-leak-kinds: definite
     fun:malloc
     fun:atclient_connection_enable_hooks
     fun:set_worker_hooks
+    fun:main
+}
+# Issues after connections have been made
+{
+  FIXME atclient_atstr_init 1
+    Memcheck:Leak
+    match-leak-kinds: definite
+    fun:malloc
+    fun:atclient_atstr_init
+    fun:atclient_atstr_init_literal
+
+}
+{
+  FIXME atclient_atstr_init 2
+    Memcheck:Leak
+    match-leak-kinds: definite
+    fun:malloc
+    fun:atclient_atstr_init
+    fun:atclient_atkey_init
+}
+# cjson related
+{
+  FIXME run_srv_process cJSON_Print
+    Memcheck:Leak
+    match-leak-kinds: definite
+    fun:realloc
+    fun:print
+    fun:cJSON_Print
+    fun:run_srv_process
+    fun:handle_ssh_request
+    fun:main_loop
+    fun:main
+}
+{
+  FIXME handle_ssh_request cJSON_AddItemReferenceToObject 1
+    Memcheck:Leak
+    match-leak-kinds: indirect
+    fun:malloc
+    fun:cJSON_strdup
+    fun:add_item_to_object
+    fun:cJSON_AddItemReferenceToObject
+    fun:handle_ssh_request
+    fun:main_loop
+    fun:main
+}
+{
+  FIXME handle_ssh_request cJSON_AddItemReferenceToObject 2
+    Memcheck:Leak
+    match-leak-kinds: indirect
+    fun:malloc
+    fun:cJSON_New_Item
+    fun:create_reference
+    fun:cJSON_AddItemReferenceToObject
+    fun:handle_ssh_request
+    fun:main_loop
+    fun:main
+}
+
+{
+  FIXME handle_ssh_request cJSON_Parse
+    Memcheck:Leak
+    match-leak-kinds: indirect
+    fun:malloc
+    fun:parse_string
+    fun:parse_value
+    fun:parse_object
+    fun:parse_value
+    fun:cJSON_ParseWithLengthOpts
+    fun:cJSON_ParseWithOpts
+    fun:cJSON_Parse
+    fun:handle_ssh_request
+    fun:main_loop
+    fun:main
+}
+{
+   FIXME handle_ssh_request cJSON_Parse 2
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:malloc
+   fun:cJSON_New_Item
+   fun:parse_object
+   fun:parse_value
+   fun:cJSON_ParseWithLengthOpts
+   fun:cJSON_ParseWithOpts
+   fun:cJSON_Parse
+   fun:handle_ssh_request
+   fun:main_loop
+   fun:main
+}
+{
+   FIXME handle_ssh_request cJSON_Parse 3
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:malloc
+   fun:parse_string
+   fun:parse_value
+   fun:parse_object
+   fun:parse_value
+   fun:parse_object
+   fun:parse_value
+   fun:cJSON_ParseWithLengthOpts
+   fun:cJSON_ParseWithOpts
+   fun:cJSON_Parse
+   fun:handle_ssh_request
+   fun:main_loop
+}
+{
+FIXME handle_ssh_request cJSON_Parse 4
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:cJSON_New_Item
+   fun:parse_object
+   fun:parse_value
+   fun:cJSON_ParseWithLengthOpts
+   fun:cJSON_ParseWithOpts
+   fun:cJSON_Parse
+   fun:handle_ssh_request
+   fun:main_loop
+   fun:main
+}
+{
+FIXME handle_ssh_request cJSON_Parse 5
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:malloc
+   fun:parse_string
+   fun:parse_object
+   fun:parse_value
+   fun:cJSON_ParseWithLengthOpts
+   fun:cJSON_ParseWithOpts
+   fun:cJSON_Parse
+   fun:handle_ssh_request
+   fun:main_loop
+   fun:main
+}
+{
+FIXME handle_ssh_request cJSON_Parse 6
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:malloc
+   fun:parse_string
+   fun:parse_object
+   fun:parse_value
+   fun:parse_object
+   fun:parse_value
+   fun:cJSON_ParseWithLengthOpts
+   fun:cJSON_ParseWithOpts
+   fun:cJSON_Parse
+   fun:handle_ssh_request
+   fun:main_loop
+   fun:main
+}
+{
+FIXME handle_ssh_request cJSON_Parse 7
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:malloc
+   fun:cJSON_New_Item
+   fun:parse_object
+   fun:parse_value
+   fun:parse_object
+   fun:parse_value
+   fun:cJSON_ParseWithLengthOpts
+   fun:cJSON_ParseWithOpts
+   fun:cJSON_Parse
+   fun:handle_ssh_request
+   fun:main_loop
+   fun:main
+}
+{
+FIXME handle_ssh_request cJSON_Parse 8
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:cJSON_New_Item
+   fun:parse_object
+   fun:parse_value
+   fun:cJSON_ParseWithLengthOpts
+   fun:cJSON_ParseWithOpts
+   fun:cJSON_Parse
+   fun:handle_ssh_request
+   fun:main_loop
+   fun:main
+}
+{
+  FIXME handle_ssh_request cJSON_CreateObject
+    Memcheck:Leak
+    match-leak-kinds: definite
+    fun:malloc
+    fun:cJSON_New_Item
+    fun:cJSON_CreateObject
+    fun:handle_ssh_request
+    fun:main_loop
+    fun:main
+}
+# mbedtls related
+{
+FIXME atclient_connection_connect mbedtls_pk_parse_subpubkey
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:mbedtls_mpi_grow
+   fun:mbedtls_mpi_resize_clear
+   fun:mbedtls_mpi_read_binary
+   fun:mbedtls_rsa_import_raw
+   fun:pk_get_rsapubkey
+   fun:mbedtls_pk_parse_subpubkey
+   fun:x509_crt_parse_der_core
+   fun:mbedtls_x509_crt_parse_der_internal
+   fun:mbedtls_x509_crt_parse_der
+   fun:mbedtls_x509_crt_parse
+   fun:atclient_connection_connect
+}
+{
+  FIXME atclient_connection_connect x509_get_certificate_policies
+    Memcheck:Leak
+    match-leak-kinds: reachable
+    fun:calloc
+    fun:x509_get_certificate_policies
+    fun:x509_get_crt_ext
+    fun:x509_crt_parse_der_core
+    fun:mbedtls_x509_crt_parse_der_internal
+    fun:mbedtls_x509_crt_parse_der
+    fun:mbedtls_x509_crt_parse
+    fun:atclient_connection_connect
+    fun:atclient_start_atserver_connection
+    fun:atclient_pkam_authenticate
+    fun:main
+}
+{
+  FIXME atclient_connection_connect x509_get_certificate_policies 2
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:x509_get_certificate_policies
+   fun:x509_get_crt_ext
+   fun:x509_crt_parse_der_core
+   fun:mbedtls_x509_crt_parse_der_internal
+   fun:mbedtls_x509_crt_parse_der
+   fun:ssl_parse_certificate_chain
+   fun:mbedtls_ssl_parse_certificate
+   fun:mbedtls_ssl_handshake_client_step
+   fun:mbedtls_ssl_handshake_step
+   fun:mbedtls_ssl_handshake
+   fun:atclient_connection_connect
+}
+{
+FIXME atclient_connection_connect mbedtls_asn1_get_sequence_of
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:asn1_get_sequence_of_cb
+   fun:mbedtls_asn1_traverse_sequence_of
+   fun:mbedtls_asn1_get_sequence_of
+   fun:x509_get_ext_key_usage
+   fun:x509_get_crt_ext
+   fun:x509_crt_parse_der_core
+   fun:mbedtls_x509_crt_parse_der_internal
+   fun:mbedtls_x509_crt_parse_der
+   fun:mbedtls_x509_crt_parse
+   fun:atclient_connection_connect
+   fun:atclient_start_atserver_connection
+}
+{
+  FIXME atclient_connection_connect pk_get_ecpubkey
+    Memcheck:Leak
+    match-leak-kinds: reachable
+    fun:calloc
+    fun:mbedtls_mpi_grow
+    fun:mbedtls_mpi_lset
+    fun:mbedtls_ecp_point_read_binary
+    fun:pk_get_ecpubkey
+    fun:mbedtls_pk_parse_subpubkey
+    fun:x509_crt_parse_der_core
+    fun:mbedtls_x509_crt_parse_der_internal
+    fun:mbedtls_x509_crt_parse_der
+    fun:mbedtls_x509_crt_parse
+    fun:atclient_connection_connect
+    fun:atclient_start_atserver_connection
+}
+{
+   FIXME mbedtls_ssl_parse_certificate
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:mbedtls_mpi_grow
+   fun:mbedtls_mpi_resize_clear
+   fun:mbedtls_mpi_read_binary
+   fun:mbedtls_rsa_import_raw
+   fun:pk_get_rsapubkey
+   fun:mbedtls_pk_parse_subpubkey
+   fun:x509_crt_parse_der_core
+   fun:mbedtls_x509_crt_parse_der_internal
+   fun:mbedtls_x509_crt_parse_der
+   fun:ssl_parse_certificate_chain
+   fun:mbedtls_ssl_parse_certificate
+}
+
+{
+   FIXME mbedtls_ssl_set_hostname
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:mbedtls_ssl_set_hostname
+   fun:atclient_connection_connect
+   fun:atclient_start_atserver_connection
+   fun:atclient_pkam_authenticate
+   fun:main
+}
+
+# False positives?
+# TODO: I couldn't see anything wrong with how we are doing it, but need to get 
+# a second set of eyes on this issue - @XavierChanth
+{
+  atchops_rsakey_privatekey_init
+    Memcheck:Leak
+    match-leak-kinds: definite
+    fun:malloc
+    fun:atchops_rsakey_privatekey_init
+    fun:main
+}
+{
+  atchops_rsakey_privatekey_free
+    Memcheck:Free
+    fun:free
+    fun:atchops_rsakey_privatekey_free
+    fun:atclient_atkeys_free
     fun:main
 }
 

--- a/packages/c/sshnpd/sshnpd.supp
+++ b/packages/c/sshnpd/sshnpd.supp
@@ -9,22 +9,13 @@
     fun:main
 }
 {
-  FIXME atlogger_get_instance
-    Memcheck:Leak
-    match-leak-kinds: reachable
-    fun:malloc
-    fun:atlogger_get_instance
-    fun:atlogger_set_logging_level
-    fun:main
-}
-{
   FIXME atclient_atsign_init
     Memcheck:Leak
     fun:malloc
     fun:atclient_atsign_init
 }
 {
-  FIXME atclient_connection_enable_hooks
+  FIXME atclient_connection_enable_hooks - FP?
     Memcheck:Leak
     fun:malloc
     fun:atclient_connection_enable_hooks

--- a/packages/c/sshnpd/sshnpd.supp
+++ b/packages/c/sshnpd/sshnpd.supp
@@ -340,24 +340,30 @@ FIXME atclient_connection_connect mbedtls_asn1_get_sequence_of
    fun:main
 }
 
-# False positives?
-# TODO: I couldn't see anything wrong with how we are doing it, but need to get 
-# a second set of eyes on this issue - @XavierChanth
+# srv
 {
-  atchops_rsakey_privatekey_init
+  FIXME srv_side_handle
     Memcheck:Leak
-    match-leak-kinds: definite
     fun:malloc
-    fun:atchops_rsakey_privatekey_init
-    fun:main
+    fun:srv_side_handle 
+    fun:start_thread 
+    fun:clone 
 }
 {
-  atchops_rsakey_privatekey_free
-    Memcheck:Free
-    fun:free
-    fun:atchops_rsakey_privatekey_free
-    fun:atclient_atkeys_free
-    fun:main
+  FIXME srv certs
+    Memcheck:Leak
+    fun:calloc 
+    fun:asn1_get_sequence_of_cb 
+    fun:mbedtls_asn1_traverse_sequence_of 
+    fun:mbedtls_asn1_get_sequence_of 
+    fun:x509_get_ext_key_usage 
+    fun:x509_get_crt_ext 
+    fun:x509_crt_parse_der_core 
+    fun:mbedtls_x509_crt_parse_der_internal 
+    fun:mbedtls_x509_crt_parse_der 
+    fun:ssl_parse_certificate_chain 
+    fun:mbedtls_ssl_parse_certificate 
+    fun:mbedtls_ssl_handshake_client_step 
 }
 
 # ignore libc

--- a/packages/c/sshnpd/sshnpd.supp
+++ b/packages/c/sshnpd/sshnpd.supp
@@ -57,7 +57,7 @@
 
 # ignore libc
 {
-  idk
+  libc 1
     Memcheck:Leak
     match-leak-kinds: reachable
     fun:calloc
@@ -75,7 +75,7 @@
     fun:_dl_catch_error
 }
 {
-  idk2
+  libc 2
     Memcheck:Leak
     match-leak-kinds: reachable
     fun:malloc
@@ -93,7 +93,7 @@
     fun:_dl_catch_error
 }
 {
-  idk3
+  libc 3
     Memcheck:Leak
     match-leak-kinds: reachable
     fun:malloc
@@ -111,7 +111,7 @@
     fun:_dl_catch_error
 }
 {
-  idk4
+  libc 4
     Memcheck:Leak
     match-leak-kinds: definite
     fun:malloc
@@ -129,7 +129,7 @@
     fun:__libc_dlopen_mode
 }
 {
-  idk5
+  libc 5
     Memcheck:Leak
     match-leak-kinds: reachable
     fun:calloc

--- a/packages/c/sshnpd/sshnpd.supp
+++ b/packages/c/sshnpd/sshnpd.supp
@@ -14,14 +14,6 @@
     fun:malloc
     fun:atclient_atsign_init
 }
-{
-  FIXME atclient_connection_enable_hooks - FP?
-    Memcheck:Leak
-    fun:malloc
-    fun:atclient_connection_enable_hooks
-    fun:set_worker_hooks
-    fun:main
-}
 # Issues after connections have been made
 {
   FIXME atclient_atstr_init 1


### PR DESCRIPTION
**- What I did**
- Pinned atsdk commit which is from https://github.com/atsign-foundation/at_c/pull/325
- Removed atlogger_free() since that is not the most recent feature

**- How to verify it**

valgrind leak summary after starting daemon, pkam authenticating, starting main loop, then Ctrl-C

```
==194277== LEAK SUMMARY:
==194277==    definitely lost: 0 bytes in 0 blocks
==194277==    indirectly lost: 0 bytes in 0 blocks
==194277==      possibly lost: 0 bytes in 0 blocks
==194277==    still reachable: 0 bytes in 0 blocks
==194277==         suppressed: 223 bytes in 1 blocks
```

