### PR TITLE
fix: (c sshnpd) username and --list-devices bug

### DIFF
--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -3,7 +3,7 @@ if(NOT atsdk_FOUND)
   FetchContent_Declare(
     atsdk
     GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-    GIT_TAG d8afd18535259b389344bc9d6392e213e7243650
+    GIT_TAG 18625590fdf4a24705ccad56e3d04b1bf1bdf5ee
   )
   FetchContent_MakeAvailable(atsdk)
   install(TARGETS atclient atchops atlogger)


### PR DESCRIPTION
closes #1115 

**- What I did**
- Updated C Daemon's use of atSDK to a commit hash with compounding namespace atkey fix

**- How I did it**
- Notice that the namespace before is `.vps` but now it is `.vps.sshnp`. The latter is correct.

**- How to verify it**

**Before** (this is current implementation of trunk on how the username is stored on device atSign):

C Daemon (Ubuntu):

```
[DEBG] 2024-07-09 14:37:55.055047 | connection |        SENT: "update:ttr:-1:ccd:true:isEncrypted:true:ivNonce:/hNQGn92PwC54ZfawOc6HA==:@soccer0:username.vps@soccer99 AB4dwzWuDYlfz4dA1PSacg=="
[DEBG] 2024-07-09 14:37:55.093833 | connection |        RECV: "data:533"
```

v5.5.0 M2 Air SSHNP Client:

As expected, the username is not shared.

```
Error : Remote username record not shared with the client

Stack Trace: #0      SshnpdChannel.resolveRemoteUsername.<anonymous closure> (package:noports_core/src/sshnp/util/sshnpd_channel/sshnpd_channel.dart:161)
#1      _rootRunUnary (dart:async/zone.dart:1407)
#2      _CustomZone.runUnary (dart:async/zone.dart:1308)
#3      _FutureListener.handleError (dart:async/future_impl.dart:181)
#4      Future._propagateToListeners.handleError (dart:async/future_impl.dart:859)
#5      Future._propagateToListeners (dart:async/future_impl.dart:880)
#6      Future._completeError (dart:async/future_impl.dart:660)
```

**AFTER**

C Daemon (This PR contains fix to compounding namespacing.)

```
[DEBG] 2024-07-09 14:40:46.111179 | connection |        SENT: "update:ttr:-1:ccd:true:isEncrypted:true:ivNonce:9WMJlltq4nxzUOq+VHuLQA==:@soccer0:username.vps.sshnp@soccer99 wbyrVsvUJf5+9JEzzMZSAw=="
[DEBG] 2024-07-09 14:40:46.148773 | connection |        RECV: "data:543"
```


**- Description for the changelog**
fix: (c sshnpd) username and --list-devices bug
