### PR TITLE
docs: add additional build flags

### DIFF
--- a/packages/c/sshnpd/README.md
+++ b/packages/c/sshnpd/README.md
@@ -51,7 +51,7 @@ With `gcc` (disables warnings found in mbedtls' tests):
 
 ```bash
 cd packages/c/sshnpd
-cmake -B build -S . -DBUILD_SHARED_LIBS=off -DCMAKE_C_COMPILER=gcc -DCMAKE_C_FLAGS="-Wno-calloc-transposed-args"
+cmake -B build -S . -DBUILD_SHARED_LIBS=off -DCMAKE_C_COMPILER=gcc -DCMAKE_C_FLAGS="-Wno-calloc-transposed-args -Wno-error -pthread -lrt"
 cmake --build build
 ```
 
@@ -59,7 +59,7 @@ With clang:
 
 ```bash
 cd packages/c/sshnpd
-cmake -B build -S . -DBUILD_SHARED_LIBS=off -DCMAKE_C_COMPILER=clang
+cmake -B build -S . -DBUILD_SHARED_LIBS=off -DCMAKE_C_COMPILER=clang -DCMAKE_C_FLAGS="-Wno-error -pthread -lrt"
 cmake --build build
 ```
 


### PR DESCRIPTION
- needed when cross compiling

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added recommended flags to README

- Wno-error: So a build doesn't fail over pedantic / trivial "errors"
- pthread & lrt - libs needed but must be explicitly specified in a cross-compiled build

**- How I did it**

**- How to verify it**

**- Description for the changelog**
docs: add additional build flags
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
