### PR TITLE
fix: if group is not $user only chown user and no group

### DIFF
--- a/packages/dart/sshnoports/bundles/shell/install.sh
+++ b/packages/dart/sshnoports/bundles/shell/install.sh
@@ -110,7 +110,7 @@ usage() {
 setup_authorized_keys() {
   mkdir -p "$user_ssh_dir"
   touch "$user_ssh_dir/authorized_keys"
-  chown $user:$user "$user_ssh_dir/authorized_keys"
+  chown $user:$user "$user_ssh_dir/authorized_keys" || chown $user "$user_ssh_dir/authorized_keys"
   chmod 644 "$user_ssh_dir/authorized_keys"
 }
 
@@ -150,12 +150,12 @@ install_single_binary() {
   then
     if ! [ -d "$user_bin_dir" ]; then
       mkdir -p "$user_bin_dir"
-      chown -R $user:$user "$user_bin_dir"
+      chown -R $user:$user "$user_bin_dir" || chown -R $user "$user_bin_dir"
     fi
 
     if [ -f "$dest/$1" ]; then
       ln -sf "$dest/$1" "$user_bin_dir/$1"
-      chown $user:$user "$user_bin_dir/$1"
+      chown $user:$user "$user_bin_dir/$1" || chown $user "$user_bin_dir/$1"
       echo "=> Linked $user_bin_dir/$1 to $dest/$1"
     else
       echo "Failed to link $user_bin_dir/$1 to $dest/$1:"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

On some platforms the group is not the same as $USER thus these `chown`s will fail

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: if group is not $user only chown user and no group
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
