### PR TITLE
fix: (i) fix race condition in daemon-side multi srv; (ii) add `\n` separator to npt control messages

### DIFF
--- a/packages/dart/noports_core/lib/src/srv/srv_impl.dart
+++ b/packages/dart/noports_core/lib/src/srv/srv_impl.dart
@@ -549,7 +549,7 @@ class SrvImplDart implements Srv<SocketConnector> {
         String socketIV =
             base64Encode(AtChopsUtil.generateRandomIV(16).ivBytes);
         controlSink.add(
-            Uint8List.fromList('connect:$socketAESKey:$socketIV'.codeUnits));
+            Uint8List.fromList('connect:$socketAESKey:$socketIV\n'.codeUnits));
         // Authenticate the sideB socket (to the rvd)
         if (rvdAuthString != null) {
           logger

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -470,7 +470,7 @@ class SshnpdImpl implements Sshnpd {
         atKey: _createResponseAtKey(
             requestingAtsign: requestingAtsign, sessionId: req.sessionId),
         value: 'Daemon does not permit connections to $requested',
-        sessionId: req.sessionId, 
+        sessionId: req.sessionId,
       );
 
       return;

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   posix: ^6.0.1
   socket_connector: ^2.2.0
   uuid: ^3.0.7
+  mutex: ^3.1.0
 
 dependency_overrides:
   dartssh2:


### PR DESCRIPTION
**- What I did**
- fix: fix race condition occurring in the daemon-side multi srv when connections are being made within the same very short time period (microS to low milliS)
- fix: append `\n` to the connect message sent on the npt control socket

**- How I did it**
1. wrap the control event handling in a mutex
2. handle situation where multiple connect requests are arriving in the same tcp/ip flow
3. fix: append \n to the connect message sent on the npt control socket

**- How to verify it**
(i) e2e tests pass
(ii) manually verified backwards compatibility with the `\n` separator by running multiple ssh sessions over an npt tunnel to port 22
