### PR TITLE
fix: use correct arch in multibuild.yaml

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -56,7 +56,7 @@ jobs:
             output-name: sshnp-linux-x64
             ext: ''
             bundle: 'shell'
-          - os: macOS-latest
+          - os: macos-13
             output-name: sshnp-macos-x64
             ext: ''
             bundle: 'shell'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- macos-latest is now an arm64 arch machine, so pointing the x64 builds at x64 machines...
- our macos x64 releases at least as far back as v5.2.0 are not x64 builds...
- This very much seems like a situation where there should have been a macos-latest and macos-arm-latest, did I miss the email or was there not one sent for this change?

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: use correct arch in multibuild.yaml
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
