### PR TITLE
ci: Add source tarballs to C sshnpd releases

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -100,10 +100,25 @@ jobs:
           name: ${{ matrix.output-name }}-${{github.ref_name}}-${{github.run_number}}-${{github.run_attempt}}
           path: ./packages/c/tarballs/${{ matrix.output-name }}.tgz
 
+  source_tarball:
+    name: Generate source tarball
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - name: Create tarball
+      run: |
+        mkdir tarball
+        cd ./packages/c
+        tar -cvf ../../tarball/csshnpd-${{ github.ref_name }}.tgz .
+    - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      with:
+        name: csshnpd-src-${{github.ref_name}}-${{github.run_number}}-${{github.run_attempt}}
+        path: ./tarball/csshnpd-${{ github.ref_name }}.tgz
+
   github-release:
     name: >-
       Upload artifacts and generate checksums for provenance
-    needs: [main_build, other_build]
+    needs: [main_build, other_build, source_tarball]
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}


### PR DESCRIPTION
External build systems (e.g. OpenWRT) expect to consume a source tarball, and there's a little too much cruft in the generic release tarball as that provides an archive of the whole repo.

**- What I did**

Added a job to the release workflow that creates a tarball with just the C package(s)

**- How I did it**

Prototyped in my release_automation repo

**- How to verify it**

https://github.com/atsign-foundation/noports/releases/tag/c0.1.1 is a pre-release against this branch
https://github.com/atsign-foundation/noports/actions/runs/9648405729 is the corresponding Actions run

**- Description for the changelog**

ci: Add source tarballs to C sshnpd releases
