### PR TITLE
fix: remove id from the process list when child process completes

### DIFF
--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -406,7 +406,8 @@ void main_loop() {
       waitpid(srv_pids.processes[i], &status, WNOHANG); // Don't wait for srv - we want it to be running in the bg
       if (WIFEXITED(status)) {
         atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Exited srv process: %d\n", srv_pids.processes[i]);
-        srv_pids.processes = realloc(srv_pids.processes, sizeof(pid_t) * --srv_pids.len);
+        srv_pids.processes[i] = srv_pids.processes[--srv_pids.len]; // move last element into the newly free slot
+        srv_pids.processes = realloc(srv_pids.processes, sizeof(pid_t) * srv_pids.len);
       }
     }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Make sure to remove the correct process id by moving the last item in the array to the position of the process id that has just finished before downsizing with realloc

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: remove id from the process list when child process completes
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
