### PR TITLE
ci: use gcc as compiler in e2e_all

### DIFF
--- a/packages/c/sshnpd/src/handle_ssh_request.c
+++ b/packages/c/sshnpd/src/handle_ssh_request.c
@@ -10,6 +10,7 @@
 #include <atlogger/atlogger.h>
 #include <cJSON.h>
 #include <pthread.h>
+#include <sshnpd/handle_ssh_request.h>
 #include <sshnpd/run_srv_process.h>
 #include <stdlib.h>
 #include <string.h>
@@ -423,8 +424,8 @@ void handle_ssh_request(atclient *atclient, pthread_mutex_t *atclient_lock, sshn
       free(session_iv_encrypted);
       free_session_base64 = true;
     } // rsa2048 - allocates (session_iv_base64, session_aes_key_base64)
-  }   // case 7
-  }   // switch
+  } // case 7
+  } // switch
 
   if (!is_valid) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
@@ -555,12 +556,12 @@ void handle_ssh_request(atclient *atclient, pthread_mutex_t *atclient_lock, sshn
       atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Released the atclient lock\n");
     }
 
-  clean_res : { free(keyname); }
-  clean_final_res_value : {
+  clean_res: { free(keyname); }
+  clean_final_res_value: {
     atclient_atkey_free(&final_res_atkey);
     free(final_res_value);
   }
-  clean_json : {
+  clean_json: {
     cJSON_Delete(final_res_envelope);
     free(signing_input);
   }

--- a/tests/e2e_all/scripts/common/common_functions.include.sh
+++ b/tests/e2e_all/scripts/common/common_functions.include.sh
@@ -540,7 +540,7 @@ buildCurrentCBinaries() {
     local base_dir="./sshnpd"
     local build_dir="$base_dir/build"
     mkdir -p "$build_dir"
-    cmake -B $build_dir -S $base_dir -DCMAKE_C_COMPILER=cc
+    cmake -B $build_dir -S $base_dir -DCMAKE_C_COMPILER=gcc
     cmake --build $build_dir
     cp $build_dir/sshnpd "$binaryOutputDir/"
   fi

--- a/tests/e2e_all/scripts/common/common_functions.include.sh
+++ b/tests/e2e_all/scripts/common/common_functions.include.sh
@@ -540,7 +540,7 @@ buildCurrentCBinaries() {
     local base_dir="./sshnpd"
     local build_dir="$base_dir/build"
     mkdir -p "$build_dir"
-    cmake -B $build_dir -S $base_dir -DCMAKE_C_COMPILER=gcc -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic -Werror" -DBUILD_TESTS=off
+    cmake -B $build_dir -S $base_dir -DCMAKE_C_COMPILER=gcc -DCMAKE_C_FLAGS="-Wall -Wextra -Werror-implicit-function-declaration" -DBUILD_TESTS=off
     cmake --build $build_dir
     if [ $? -ne 0 ]; then
       logErrorAndExit "cmake build failed"

--- a/tests/e2e_all/scripts/common/common_functions.include.sh
+++ b/tests/e2e_all/scripts/common/common_functions.include.sh
@@ -540,7 +540,7 @@ buildCurrentCBinaries() {
     local base_dir="./sshnpd"
     local build_dir="$base_dir/build"
     mkdir -p "$build_dir"
-    cmake -B $build_dir -S $base_dir -DCMAKE_C_COMPILER=gcc
+    cmake -B $build_dir -S $base_dir -DCMAKE_C_COMPILER=gcc -DCMAKE_C_FLAGS="-Wall" -DBUILD_TESTS=off
     cmake --build $build_dir
     cp $build_dir/sshnpd "$binaryOutputDir/"
   fi

--- a/tests/e2e_all/scripts/common/common_functions.include.sh
+++ b/tests/e2e_all/scripts/common/common_functions.include.sh
@@ -540,7 +540,7 @@ buildCurrentCBinaries() {
     local base_dir="./sshnpd"
     local build_dir="$base_dir/build"
     mkdir -p "$build_dir"
-    cmake -B $build_dir -S $base_dir -DCMAKE_C_COMPILER=gcc -DCMAKE_C_FLAGS="-Wall" -DBUILD_TESTS=off
+    cmake -B $build_dir -S $base_dir -DCMAKE_C_COMPILER=gcc -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic -Werror" -DBUILD_TESTS=off
     cmake --build $build_dir
     cp $build_dir/sshnpd "$binaryOutputDir/"
   fi

--- a/tests/e2e_all/scripts/common/common_functions.include.sh
+++ b/tests/e2e_all/scripts/common/common_functions.include.sh
@@ -542,6 +542,9 @@ buildCurrentCBinaries() {
     mkdir -p "$build_dir"
     cmake -B $build_dir -S $base_dir -DCMAKE_C_COMPILER=gcc -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic -Werror" -DBUILD_TESTS=off
     cmake --build $build_dir
+    if [ $? -ne 0 ]; then
+      logErrorAndExit "cmake build failed"
+    fi
     cp $build_dir/sshnpd "$binaryOutputDir/"
   fi
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- e2e tests check for implicit function declarations
- ensured explicit function declarations for handle_ssh_request.c file

**- How I did it**

**- How to verify it**

**- Description for the changelog**
ci: use gcc as compiler in e2e_all
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
