### PR TITLE
fix: remove duplicate os' in our build matrix

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -50,7 +50,6 @@ jobs:
         working-directory: ./packages/dart/sshnoports
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
         include:
           - os: ubuntu-latest
             output-name: sshnp-linux-x64

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -126,14 +126,14 @@ jobs:
             -v \
             sshnp/{sshnp,sshnpd,srv,srvd,at_activate,debug/srvd,npt}
       # zip the build
-      - if: ${{ matrix.os == 'macos-13' || matrix.os == 'macos-14'}}
+      - if: ${{ matrix.os == 'macos-13' || matrix.os == 'macos-14' }}
         run: ditto -c -k --keepParent sshnp tarball/${{ matrix.output-name }}.zip
       - if: ${{ matrix.os == 'ubuntu-latest' }}
         run: tar -cvzf tarball/${{ matrix.output-name }}.tgz sshnp
       - if: ${{ matrix.os == 'windows-latest' }}
         run: Compress-Archive -Path sshnp -Destination tarball/${{ matrix.output-name }}.zip
       # notarize the build
-      - if: ${{ matrix.os == 'macos-13' || matrix.os == 'macos-14'}}
+      - if: ${{ matrix.os == 'macos-13' || matrix.os == 'macos-14' }}
         env:
           MACOS_APPLE_ID: ${{ secrets.MACOS_APPLE_ID }}
           MACOS_TEAM_ID: ${{ secrets.MACOS_TEAM_ID }}

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -50,7 +50,7 @@ jobs:
         working-directory: ./packages/dart/sshnoports
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         include:
           - os: ubuntu-latest
             output-name: sshnp-linux-x64
@@ -98,7 +98,7 @@ jobs:
           cp -r bundles/${{ matrix.bundle }}/* sshnp/
           cp LICENSE sshnp
       # codesign for apple
-      - if: ${{ matrix.os == 'macos-13' || matrix.os == 'macos-14'}}
+      - if: ${{ matrix.os == 'macos-13' || matrix.os == 'macos-14' }}
         name: Import certificates
         env:
           MACOS_CODESIGN_CERT: ${{ secrets.MACOS_CODESIGN_CERT }}


### PR DESCRIPTION
**- What I did**
 originally removed just the macos-latest, but we don't need the entire os line due to the `includes:`
**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: remove duplicate os' in our build matrix