### PR TITLE
fix: make sure necessary directories exist

### DIFF
--- a/packages/dart/noports_core/lib/src/common/at_ssh_key_util/local_ssh_key_util.dart
+++ b/packages/dart/noports_core/lib/src/common/at_ssh_key_util/local_ssh_key_util.dart
@@ -28,8 +28,8 @@ class LocalSshKeyUtil implements AtSshKeyUtil {
     this.cacheKeys = true,
     @visibleForTesting this.fs = const LocalFileSystem(),
   }) : homeDirectory = homeDirectory ?? getHomeDirectory(throwIfNull: true)! {
-    sshHomeDirectory = path.normalize('$homeDirectory/.ssh/');
-    sshnpHomeDirectory = path.normalize('$homeDirectory/.sshnp/');
+    sshHomeDirectory = path.normalize('${this.homeDirectory}/.ssh/');
+    sshnpHomeDirectory = path.normalize('${this.homeDirectory}/.sshnp/');
 
     if (!fs.directory(sshHomeDirectory).existsSync()) {
       fs.directory(sshHomeDirectory).createSync(recursive: true);

--- a/packages/dart/noports_core/lib/src/common/at_ssh_key_util/local_ssh_key_util.dart
+++ b/packages/dart/noports_core/lib/src/common/at_ssh_key_util/local_ssh_key_util.dart
@@ -19,19 +19,32 @@ class LocalSshKeyUtil implements AtSshKeyUtil {
   final FileSystem fs;
 
   final String homeDirectory;
+  late final String sshHomeDirectory;
+  late final String sshnpHomeDirectory;
   bool cacheKeys;
 
   LocalSshKeyUtil({
     String? homeDirectory,
     this.cacheKeys = true,
     @visibleForTesting this.fs = const LocalFileSystem(),
-  }) : homeDirectory = homeDirectory ?? getHomeDirectory(throwIfNull: true)!;
+  }) : homeDirectory = homeDirectory ?? getHomeDirectory(throwIfNull: true)! {
+    sshHomeDirectory = path.normalize('$homeDirectory/.ssh/');
+    sshnpHomeDirectory = path.normalize('$homeDirectory/.sshnp/');
+
+    if (!fs.directory(sshHomeDirectory).existsSync()) {
+      fs.directory(sshHomeDirectory).createSync(recursive: true);
+    }
+    if (!fs.directory(sshnpHomeDirectory).existsSync()) {
+      fs.directory(sshnpHomeDirectory).createSync(recursive: true);
+    }
+    if (!Platform.isWindows) {
+      chmod(sshHomeDirectory, '700');
+      chmod(sshnpHomeDirectory, '700');
+    }
+  }
 
   bool get isValidPlatform =>
       Platform.isLinux || Platform.isMacOS || Platform.isWindows;
-
-  String get sshHomeDirectory => path.normalize('$homeDirectory/.ssh/');
-  String get sshnpHomeDirectory => path.normalize('$homeDirectory/.sshnp/');
 
   String get _defaultDirectory => sshnpHomeDirectory;
 
@@ -137,10 +150,6 @@ class LocalSshKeyUtil implements AtSshKeyUtil {
     if (!sshPublicKey.startsWith(RegExp(
         r'^(ecdsa-sha2-nistp)|(rsa-sha2-)|(ssh-rsa)|(ssh-ed25519)|(ecdsa-sha2-nistp)'))) {
       throw ('$sshPublicKey does not look like a public key');
-    }
-
-    if (!fs.directory(sshHomeDirectory).existsSync()) {
-      fs.directory(sshHomeDirectory).createSync();
     }
 
     // Check to see if the ssh Publickey is already in the authorized_keys file.


### PR DESCRIPTION
**- What I did**
fix: make LocalSshKeyUtil constructor (1) create, if they don't already exist, any directories that are expected to exist and (2) set strict directory permissions
Fixes #1138 

**- How I did it**

**- How to verify it**
Tests pass
