### PR TITLE
fix: more time for npt control socket creation

### DIFF
--- a/packages/dart/noports_core/lib/src/srv/srv_impl.dart
+++ b/packages/dart/noports_core/lib/src/srv/srv_impl.dart
@@ -497,7 +497,7 @@ class SrvImplDart implements Srv<SocketConnector> {
 
     Socket sessionControlSocket = await Socket.connect(
         streamingHost, streamingPort,
-        timeout: Duration(seconds: 1));
+        timeout: Duration(seconds: 10));
     // Authenticate the control socket
     if (rvdAuthString != null) {
       logger.info('_runClientSideMulti authenticating'
@@ -580,7 +580,7 @@ class SrvImplDart implements Srv<SocketConnector> {
     // - for each request, create a socketToSocket connection
     Socket sessionControlSocket = await Socket.connect(
         streamingHost, streamingPort,
-        timeout: Duration(seconds: 1));
+        timeout: Duration(seconds: 10));
     // Authenticate the control socket
     if (rvdAuthString != null) {
       logger.info('_runDaemonSideMulti authenticating'


### PR DESCRIPTION
**- What I did**
- when creating the control sockets, there is currently only a 1-second timeout for the actual socket creation... on slow networks or highly loaded machines this will not be long enough; increased timeout to 10 seconds

**- How I did it**
See commits

**- How to verify it**
Tests pass

