### PR TITLE
fix: skipping macOS related tasks due to name change

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -98,7 +98,7 @@ jobs:
           cp -r bundles/${{ matrix.bundle }}/* sshnp/
           cp LICENSE sshnp
       # codesign for apple
-      - if: ${{ matrix.os == 'macOS-latest' || matrix.os == 'macos-14'}}
+      - if: ${{ matrix.os == 'macos-13' || matrix.os == 'macos-14'}}
         name: Import certificates
         env:
           MACOS_CODESIGN_CERT: ${{ secrets.MACOS_CODESIGN_CERT }}
@@ -127,14 +127,14 @@ jobs:
             -v \
             sshnp/{sshnp,sshnpd,srv,srvd,at_activate,debug/srvd,npt}
       # zip the build
-      - if: ${{ matrix.os == 'macOS-latest' || matrix.os == 'macos-14'}}
+      - if: ${{ matrix.os == 'macos-13' || matrix.os == 'macos-14'}}
         run: ditto -c -k --keepParent sshnp tarball/${{ matrix.output-name }}.zip
       - if: ${{ matrix.os == 'ubuntu-latest' }}
         run: tar -cvzf tarball/${{ matrix.output-name }}.tgz sshnp
       - if: ${{ matrix.os == 'windows-latest' }}
         run: Compress-Archive -Path sshnp -Destination tarball/${{ matrix.output-name }}.zip
       # notarize the build
-      - if: ${{ matrix.os == 'macOS-latest' || matrix.os == 'macos-14'}}
+      - if: ${{ matrix.os == 'macos-13' || matrix.os == 'macos-14'}}
         env:
           MACOS_APPLE_ID: ${{ secrets.MACOS_APPLE_ID }}
           MACOS_TEAM_ID: ${{ secrets.MACOS_TEAM_ID }}


### PR DESCRIPTION
**- What I did**
in [#1144](https://github.com/atsign-foundation/noports/pull/1144/files) we changed macOS-latest to macos-13 but didn't change the other related tasks.

[see this run for skipped tasks](https://github.com/atsign-foundation/noports/actions/runs/9598741083/job/26470827234)
**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: skipping macOS related tasks due to name change