### PR TITLE
fix: use wrapped chown method in all places

### DIFF
--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -617,7 +617,7 @@ get_atsign() {
     fi
   else
     mkdir -p "$user_home"/.atsign/keys
-    chown -R $user:$user "$user_home"/.atsign
+    chown_dir "$user_home"/.atsign
     echo "$HOME/.atsign/keys directory created"
     echo "Since we did not detect any atkeys on this machine, please enter the $clientOrDevice atSign manually."
     get_atsign_manually


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Used the `chown_dir` wrapper function instead of calling `chown` directly.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: use wrapped chown method in all places
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
