### PR TITLE
ci: parallel e2e tests

### DIFF
--- a/.github/workflows/e2e_all.yaml
+++ b/.github/workflows/e2e_all.yaml
@@ -21,7 +21,9 @@ on:
 jobs:
   e2e_all:
     # Don't run on PRs from a fork or Dependabot as the secrets aren't available
-    if: ${{ github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'}}
+    if:
+      ${{ github.event.pull_request.head.repo.fork == false && github.actor !=
+      'dependabot[bot]'}}
     concurrency: e2e_all
     runs-on: ubuntu-latest
 
@@ -44,4 +46,4 @@ jobs:
             echo "Running git checkout -f $SHA"
             git checkout -f "$SHA"
             echo "Running tests"
-            tests/e2e_all/scripts/main.sh @apricoteventual @combinedbelgian @rv_am
+            tests/e2e_all/scripts/main.sh @apricoteventual @combinedbelgian @rv_am -p

--- a/tests/e2e_all/scripts/common/apkam_setup.sh
+++ b/tests/e2e_all/scripts/common/apkam_setup.sh
@@ -72,7 +72,7 @@ enroll() {
     logInfo "keys file HAS been created at $keysFileName"
     return 0
   else
-    logError "keys file has NOT been created at $keysFileName"
+    logErrorAndReport "keys file has NOT been created at $keysFileName"
     return 1
   fi
 }

--- a/tests/e2e_all/scripts/common/common_functions.include.sh
+++ b/tests/e2e_all/scripts/common/common_functions.include.sh
@@ -181,6 +181,16 @@ logInfoAndReport() {
   echo -e "$(iso8601Date) | $1" | tee -a "$(getReportFile)"
 }
 
+getBaseFileName() {
+  # expected input: $testToRun $daemonVersion $clientVersion
+  printf "$(getOutputDir)/clients/${1}.daemon.${2}.client.${3}"
+}
+
+getDaemonLogFragmentName() {
+  # expected input: $testToRun $daemonVersion $clientVersion
+  printf "$(getBaseFileName $1 $2 $3).daemonLogFragment.log"
+}
+
 getVersionDescription() {
   if (($# != 1)); then logErrorAndExit "getVersionDescription requires 1 parameter"; fi
   IFS=: read -r type version <<<"$1"

--- a/tests/e2e_all/scripts/common/common_functions.include.sh
+++ b/tests/e2e_all/scripts/common/common_functions.include.sh
@@ -109,7 +109,7 @@ getReportFile() {
 
 getDeviceNameNoFlags() {
   if (($# != 2)); then
-    logError "getDeviceNameNoFlags expects two parameters; $# were supplied"
+    logErrorAndReport "getDeviceNameNoFlags expects two parameters; $# were supplied"
     exit 1
   fi
   commitId="$1"
@@ -124,45 +124,25 @@ getDeviceNameNoFlags() {
 
 getDeviceNameWithFlags() {
   if (($# != 2)); then
-    logError "getDeviceNameFlags expects two parameters; $# were supplied"
+    logErrorAndReport "getDeviceNameFlags expects two parameters; $# were supplied"
     exit 1
   fi
   # shellcheck disable=SC2086
   echo "$(getDeviceNameNoFlags $1 $2)f"
 }
 
-OS=""
+# Calling this "OS" unsets the environment variable of the same name thus it is named "cachedOS" to avoid side effects
+cachedOS=""
 iso8601Date() {
-  if test "$OS" == ""; then
-    OS=$(uname -s)
+  if test "$cachedOS" == ""; then
+    cachedOS=$(uname -s)
   fi
-  if test "$OS" == "Darwin"; then
+  if test "$cachedOS" == "Darwin"; then
     # no milliseconds in Darwin
     date +"%Y-%m-%d %H:%M:%S"
   else
     date +"%Y-%m-%d %H:%M:%S.%3N"
   fi
-}
-
-logGreenInfo() {
-  echo -e "$(iso8601Date) |     ${GREEN}INFO :${NC} $1"
-}
-
-logError() {
-  echo -e "$(iso8601Date) |     ${RED}ERROR:${NC} $1" | tee -a "$(getReportFile)"
-}
-
-logErrorAndExit() {
-  logError "$1"
-  exit 1
-}
-
-logWarning() {
-  echo -e "$(iso8601Date) |     ${ORANGE}WARN :${NC} $1" | tee -a "$(getReportFile)"
-}
-
-crLog() {
-  echo -e "\r$(iso8601Date) | $1"
 }
 
 log() {
@@ -173,12 +153,33 @@ logInfo() {
   log "$1"
 }
 
-reportInfo() {
-  logInfo "$1" >>"$(getReportFile)"
+logGreenInfo() {
+  log "${GREEN}INFO :${NC} $1"
+}
+
+logError() {
+  log "${RED}ERROR:${NC} $1"
+}
+
+logWarning() {
+  echo -e "$(iso8601Date) |     ${ORANGE}WARN :${NC} $1"
 }
 
 logInfoAndReport() {
-  echo -e "$(iso8601Date) | $1" | tee -a "$(getReportFile)"
+  logInfo "$1" | tee -a "$(getReportFile)"
+}
+
+logErrorAndReport() {
+  logError "$1" | tee -a "$(getReportFile)"
+}
+
+logErrorAndExit() {
+  logErrorAndReport "$1"
+  exit 1
+}
+
+crLog() {
+  echo -e "\r$(iso8601Date) | $1"
 }
 
 getBaseFileName() {
@@ -189,6 +190,14 @@ getBaseFileName() {
 getDaemonLogFragmentName() {
   # expected input: $testToRun $daemonVersion $clientVersion
   printf "$(getBaseFileName $1 $2 $3).daemonLogFragment.log"
+}
+
+getSingleTestOutputLogName() {
+  printf "$(getBaseFileName $1 $2 $3).testOutput.log"
+}
+
+getSingleTestResultLogName() {
+  printf "$(getBaseFileName $1 $2 $3).testResult.log"
 }
 
 getVersionDescription() {
@@ -317,7 +326,7 @@ versionIsAtLeast() {
 
 getPathToBinariesForTypeAndVersion() {
   if (($# != 1)); then
-    logError "getPathToBinariesForTypeAndVersion expects one parameter, but was supplied $#"
+    logErrorAndReport "getPathToBinariesForTypeAndVersion expects one parameter, but was supplied $#"
     exit 1
   fi
   typeAndVersion="$1"
@@ -562,3 +571,19 @@ buildCurrentCBinaries() {
 }
 
 ### END C ###
+
+setup_type_and_version() {
+  IFS=: read -r type version <<<"$1"
+  case "$type" in
+    d) # dart
+      setupDartVersion "$version" || logErrorAndExit "Failed to set up binaries for dart version [$version]"
+      ;;
+    c) # c
+      setupCVersion "$version" || logErrorAndExit "Failed to set up binaries for c version [$version]"
+      ;;
+    *)
+      logErrorAndExit "This script doesn't know where to find NoPorts daemon binary for [$typeAndVersion]"
+      exit 1
+      ;;
+  esac
+}

--- a/tests/e2e_all/scripts/common/run_single_test.sh
+++ b/tests/e2e_all/scripts/common/run_single_test.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# N.B. this file must not depend on any external environment variables that are set in various places by the end2end
+# test suite. When running under GNU parallels, the environment is empty, thus every single variable in this file must
+# either be explicitly set in the parallels command with `--env` or passed to this script as part of the argument list
+
+script_dir="$(dirname -- "$(readlink -f -- "$0")")"
+source "$script_dir/common_functions.include.sh"
+
+clientVersion="$1"
+daemonVersion="$2"
+testToRun="$3"
+timeoutDuration="$4"
+
+baseFileName="$(getBaseFileName $testToRun $daemonVersion $clientVersion)"
+daemonLogFragmentName="$(getDaemonLogFragmentName $testToRun $daemonVersion $clientVersion)"
+stdoutFileName="${baseFileName}.out"
+stderrFileName="${baseFileName}.err"
+singleTestOutputLog="$(getSingleTestOutputLogName $testToRun $daemonVersion $clientVersion)"
+singleTestResultLog="$(getSingleTestResultLogName $testToRun $daemonVersion $clientVersion)"
+
+touch $singleTestOutputLog
+
+pdv=$(getVersionDescription "$daemonVersion")
+pcv=$(getVersionDescription "$clientVersion")
+what="${BOLD}Running test: ${BBLUE}${testToRun}${NC} ${BOLD}Client: ${BBLUE}${pcv}${NC} ${BOLD}Daemon: ${BBLUE}${pdv}${NC}"
+logInfo "$what" | tee -a "$singleTestOutputLog"
+
+exitStatus=1
+maxAttempts=5
+if [[ $(uname -s) == "Darwin" ]]; then
+  maxAttempts=2
+fi
+attempts=0
+
+while ((exitStatus != 0 && exitStatus != 50 && attempts < maxAttempts)); do
+  rm -f "$daemonLogFragmentName"
+  touch "$daemonLogFragmentName"
+  if ((attempts > 0)); then
+    logWarning "    Exit status was $exitStatus; will retry in 3 seconds"
+    sleep 3
+  fi
+
+  # Execute the test script
+  timeout --foreground "$timeoutDuration" "$testScriptsDir/tests/$testToRun" "$daemonVersion" "$clientVersion" \
+    >"$stdoutFileName" 2>"$stderrFileName"
+
+  exitStatus=$?
+  if ((exitStatus != 0 && exitStatus != 50)); then
+    # shellcheck disable=SC2129
+    echo "    test execution's stdout: " >>"$singleTestOutputLog" 2>&1
+    sed 's/^/        /' "$stdoutFileName" >>"$singleTestOutputLog" 2>&1
+
+    echo "    test execution's stderr: " >>"$singleTestOutputLog" 2>&1
+    sed 's/^/        /' "$stderrFileName" >>"$singleTestOutputLog" 2>&1
+
+    echo "    daemon log fragment: " >>"$singleTestOutputLog" 2>&1
+    sed 's/^/        /' "$daemonLogFragmentName" >>"$singleTestOutputLog" 2>&1
+
+    echo
+    echo >>"$singleTestOutputLog" 2>&1
+  fi
+
+  attempts=$((attempts + 1))
+done
+
+if ((exitStatus != 0 && exitStatus != 50 && attempts == maxAttempts)); then
+  logError "    Failed after $maxAttempts attempts" >>"$singleTestOutputLog" 2>&1
+fi
+
+if ((exitStatus == 0)); then
+  # Exit code 0, but did the output contain the magic 'TEST PASSED' words?
+  if ! grep -q "TEST PASSED" "$stdoutFileName"; then
+    exitStatus=51
+  fi
+fi
+
+echo "$exitStatus" >"$singleTestResultLog"

--- a/tests/e2e_all/scripts/common/run_tests.sh
+++ b/tests/e2e_all/scripts/common/run_tests.sh
@@ -12,11 +12,6 @@ mkdir -p /tmp/e2e_all
 reportFile=$(getReportFile)
 rm -f "$reportFile"
 
-passed=0
-failed=0
-ignored=0
-total=0
-
 # shellcheck disable=SC2129
 echo "###########################################################" >>"$reportFile"
 echo "### NoPorts e2e test run starting at $(iso8601Date)" >>"$reportFile"
@@ -32,159 +27,114 @@ numClients=$(wc -w <<<"$clientVersions")
 numTestScripts=$(wc -w <<<"$testsToRun")
 totalNumTests=$((numDaemons * numClients * numTestScripts))
 
-run_test() {
-  local clientVersion="$1"
-  local daemonVersion="$2"
-  local testToRun="$3"
-
-  pdv=$(getVersionDescription "$daemonVersion")
-  pcv=$(getVersionDescription "$clientVersion")
-  what="Test $((total + 1)) of $totalNumTests | ${BOLD}Test script: ${BBLUE}${testToRun}${NC} ${BOLD}Client: ${BBLUE}${pcv}${NC} ${BOLD}Daemon: ${BBLUE}${pdv}${NC}"
-  echo
-  logInfoAndReport "$what"
-
-  baseFileName="$(getBaseFileName $testToRun $daemonVersion $clientVersion)"
-  daemonLogFragmentName="$(getDaemonLogFragmentName $testToRun $daemonVersion $clientVersion)"
-  stdoutFileName="${baseFileName}.out"
-  stderrFileName="${baseFileName}.err"
-
-  exitStatus=1
-  maxAttempts=5
-  if [[ $(uname -s) == "Darwin" ]]; then
-    maxAttempts=2
-  fi
-  attempts=0
-
-  while ((exitStatus != 0 && exitStatus != 50 && attempts < maxAttempts)); do
-    rm -f "$daemonLogFragmentName"
-    touch "$daemonLogFragmentName"
-    if ((attempts > 0)); then
-      logWarning "    Exit status was $exitStatus; will retry in 3 seconds"
-      sleep 3
-    fi
-    log "    Running test script ... "
-
-    # Execute the test script
-    timeout --foreground "$timeoutDuration" "$testScriptsDir/tests/$testToRun" "$daemonVersion" "$clientVersion" \
-      >"$stdoutFileName" 2>"$stderrFileName"
-
-    exitStatus=$?
-    if ((exitStatus != 0 && exitStatus != 50)); then
-      # shellcheck disable=SC2129
-      echo "    test execution's stdout: " | tee -a "$reportFile"
-      sed 's/^/        /' "$stdoutFileName" | tee -a "$reportFile"
-
-      echo "    test execution's stderr: " | tee -a "$reportFile"
-      sed 's/^/        /' "$stderrFileName" | tee -a "$reportFile"
-
-      echo "    daemon log fragment: " | tee -a "$reportFile"
-      sed 's/^/        /' "$daemonLogFragmentName" | tee -a "$reportFile"
-
-      echo
-      echo >>"$reportFile"
-    fi
-
-    attempts=$((attempts + 1))
-  done
-
-  if ((exitStatus != 0 && exitStatus != 50 && attempts == maxAttempts)); then
-    logError "    Failed after $maxAttempts attempts                                                            "
-  fi
-
-  total=$((total + 1))
-  if ((exitStatus == 0)); then
-    # Exit code 0, but did the output contain the magic 'TEST PASSED' words?
-    if ! grep -q "TEST PASSED" "$stdoutFileName"; then
-      exitStatus=51
-    fi
-  fi
-
-  additionalInfo=""
-  testResult="WAT"
-
-  case $exitStatus in
-    0) # test passed
-      testResult="PASSED"
-      passed=$((passed + 1))
-      ;;
-    50) # special exit code, indicates the test was deliberately ignored
-      testResult="N/A"
-      additionalInfo="(not applicable)"
-      ignored=$((ignored + 1))
-      ;;
-    51) # special exit code, indicates the exit code was 0 but there was no 'TEST PASSED' output
-      testResult="FAILED"
-      additionalInfo="(test exit status was 0, but no 'TEST PASSED' in test output)"
-      failed=$((failed + 1))
-      ;;
-    124) # timeout returns 124 if the command timed out
-      testResult="FAILED"
-      additionalInfo="(timed out after $timeoutDuration seconds)"
-      failed=$((failed + 1))
-      ;;
-    *) # any other non-zero exit code is a failure
-      testResult="FAILED"
-      failed=$((failed + 1))
-      ;;
-  esac
-  case $testResult in
-    FAILED) logColour=$RED ;;
-    "N/A") logColour=$BLUE ;;
-    PASSED) logColour=$GREEN ;;
-    *) logErrorAndExit "Unexpected testResult $testResult" ;;
-  esac
-
-  case $testResult in
-    FAILED)
-      logInfoAndReport "    ${logColour}Test ${testResult}${NC} : exit code $exitStatus $additionalInfo"
-      ;;
-    "N/A")
-      logInfoAndReport "    ${logColour}Test ${testResult}${NC}"
-      ;;
-    PASSED)
-      logInfoAndReport "    ${logColour}Test ${testResult}${NC}"
-      ;;
-  esac
-  echo >>"$reportFile"
-}
-
+# N.B. any variable used by this function must be explicitly set when called from GNU parallel
 run_tests_for_daemon() {
-  local daemonVersion = "$1"
+  local daemonVersion="$1"
   for testToRun in $testsToRun; do
     for clientVersion in $clientVersions; do
-      run_test $clientVersion $daemonVersion $testToRun
-      if [[ "$testResult" == "FAILED" ]]; then
-        break
-      fi
+      "$testScriptsDir/common/run_single_test.sh" $clientVersion $daemonVersion $testToRun $timeoutDuration
     done
-    if [[ "$testResult" == "FAILED" ]]; then
-      break
-    fi
   done
 }
 
-if command -v parallel >/dev/null 2>&1; then
-  parallel run_tests_for_daemon -- $daemonVersions
+if [ $allowParallelization == "true" ] && command -v env_parallel >/dev/null 2>&1; then
+  logInfo "Found GNU parallel, running tests in parallel"
+  export -f run_tests_for_daemon
+  # Run a round of tests against each daemon in parallel
+  parallel --jobs 5 \
+    --env run_tests_for_daemon \
+    "testScriptsDir='$testScriptsDir' && testsToRun='$testsToRun' && clientVersions='$clientVersions' && testScriptsDir='$testScriptsDir' && timeoutDuration='$timeoutDuration' && run_tests_for_daemon" \
+    ::: $daemonVersions
 else
-  logWarning "Unable to find GNU parallel, running tests linearly"
-  for testToRun in $testsToRun; do
-    for daemonVersion in $daemonVersions; do
+  # The old way of running e2e tests - no parallelization
+  logWarning "Unable to find GNU parallel, running tests serially :("
+  for daemonVersion in $daemonVersions; do
+    for testToRun in $testsToRun; do
       for clientVersion in $clientVersions; do
-        run_test $clientVersion $daemonVersion $testToRun
-        if [[ "$testResult" == "FAILED" ]]; then
-          break
-        fi
+        "$testScriptsDir/common/run_single_test.sh" $clientVersion $daemonVersion $testToRun $timeoutDuration
       done
-      if [[ "$testResult" == "FAILED" ]]; then
-        break
-      fi
     done
-    if [[ "$testResult" == "FAILED" ]]; then
-      break
-    fi
   done
-
 fi
+
+passed=0
+failed=0
+ignored=0
+total=0
+
+logInfo "Aggregating Test Info:"
+
+# Aggregation of all the logs at the end serially so that the final report is in order
+for daemonVersion in $daemonVersions; do
+  for testToRun in $testsToRun; do
+    for clientVersion in $clientVersions; do
+      singleTestOutputLog="$(getSingleTestOutputLogName $testToRun $daemonVersion $clientVersion)"
+      singleTestResultLog="$(getSingleTestResultLogName $testToRun $daemonVersion $clientVersion)"
+
+      exitStatus=$(cat $singleTestResultLog | tr -d "\n")
+
+      additionalInfo=""
+      testResult="WAT"
+
+      cat "$singleTestOutputLog" >>"$reportFile"
+
+      case $exitStatus in
+        0) # test passed
+          testResult="PASSED"
+          ;;
+        50) # special exit code, indicates the test was deliberately ignored
+          testResult="N/A"
+          additionalInfo="(not applicable)"
+          ;;
+        51) # special exit code, indicates the exit code was 0 but there was no 'TEST PASSED' output
+          testResult="FAILED"
+          additionalInfo="(test exit status was 0, but no 'TEST PASSED' in test output)"
+          ;;
+        124) # timeout returns 124 if the command timed out
+          testResult="FAILED"
+          additionalInfo="(timed out after $timeoutDuration seconds)"
+          ;;
+        *) # any other non-zero exit code is a failure
+          testResult="FAILED"
+          ;;
+      esac
+
+      total=$((total + 1))
+      case $testResult in
+        FAILED)
+          logColour=$RED
+          failed=$((failed + 1))
+          ;;
+        "N/A")
+          logColour=$BLUE
+          ignored=$((ignored + 1))
+          ;;
+        PASSED)
+          logColour=$GREEN
+          passed=$((passed + 1))
+          ;;
+        *)
+          logError "    Unexpected testResult $testResult" >>"$reportFile"
+          failed=$((failed + 1))
+          ;;
+      esac
+
+      case $testResult in
+        FAILED)
+          logError "    ${logColour}Test ${testResult}${NC} : exit code $exitStatus $additionalInfo" >>"$reportFile"
+          ;;
+        "N/A")
+          logInfo "    ${logColour}Test ${testResult}${NC}" >>"$reportFile"
+          ;;
+        PASSED)
+          logInfo "    ${logColour}Test ${testResult}${NC}" >>"$reportFile"
+          ;;
+      esac
+
+    done
+  done
+done
+
 # shellcheck disable=SC2129
 
 echo "### " >>"$reportFile"
@@ -201,4 +151,8 @@ echo -e "### Of a possible $total, $ignored were not applicable (usually version
 echo -e "${colour}### Executed: $actuallyExecuted  Passed: $passed  Failed: $failed${NC}" >>"$reportFile"
 echo "###########################################################" >>"$reportFile"
 
-exit $failed
+if ((failed == 0)); then
+  exit 0
+else
+  exit 1
+fi

--- a/tests/e2e_all/scripts/common/run_tests.sh
+++ b/tests/e2e_all/scripts/common/run_tests.sh
@@ -32,120 +32,127 @@ numClients=$(wc -w <<<"$clientVersions")
 numTestScripts=$(wc -w <<<"$testsToRun")
 totalNumTests=$((numDaemons * numClients * numTestScripts))
 
-for testToRun in $testsToRun; do
-  for daemonVersion in $daemonVersions; do
-    pdv=$(getVersionDescription "$daemonVersion")
-    for clientVersion in $clientVersions; do
-      pcv=$(getVersionDescription "$clientVersion")
-      what="Test $((total + 1)) of $totalNumTests | ${BOLD}Test script: ${BBLUE}${testToRun}${NC} ${BOLD}Client: ${BBLUE}${pcv}${NC} ${BOLD}Daemon: ${BBLUE}${pdv}${NC}"
+run_test() {
+  local clientVersion="$1"
+  local daemonVersion="$2"
+  local testToRun="$3"
+
+  pdv=$(getVersionDescription "$daemonVersion")
+  pcv=$(getVersionDescription "$clientVersion")
+  what="Test $((total + 1)) of $totalNumTests | ${BOLD}Test script: ${BBLUE}${testToRun}${NC} ${BOLD}Client: ${BBLUE}${pcv}${NC} ${BOLD}Daemon: ${BBLUE}${pdv}${NC}"
+  echo
+  logInfoAndReport "$what"
+
+  baseFileName="$(getBaseFileName $testToRun $daemonVersion $clientVersion)"
+  daemonLogFragmentName="$(getDaemonLogFragmentName $testToRun $daemonVersion $clientVersion)"
+  stdoutFileName="${baseFileName}.out"
+  stderrFileName="${baseFileName}.err"
+
+  exitStatus=1
+  maxAttempts=5
+  if [[ $(uname -s) == "Darwin" ]]; then
+    maxAttempts=2
+  fi
+  attempts=0
+
+  while ((exitStatus != 0 && exitStatus != 50 && attempts < maxAttempts)); do
+    rm -f "$daemonLogFragmentName"
+    touch "$daemonLogFragmentName"
+    if ((attempts > 0)); then
+      logWarning "    Exit status was $exitStatus; will retry in 3 seconds"
+      sleep 3
+    fi
+    log "    Running test script ... "
+
+    # Execute the test script
+    timeout --foreground "$timeoutDuration" "$testScriptsDir/tests/$testToRun" "$daemonVersion" "$clientVersion" \
+      >"$stdoutFileName" 2>"$stderrFileName"
+
+    exitStatus=$?
+    if ((exitStatus != 0 && exitStatus != 50)); then
+      # shellcheck disable=SC2129
+      echo "    test execution's stdout: " | tee -a "$reportFile"
+      sed 's/^/        /' "$stdoutFileName" | tee -a "$reportFile"
+
+      echo "    test execution's stderr: " | tee -a "$reportFile"
+      sed 's/^/        /' "$stderrFileName" | tee -a "$reportFile"
+
+      echo "    daemon log fragment: " | tee -a "$reportFile"
+      sed 's/^/        /' "$daemonLogFragmentName" | tee -a "$reportFile"
+
       echo
-      logInfoAndReport "$what"
-
-      baseFileName="${outputDir}/clients/${testToRun}.daemon.${daemonVersion}.client.${clientVersion}"
-      stdoutFileName="${baseFileName}.out"
-      stderrFileName="${baseFileName}.err"
-      DAEMON_LOG_FRAGMENT_NAME="${baseFileName}.daemonLogFragment.log"
-      export DAEMON_LOG_FRAGMENT_NAME
-
-      exitStatus=1
-      maxAttempts=5
-      if [[ $(uname -s) == "Darwin" ]]; then
-        maxAttempts=2
-      fi
-      attempts=0
-
-      while ((exitStatus != 0 && exitStatus != 50 && attempts < maxAttempts)); do
-        rm -f "$DAEMON_LOG_FRAGMENT_NAME"
-        touch "$DAEMON_LOG_FRAGMENT_NAME"
-        if ((attempts > 0)); then
-          logWarning "    Exit status was $exitStatus; will retry in 3 seconds"
-          sleep 3
-        fi
-        log "    Running test script ... "
-
-        # Execute the test script
-        timeout --foreground "$timeoutDuration" "$testScriptsDir/tests/$testToRun" "$daemonVersion" "$clientVersion" \
-          >"$stdoutFileName" 2>"$stderrFileName"
-
-        exitStatus=$?
-        if ((exitStatus != 0 && exitStatus != 50)); then
-          # shellcheck disable=SC2129
-          echo "    test execution's stdout: " | tee -a "$reportFile"
-          sed 's/^/        /' "$stdoutFileName" | tee -a "$reportFile"
-
-          echo "    test execution's stderr: " | tee -a "$reportFile"
-          sed 's/^/        /' "$stderrFileName" | tee -a "$reportFile"
-
-          echo "    daemon log fragment: " | tee -a "$reportFile"
-          sed 's/^/        /' "$DAEMON_LOG_FRAGMENT_NAME" | tee -a "$reportFile"
-
-          echo
-          echo >>"$reportFile"
-        fi
-
-        attempts=$((attempts + 1))
-      done
-
-      if ((exitStatus != 0 && exitStatus != 50 && attempts == maxAttempts)); then
-        logError "    Failed after $maxAttempts attempts                                                            "
-      fi
-
-      total=$((total + 1))
-      if ((exitStatus == 0)); then
-        # Exit code 0, but did the output contain the magic 'TEST PASSED' words?
-        if ! grep -q "TEST PASSED" "$stdoutFileName"; then
-          exitStatus=51
-        fi
-      fi
-
-      additionalInfo=""
-      testResult="WAT"
-
-      case $exitStatus in
-        0) # test passed
-          testResult="PASSED"
-          passed=$((passed + 1))
-          ;;
-        50) # special exit code, indicates the test was deliberately ignored
-          testResult="N/A"
-          additionalInfo="(not applicable)"
-          ignored=$((ignored + 1))
-          ;;
-        51) # special exit code, indicates the exit code was 0 but there was no 'TEST PASSED' output
-          testResult="FAILED"
-          additionalInfo="(test exit status was 0, but no 'TEST PASSED' in test output)"
-          failed=$((failed + 1))
-          ;;
-        124) # timeout returns 124 if the command timed out
-          testResult="FAILED"
-          additionalInfo="(timed out after $timeoutDuration seconds)"
-          failed=$((failed + 1))
-          ;;
-        *) # any other non-zero exit code is a failure
-          testResult="FAILED"
-          failed=$((failed + 1))
-          ;;
-      esac
-      case $testResult in
-        FAILED) logColour=$RED ;;
-        "N/A") logColour=$BLUE ;;
-        PASSED) logColour=$GREEN ;;
-        *) logErrorAndExit "Unexpected testResult $testResult" ;;
-      esac
-
-      case $testResult in
-        FAILED)
-          logInfoAndReport "    ${logColour}Test ${testResult}${NC} : exit code $exitStatus $additionalInfo"
-          ;;
-        "N/A")
-          logInfoAndReport "    ${logColour}Test ${testResult}${NC}"
-          ;;
-        PASSED)
-          logInfoAndReport "    ${logColour}Test ${testResult}${NC}"
-          ;;
-      esac
       echo >>"$reportFile"
+    fi
 
+    attempts=$((attempts + 1))
+  done
+
+  if ((exitStatus != 0 && exitStatus != 50 && attempts == maxAttempts)); then
+    logError "    Failed after $maxAttempts attempts                                                            "
+  fi
+
+  total=$((total + 1))
+  if ((exitStatus == 0)); then
+    # Exit code 0, but did the output contain the magic 'TEST PASSED' words?
+    if ! grep -q "TEST PASSED" "$stdoutFileName"; then
+      exitStatus=51
+    fi
+  fi
+
+  additionalInfo=""
+  testResult="WAT"
+
+  case $exitStatus in
+    0) # test passed
+      testResult="PASSED"
+      passed=$((passed + 1))
+      ;;
+    50) # special exit code, indicates the test was deliberately ignored
+      testResult="N/A"
+      additionalInfo="(not applicable)"
+      ignored=$((ignored + 1))
+      ;;
+    51) # special exit code, indicates the exit code was 0 but there was no 'TEST PASSED' output
+      testResult="FAILED"
+      additionalInfo="(test exit status was 0, but no 'TEST PASSED' in test output)"
+      failed=$((failed + 1))
+      ;;
+    124) # timeout returns 124 if the command timed out
+      testResult="FAILED"
+      additionalInfo="(timed out after $timeoutDuration seconds)"
+      failed=$((failed + 1))
+      ;;
+    *) # any other non-zero exit code is a failure
+      testResult="FAILED"
+      failed=$((failed + 1))
+      ;;
+  esac
+  case $testResult in
+    FAILED) logColour=$RED ;;
+    "N/A") logColour=$BLUE ;;
+    PASSED) logColour=$GREEN ;;
+    *) logErrorAndExit "Unexpected testResult $testResult" ;;
+  esac
+
+  case $testResult in
+    FAILED)
+      logInfoAndReport "    ${logColour}Test ${testResult}${NC} : exit code $exitStatus $additionalInfo"
+      ;;
+    "N/A")
+      logInfoAndReport "    ${logColour}Test ${testResult}${NC}"
+      ;;
+    PASSED)
+      logInfoAndReport "    ${logColour}Test ${testResult}${NC}"
+      ;;
+  esac
+  echo >>"$reportFile"
+}
+
+run_tests_for_daemon() {
+  local daemonVersion = "$1"
+  for testToRun in $testsToRun; do
+    for clientVersion in $clientVersions; do
+      run_test $clientVersion $daemonVersion $testToRun
       if [[ "$testResult" == "FAILED" ]]; then
         break
       fi
@@ -154,10 +161,30 @@ for testToRun in $testsToRun; do
       break
     fi
   done
-  if [[ "$testResult" == "FAILED" ]]; then
-    break
-  fi
-done
+}
+
+if command -v parallel >/dev/null 2>&1; then
+  parallel run_tests_for_daemon -- $daemonVersions
+else
+  logWarning "Unable to find GNU parallel, running tests linearly"
+  for testToRun in $testsToRun; do
+    for daemonVersion in $daemonVersions; do
+      for clientVersion in $clientVersions; do
+        run_test $clientVersion $daemonVersion $testToRun
+        if [[ "$testResult" == "FAILED" ]]; then
+          break
+        fi
+      done
+      if [[ "$testResult" == "FAILED" ]]; then
+        break
+      fi
+    done
+    if [[ "$testResult" == "FAILED" ]]; then
+      break
+    fi
+  done
+
+fi
 # shellcheck disable=SC2129
 
 echo "### " >>"$reportFile"

--- a/tests/e2e_all/scripts/common/start_daemons.sh
+++ b/tests/e2e_all/scripts/common/start_daemons.sh
@@ -17,7 +17,7 @@ waitUntilStarted() {
 
   while ! grep "Monitor .*monitor started" "$3"; do
     if ! ps -p "$1" >/dev/null; then
-      logError "Daemon $2 has exited. Log file follows: "
+      logErrorAndReport "Daemon $2 has exited. Log file follows: "
       cat "$3"
       # Do something knowing the pid exists, i.e. the process with $PID is running
       exit 1
@@ -25,7 +25,7 @@ waitUntilStarted() {
     sleep 1
     totalSleepTime=$((totalSleepTime + 1))
     if ((totalSleepTime > daemonStartWait)); then
-      logError "Daemon $2 has failed to start. Log file follows: "
+      logErrorAndReport "Daemon $2 has failed to start. Log file follows: "
       cat "$3"
       exit 1
     fi

--- a/tests/e2e_all/scripts/main.sh
+++ b/tests/e2e_all/scripts/main.sh
@@ -48,8 +48,8 @@ atDirectoryPort=64
 testsToRun="all"
 
 # defaultDaemonVersions="c:current"
-defaultDaemonVersions="d:4.0.5 d:5.2.0 d:current c:current"
-defaultClientVersions="d:4.0.5 d:5.2.0 d:current"
+defaultDaemonVersions="d:4.0.5 d:5.2.0 d:5.5.0 d:current c:current"
+defaultClientVersions="d:4.0.5 d:5.2.0 d:5.5.0 d:current"
 
 daemonVersions=$defaultDaemonVersions
 clientVersions=$defaultClientVersions

--- a/tests/e2e_all/scripts/main.sh
+++ b/tests/e2e_all/scripts/main.sh
@@ -25,6 +25,7 @@ function usageAndExit {
   echo "     [-u <remote username>] - defaults to the local username \\"
   echo "     [-w <daemon start wait time> - how long to wait for daemons to start up - defaults to 30 seconds] \\"
   echo "     [-n (Do not recompile binaries for current commit. Default is to always recompile.)]"
+  echo "     [-p (Enable test parallelization, requires GNU parallel to be installed.) ]"
   echo ""
   echo "Notes:"
   echo "  <atDirectory host> defaults to root.atsign.org"
@@ -57,6 +58,10 @@ clientVersions=$defaultClientVersions
 unset testScriptsDir
 unset testRootDir
 unset testRuntimeDir
+
+# Parallelization was designed for use with "GNU parallel 20210822"
+allowParallelization="false"
+
 recompile="true"
 
 scriptName=$(basename -- "$0")
@@ -80,17 +85,17 @@ fi
 
 clientAtSign="$1"
 if test "${clientAtSign:0:1}" != "@"; then
-  logError "invalid clientAtSign $clientAtSign"
+  logErrorAndReport "invalid clientAtSign $clientAtSign"
   usageAndExit
 fi
 daemonAtSign="$2"
 if test "${daemonAtSign:0:1}" != "@"; then
-  logError "invalid daemonAtSign $daemonAtSign"
+  logErrorAndReport "invalid daemonAtSign $daemonAtSign"
   usageAndExit
 fi
 srvAtSign="$3"
 if test "${srvAtSign:0:1}" != "@"; then
-  logError "invalid srvAtSign $srvAtSign"
+  logErrorAndReport "invalid srvAtSign $srvAtSign"
   usageAndExit
 fi
 
@@ -107,7 +112,7 @@ identityFilename="$HOME/.ssh/e2e_all.${commitId}"
 
 daemonStartWait=15
 
-while getopts r:t:s:c:u:w:n opt; do
+while getopts r:t:s:c:u:w:pn opt; do
   case $opt in
     r) atDirectoryHost=$OPTARG ;;
     t) testsToRun=$OPTARG ;;
@@ -115,6 +120,7 @@ while getopts r:t:s:c:u:w:n opt; do
     c) clientVersions=$OPTARG ;;
     u) remoteUsername=$OPTARG ;;
     w) daemonStartWait=$OPTARG ;;
+    p) allowParallelization="true" ;;
     n) recompile="false" ;;
     *) usageAndExit ;;
   esac
@@ -134,6 +140,7 @@ export clientVersions
 export remoteUsername
 export identityFilename
 export daemonStartWait
+export allowParallelization
 timeoutDuration=20
 export timeoutDuration
 
@@ -165,6 +172,7 @@ logInfo "    testRootDir:      $testRootDir"
 logInfo "    testRuntimeDir:   $testRuntimeDir"
 logInfo "    testScriptsDir:   $testScriptsDir"
 logInfo "    recompile:        $recompile"
+logInfo "    parallelization:  $allowParallelization"
 logInfo "    atDirectoryHost:  $atDirectoryHost"
 logInfo "    daemonVersions:   $daemonVersions"
 logInfo "    clientVersions:   $clientVersions"
@@ -177,7 +185,7 @@ export recompile
 "$testScriptsDir/common/setup_binaries.sh"
 retCode=$?
 if test "$retCode" != 0; then
-  logError "Failed to set up binaries - exiting"
+  logErrorAndReport "Failed to set up binaries - exiting"
   exit $retCode
 fi
 
@@ -202,7 +210,7 @@ logInfo "Calling start_daemons.sh"
 "$testScriptsDir/common/start_daemons.sh"
 retCode=$?
 if test "$retCode" != 0; then
-  logError "Failed to start daemons; will not run tests"
+  logErrorAndReport "Failed to start daemons; will not run tests"
   logInfo "Calling stop_daemons.sh"
   "$testScriptsDir/common/stop_daemons.sh"
   exit $retCode
@@ -216,7 +224,7 @@ logInfo "Calling common/stop_daemons.sh"
 "$testScriptsDir/common/stop_daemons.sh"
 retCode=$?
 if test "$retCode" != 0; then
-  logError "stop_daemons failed with exit status $retCode"
+  logErrorAndReport "stop_daemons failed with exit status $retCode"
 fi
 
 echo

--- a/tests/e2e_all/scripts/tests/minus_r_flag
+++ b/tests/e2e_all/scripts/tests/minus_r_flag
@@ -29,12 +29,12 @@ badSrvAtSign="@do_not_activate" # This atsign is a known reserved atsign which i
 
 # -r added in d:5.2.0
 if [[ $(versionIsLessThan "$clientVersion" "d:5.2.0") == "true" ]]; then
-  logInfoAndReport "    N/A because client version is $clientVersion and -r was added in v5.2.0"
+  logInfo "    N/A because client version is $clientVersion and -r was added in v5.2.0"
   exit 50
 fi
 
 if [[ "${daemonVersion:0:1}" == "c" ]]; then
-  logInfoAndReport "    N/A C daemon doesn't need to test a client side only feature"
+  logInfo "    N/A C daemon doesn't need to test a client side only feature"
   exit 50
 fi
 
@@ -82,7 +82,7 @@ sshCommand=$($sshnpCommand)
 sshnpExitStatus=$?
 
 if ((sshnpExitStatus != 0)); then
-  logErrorAndReport "$scriptName: sshnp to ${deviceName} with '--host <host>' should have succeeded but did not"
+  logError "$scriptName: sshnp to ${deviceName} with '--host <host>' should have succeeded but did not"
   kill $tailPid
   exit $sshnpExitStatus
 fi
@@ -93,7 +93,7 @@ echo "$(iso8601Date) | Executing $sshCommand"
 $(getTestSshCommand "$sshCommand")
 sshExitStatus=$?
 if ((sshExitStatus != 0)); then
-  logErrorAndReport "$scriptName: ssh to ${deviceName} with '--host <host>' should have succeeded but did not"
+  logError "$scriptName: ssh to ${deviceName} with '--host <host>' should have succeeded but did not"
   kill $tailPid
   exit $sshExitStatus
 fi
@@ -121,7 +121,7 @@ sshCommand=$($sshnpCommand)
 sshnpExitStatus=$?
 
 if ((sshnpExitStatus != 0)); then
-  logErrorAndReport "$scriptName: sshnp to ${deviceName} with '-r <host> -h <bad host>' should have succeeded but did not"
+  logError "$scriptName: sshnp to ${deviceName} with '-r <host> -h <bad host>' should have succeeded but did not"
   kill $tailPid
   exit $sshnpExitStatus
 fi
@@ -132,7 +132,7 @@ echo "$(iso8601Date) | Executing $sshCommand"
 $(getTestSshCommand "$sshCommand")
 sshExitStatus=$?
 if ((sshExitStatus != 0)); then
-  logErrorAndReport "$scriptName: ssh to ${deviceName} with '-r <host> -h <bad host>' should have succeeded but did not"
+  logError "$scriptName: ssh to ${deviceName} with '-r <host> -h <bad host>' should have succeeded but did not"
 fi
 
 kill $tailPid

--- a/tests/e2e_all/scripts/tests/minus_r_flag
+++ b/tests/e2e_all/scripts/tests/minus_r_flag
@@ -82,7 +82,7 @@ sshCommand=$($sshnpCommand)
 sshnpExitStatus=$?
 
 if ((sshnpExitStatus != 0)); then
-  logError "$scriptName: sshnp to ${deviceName} with '--host <host>' should have succeeded but did not"
+  logErrorAndReport "$scriptName: sshnp to ${deviceName} with '--host <host>' should have succeeded but did not"
   kill $tailPid
   exit $sshnpExitStatus
 fi
@@ -93,7 +93,7 @@ echo "$(iso8601Date) | Executing $sshCommand"
 $(getTestSshCommand "$sshCommand")
 sshExitStatus=$?
 if ((sshExitStatus != 0)); then
-  logError "$scriptName: ssh to ${deviceName} with '--host <host>' should have succeeded but did not"
+  logErrorAndReport "$scriptName: ssh to ${deviceName} with '--host <host>' should have succeeded but did not"
   kill $tailPid
   exit $sshExitStatus
 fi
@@ -121,7 +121,7 @@ sshCommand=$($sshnpCommand)
 sshnpExitStatus=$?
 
 if ((sshnpExitStatus != 0)); then
-  logError "$scriptName: sshnp to ${deviceName} with '-r <host> -h <bad host>' should have succeeded but did not"
+  logErrorAndReport "$scriptName: sshnp to ${deviceName} with '-r <host> -h <bad host>' should have succeeded but did not"
   kill $tailPid
   exit $sshnpExitStatus
 fi
@@ -132,7 +132,7 @@ echo "$(iso8601Date) | Executing $sshCommand"
 $(getTestSshCommand "$sshCommand")
 sshExitStatus=$?
 if ((sshExitStatus != 0)); then
-  logError "$scriptName: ssh to ${deviceName} with '-r <host> -h <bad host>' should have succeeded but did not"
+  logErrorAndReport "$scriptName: ssh to ${deviceName} with '-r <host> -h <bad host>' should have succeeded but did not"
 fi
 
 kill $tailPid

--- a/tests/e2e_all/scripts/tests/minus_r_flag
+++ b/tests/e2e_all/scripts/tests/minus_r_flag
@@ -10,6 +10,7 @@
 #  - expect this test to fail
 
 scriptName=$(basename -- "$0")
+testToRun="$scriptName"
 
 if test -z "$testScriptsDir"; then
   echo -e "    ${RED}check_env: testScriptsDir is not set${NC}" && exit 1
@@ -64,9 +65,10 @@ deviceName=$(getDeviceNameWithFlags "$commitId" "$daemonVersion")
 # We will capture daemon log from now until end of test
 outputDir=$(getOutputDir)
 daemonLogFile="${outputDir}/daemons/${deviceName}.log"
-echo "First daemon (--host) $deviceName" >>"$DAEMON_LOG_FRAGMENT_NAME"
-echo "" >>"$DAEMON_LOG_FRAGMENT_NAME"
-tail -f "$daemonLogFile" >>"$DAEMON_LOG_FRAGMENT_NAME" &
+daemonLogFragmentName="$(getDaemonLogFragmentName $testToRun $daemonVersion $clientVersion)"
+echo "First daemon (--host) $deviceName" >>"$daemonLogFragmentName"
+echo "" >>"$daemonLogFragmentName"
+tail -f "$daemonLogFile" >>"$daemonLogFragmentName" &
 tailPid=$! # We'll kill this later
 
 l1="$clientBinaryPath/sshnp -f $clientAtSign -d $deviceName -i $identityFilename"
@@ -102,9 +104,9 @@ kill $tailPid
 # We will capture daemon log from now until end of test
 outputDir=$(getOutputDir)
 daemonLogFile="${outputDir}/daemons/${deviceName}.log"
-echo "Third daemon (-r <good> && -h <bad>) $deviceName" >>"$DAEMON_LOG_FRAGMENT_NAME"
-echo "" >>"$DAEMON_LOG_FRAGMENT_NAME"
-tail -f "$daemonLogFile" >>"$DAEMON_LOG_FRAGMENT_NAME" &
+echo "Third daemon (-r <good> && -h <bad>) $deviceName" >>"$daemonLogFragmentName"
+echo "" >>"$daemonLogFragmentName"
+tail -f "$daemonLogFile" >>"$daemonLogFragmentName" &
 tailPid=$! # We'll kill this later
 
 l1="$clientBinaryPath/sshnp -f $clientAtSign -d $deviceName -i $identityFilename"

--- a/tests/e2e_all/scripts/tests/minus_s_flag
+++ b/tests/e2e_all/scripts/tests/minus_s_flag
@@ -98,7 +98,7 @@ else
 
   if ((exitStatus == 0)); then
     # It should have failed
-    logError "$scriptName: sshnp with new key did not fail as expected"
+    logErrorAndReport "$scriptName: sshnp with new key did not fail as expected"
     kill $tailPid
     exit 1
   else

--- a/tests/e2e_all/scripts/tests/minus_s_flag
+++ b/tests/e2e_all/scripts/tests/minus_s_flag
@@ -7,6 +7,7 @@
 #   3b. Verify it succeeds
 
 scriptName=$(basename -- "$0")
+testToRun="$scriptName"
 
 if test -z "$testScriptsDir"; then
   echo -e "    ${RED}check_env: testScriptsDir is not set${NC}" && exit 1
@@ -64,9 +65,11 @@ deviceName=$(getDeviceNameNoFlags "$commitId" "$daemonVersion")
 # We will capture daemon log from now until end of test
 outputDir=$(getOutputDir)
 daemonLogFile="${outputDir}/daemons/${deviceName}.log"
-echo "First daemon (without flags) $deviceName" >>"$DAEMON_LOG_FRAGMENT_NAME"
-echo "" >>"$DAEMON_LOG_FRAGMENT_NAME"
-tail -f "$daemonLogFile" >>"$DAEMON_LOG_FRAGMENT_NAME" &
+daemonLogFragmentName="$(getDaemonLogFragmentName $testToRun $daemonVersion $clientVersion)"
+
+echo "First daemon (without flags) $deviceName" >>"$daemonLogFragmentName"
+echo "" >>"$daemonLogFragmentName"
+tail -f "$daemonLogFile" >>"$daemonLogFragmentName" &
 tailPid=$! # We'll kill this later
 
 l1="$clientBinaryPath/sshnp -f $clientAtSign -d $deviceName -i $identityFilename"
@@ -111,10 +114,10 @@ deviceName=$(getDeviceNameWithFlags "$commitId" "$daemonVersion")
 kill $tailPid
 outputDir=$(getOutputDir)
 daemonLogFile="${outputDir}/daemons/${deviceName}.log"
-echo "" >>"$DAEMON_LOG_FRAGMENT_NAME"
-echo "Second daemon (with flags) : $deviceName" >>"$DAEMON_LOG_FRAGMENT_NAME"
-echo "" >>"$DAEMON_LOG_FRAGMENT_NAME"
-tail -f "$daemonLogFile" >>"$DAEMON_LOG_FRAGMENT_NAME" &
+echo "" >>"$daemonLogFragmentName"
+echo "Second daemon (with flags) : $deviceName" >>"$daemonLogFragmentName"
+echo "" >>"$daemonLogFragmentName"
+tail -f "$daemonLogFile" >>"$daemonLogFragmentName" &
 tailPid=$! # We'll kill this later
 
 l1="$clientBinaryPath/sshnp -f $clientAtSign -d $deviceName -i $identityFilename"

--- a/tests/e2e_all/scripts/tests/minus_s_flag
+++ b/tests/e2e_all/scripts/tests/minus_s_flag
@@ -28,7 +28,7 @@ if [[ "$clientVersion" != "d:current" ]] || [[ "${daemonVersion:1}" != ":current
 fi
 
 if [[ "${daemonVersion:0:1}" == "c" && $(versionIsLessThan "$clientVersion" "d:5.3.0") ]]; then
-  logInfoAndReport "    N/A C daemon is not compatible with thi client"
+  logInfo "    N/A C daemon is not compatible with thi client"
   exit 50
 fi
 
@@ -98,7 +98,7 @@ else
 
   if ((exitStatus == 0)); then
     # It should have failed
-    logErrorAndReport "$scriptName: sshnp with new key did not fail as expected"
+    logError "$scriptName: sshnp with new key did not fail as expected"
     kill $tailPid
     exit 1
   else

--- a/tests/e2e_all/scripts/tests/minus_u_flag
+++ b/tests/e2e_all/scripts/tests/minus_u_flag
@@ -8,6 +8,7 @@
 # 2b. Verify it succeeds
 
 scriptName=$(basename -- "$0")
+testToRun="$scriptName"
 
 if test -z "$testScriptsDir"; then
   echo -e "    ${RED}check_env: testScriptsDir is not set${NC}" && exit 1
@@ -62,11 +63,11 @@ deviceName=$(getDeviceNameNoFlags "$commitId" "$daemonVersion")
 
 # We will capture daemon log from now until end of test
 outputDir=$(getOutputDir)
-daemonLogFile="${outputDir}/daemons/${deviceName}.log"
-echo "" >>"$DAEMON_LOG_FRAGMENT_NAME"
-echo "First daemon (without flags) $deviceName" >>"$DAEMON_LOG_FRAGMENT_NAME"
-echo "" >>"$DAEMON_LOG_FRAGMENT_NAME"
-tail -f "$daemonLogFile" >>"$DAEMON_LOG_FRAGMENT_NAME" &
+daemonLogFragmentName="$(getDaemonLogFragmentName $testToRun $daemonVersion $clientVersion)"
+echo "" >>"$daemonLogFragmentName"
+echo "First daemon (without flags) $deviceName" >>"$daemonLogFragmentName"
+echo "" >>"$daemonLogFragmentName"
+tail -f "$daemonLogFile" >>"$daemonLogFragmentName" &
 tailPid=$! # We'll kill this later
 
 l1="$clientBinaryPath/sshnp -f $clientAtSign -d $deviceName -i $identityFilename"
@@ -92,10 +93,10 @@ fi
 deviceName=$(getDeviceNameWithFlags "$commitId" "$daemonVersion")
 kill $tailPid
 daemonLogFile="${outputDir}/daemons/${deviceName}.log"
-echo "" >>"$DAEMON_LOG_FRAGMENT_NAME"
-echo "Second daemon (with flags) : $deviceName" >>"$DAEMON_LOG_FRAGMENT_NAME"
-echo "" >>"$DAEMON_LOG_FRAGMENT_NAME"
-tail -f "$daemonLogFile" >>"$DAEMON_LOG_FRAGMENT_NAME" &
+echo "" >>"$daemonLogFragmentName"
+echo "Second daemon (with flags) : $deviceName" >>"$daemonLogFragmentName"
+echo "" >>"$daemonLogFragmentName"
+tail -f "$daemonLogFile" >>"$daemonLogFragmentName" &
 tailPid=$! # We'll kill this later
 
 l1="$clientBinaryPath/sshnp -f $clientAtSign -d $deviceName -i $identityFilename"

--- a/tests/e2e_all/scripts/tests/minus_u_flag
+++ b/tests/e2e_all/scripts/tests/minus_u_flag
@@ -82,7 +82,7 @@ sshnpExitStatus=$?
 
 if ((sshnpExitStatus == 0)); then
   # It should have failed
-  logError "$scriptName: sshnp to ${deviceName} without '-u <username>' did not fail as expected"
+  logErrorAndReport "$scriptName: sshnp to ${deviceName} without '-u <username>' did not fail as expected"
   kill $tailPid
   exit 1
 fi
@@ -109,7 +109,7 @@ echo "$(iso8601Date) | Executing $sshnpCommand"
 sshCommand=$($sshnpCommand)
 sshnpExitStatus=$?
 if ((sshnpExitStatus != 0)); then
-  logError "$scriptName: sshnp to ${deviceName} without '-u <username>' should have succeeded but did not"
+  logErrorAndReport "$scriptName: sshnp to ${deviceName} without '-u <username>' should have succeeded but did not"
   kill $tailPid
   exit $sshnpExitStatus
 fi
@@ -120,7 +120,7 @@ echo "$(iso8601Date) | Executing $sshCommand"
 $(getTestSshCommand "$sshCommand")
 sshExitStatus=$?
 if ((sshExitStatus != 0)); then
-  logError "$scriptName: ssh to ${deviceName} without '-u <username>' should have succeeded but did not"
+  logErrorAndReport "$scriptName: ssh to ${deviceName} without '-u <username>' should have succeeded but did not"
 fi
 kill $tailPid
 exit $sshExitStatus

--- a/tests/e2e_all/scripts/tests/minus_u_flag
+++ b/tests/e2e_all/scripts/tests/minus_u_flag
@@ -32,7 +32,7 @@ fi
 clientBinaryPath=$(getPathToBinariesForTypeAndVersion "$clientVersion")
 
 if [[ "${daemonVersion:0:1}" == "c" && $(versionIsLessThan "$clientVersion" "d:5.3.0") ]]; then
-  logInfoAndReport "    N/A C daemon is not compatible with this client"
+  logInfo "    N/A C daemon is not compatible with this client"
   exit 50
 fi
 
@@ -82,7 +82,7 @@ sshnpExitStatus=$?
 
 if ((sshnpExitStatus == 0)); then
   # It should have failed
-  logErrorAndReport "$scriptName: sshnp to ${deviceName} without '-u <username>' did not fail as expected"
+  logError "$scriptName: sshnp to ${deviceName} without '-u <username>' did not fail as expected"
   kill $tailPid
   exit 1
 fi
@@ -109,7 +109,7 @@ echo "$(iso8601Date) | Executing $sshnpCommand"
 sshCommand=$($sshnpCommand)
 sshnpExitStatus=$?
 if ((sshnpExitStatus != 0)); then
-  logErrorAndReport "$scriptName: sshnp to ${deviceName} without '-u <username>' should have succeeded but did not"
+  logError "$scriptName: sshnp to ${deviceName} without '-u <username>' should have succeeded but did not"
   kill $tailPid
   exit $sshnpExitStatus
 fi
@@ -120,7 +120,7 @@ echo "$(iso8601Date) | Executing $sshCommand"
 $(getTestSshCommand "$sshCommand")
 sshExitStatus=$?
 if ((sshExitStatus != 0)); then
-  logErrorAndReport "$scriptName: ssh to ${deviceName} without '-u <username>' should have succeeded but did not"
+  logError "$scriptName: ssh to ${deviceName} without '-u <username>' should have succeeded but did not"
 fi
 kill $tailPid
 exit $sshExitStatus

--- a/tests/e2e_all/scripts/tests/noop
+++ b/tests/e2e_all/scripts/tests/noop
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 scriptName=$(basename -- "$0")
+testToRun="$scriptName"
 
-if test -z "$testScriptsDir" ; then
+if test -z "$testScriptsDir"; then
   echo -e "    ${RED}check_env: testScriptsDir is not set${NC}" && exit 1
 fi
 
 source "$testScriptsDir/common/common_functions.include.sh"
 source "$testScriptsDir/common/check_env.include.sh" || exit $?
 
-if test $# != 2 ; then
+if test $# != 2; then
   logErrorAndExit "Must supply daemonVersion, clientVersion"
 fi
 

--- a/tests/e2e_all/scripts/tests/npt_to_port_22
+++ b/tests/e2e_all/scripts/tests/npt_to_port_22
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 scriptName=$(basename -- "$0")
+testToRun="$scriptName"
 
 if test -z "$testScriptsDir"; then
   echo -e "    ${RED}check_env: testScriptsDir is not set${NC}" && exit 1
@@ -47,7 +48,8 @@ deviceName=$(getDeviceNameWithFlags "$commitId" "$daemonVersion")
 # We will capture daemon log from now until end of test
 outputDir=$(getOutputDir)
 daemonLogFile="${outputDir}/daemons/${deviceName}.log"
-tail -f -n 0 "$daemonLogFile" >>"$DAEMON_LOG_FRAGMENT_NAME" &
+daemonLogFragmentName="$(getDaemonLogFragmentName $testToRun $daemonVersion $clientVersion)"
+tail -f -n 0 "$daemonLogFile" >>"$daemonLogFragmentName" &
 tailPid=$! # We'll kill this later
 
 clientBinaryPath=$(getPathToBinariesForTypeAndVersion "$clientVersion")

--- a/tests/e2e_all/scripts/tests/npt_to_port_22
+++ b/tests/e2e_all/scripts/tests/npt_to_port_22
@@ -27,19 +27,19 @@ fi
 # i.e. if client != current and daemon != current then exit 50
 
 if ! grep -q "current" <<<"$clientVersion" && ! grep -q "current" <<<"$daemonVersion"; then
-  logInfoAndReport "    N/A  because released client $(getVersionDescription "$clientVersion") has already been tested against released daemon $(getVersionDescription "$daemonVersion")"
+  logInfo "    N/A  because released client $(getVersionDescription "$clientVersion") has already been tested against released daemon $(getVersionDescription "$daemonVersion")"
   exit 50
 fi
 
 if [[ ${daemonVersion:0:1} == "c" ]]; then
-  logInfoAndReport "    N/A  because c daemon doesn't support npt request yet"
+  logInfo "    N/A  because c daemon doesn't support npt request yet"
   exit 50
 fi
 
 # Require a v5.1+ client to test v5.1+ features
 if [[ $(versionIsLessThan "$clientVersion" "d:5.1.0") == "true" ]] ||
   [[ $(versionIsLessThan "$daemonVersion" "d:5.1.0") == "true" ]]; then
-  logInfoAndReport "    N/A  because npt requires client and daemon versions >= v5.1.x"
+  logInfo "    N/A  because npt requires client and daemon versions >= v5.1.x"
   exit 50 # test rig interprets this exit status as 'test was not applicable'
 fi
 

--- a/tests/e2e_all/scripts/tests/shared/sshnp
+++ b/tests/e2e_all/scripts/tests/shared/sshnp
@@ -28,12 +28,12 @@ testToRun="$6"
 # i.e. if client != current and daemon != current then exit 50
 
 if ! grep -q "current" <<<"$clientVersion" && ! grep -q "current" <<<"$daemonVersion"; then
-  logInfoAndReport "    N/A  because released client $(getVersionDescription "$clientVersion") has already been tested against released daemon $(getVersionDescription "$daemonVersion")"
+  logInfo "    N/A  because released client $(getVersionDescription "$clientVersion") has already been tested against released daemon $(getVersionDescription "$daemonVersion")"
   exit 50
 fi
 
 if [[ "$sshClient" != "openssh" ]] && [[ "$sshClient" != "dart" ]]; then
-  logErrorAndReport "tests/shared/sshnp: Unhandled sshClient parameter [$sshClient] - must be openssh or dart"
+  logError "tests/shared/sshnp: Unhandled sshClient parameter [$sshClient] - must be openssh or dart"
   exit 1
 fi
 
@@ -63,17 +63,17 @@ case "$daemonFeatureSet" in
   v5)
     # Require a v5 client to test v5 features
     if [[ $(versionIsLessThan "$clientVersion" "d:5.0.0") == "true" ]]; then
-      logInfoAndReport "    N/A  because requires a v5+ client to test v5+ daemon features"
+      logInfo "    N/A  because requires a v5+ client to test v5+ daemon features"
       exit 50 # test rig interprets this exit status as 'test was not applicable'
     fi
     # Require a v5 daemon to test v5 features
     if [[ $(versionIsLessThan "$daemonVersion" "d:5.0.0") == "true" ]]; then
-      logInfoAndReport "    N/A  because can't test v5+ daemon features on a daemon version < 5"
+      logInfo "    N/A  because can't test v5+ daemon features on a daemon version < 5"
       exit 50 # test rig interprets this exit status as 'test was not applicable'
     fi
     ;;
   *)
-    logErrorAndReport "tests/shared/sshnp: Unhandled daemonFeatureSet parameter [$daemonFeatureSet] - must be v4 or v5"
+    logError "tests/shared/sshnp: Unhandled daemonFeatureSet parameter [$daemonFeatureSet] - must be v4 or v5"
     exit 1
     ;;
 esac
@@ -83,7 +83,7 @@ case "$executionType" in
     #  When outputting command line
     #    if ssh-client is 'dart' this is not applicable
     if [[ "$sshClient" == "dart" ]]; then
-      logInfoAndReport "    N/A  because sshClient is $sshClient which always executes the ssh 'inline'"
+      logInfo "    N/A  because sshClient is $sshClient which always executes the ssh 'inline'"
       exit 50 # test rig interprets this exit status as 'test was not applicable'
     fi
     #    if v5 client add the '-x' flag
@@ -94,12 +94,12 @@ case "$executionType" in
   "inline")
     # Running inline - requires either (1) sshClient='dart' or (2) v5+ client
     if [[ "$sshClient" != "dart" ]] && [[ $(versionIsAtLeast "$clientVersion" "d:5.0.0") != "true" ]]; then
-      logInfoAndReport "    N/A  because sshClient is $sshClient and client version is $clientVersion"
+      logInfo "    N/A  because sshClient is $sshClient and client version is $clientVersion"
       exit 50 # test rig interprets this exit status as 'test was not applicable'
     fi
     ;;
   *)
-    logErrorAndReport "tests/shared/sshnp: Unhandled executionType parameter [$executionType] - must be print or inline"
+    logError "tests/shared/sshnp: Unhandled executionType parameter [$executionType] - must be print or inline"
     exit 1
     ;;
 esac
@@ -119,7 +119,7 @@ case "$executionType" in
   "print")
     # If it's 5.0.x then we can't run this from a script because reasons
     if [[ $(versionIsAtLeast "$clientVersion" "d:5.0.0") == "true" ]] && [[ $(versionIsLessThan "$clientVersion" "d:5.1.0") == "true" ]]; then
-      logInfoAndReport "    N/A  because of bug in client versions 5.0.x which prevent running except with a real terminal attached "
+      logInfo "    N/A  because of bug in client versions 5.0.x which prevent running except with a real terminal attached "
       kill $tailPid
       exit 50 # test rig interprets this exit status as 'test was not applicable'
     fi

--- a/tests/e2e_all/scripts/tests/shared/sshnp
+++ b/tests/e2e_all/scripts/tests/shared/sshnp
@@ -33,7 +33,7 @@ if ! grep -q "current" <<<"$clientVersion" && ! grep -q "current" <<<"$daemonVer
 fi
 
 if [[ "$sshClient" != "openssh" ]] && [[ "$sshClient" != "dart" ]]; then
-  logError "tests/shared/sshnp: Unhandled sshClient parameter [$sshClient] - must be openssh or dart"
+  logErrorAndReport "tests/shared/sshnp: Unhandled sshClient parameter [$sshClient] - must be openssh or dart"
   exit 1
 fi
 
@@ -73,7 +73,7 @@ case "$daemonFeatureSet" in
     fi
     ;;
   *)
-    logError "tests/shared/sshnp: Unhandled daemonFeatureSet parameter [$daemonFeatureSet] - must be v4 or v5"
+    logErrorAndReport "tests/shared/sshnp: Unhandled daemonFeatureSet parameter [$daemonFeatureSet] - must be v4 or v5"
     exit 1
     ;;
 esac
@@ -99,7 +99,7 @@ case "$executionType" in
     fi
     ;;
   *)
-    logError "tests/shared/sshnp: Unhandled executionType parameter [$executionType] - must be print or inline"
+    logErrorAndReport "tests/shared/sshnp: Unhandled executionType parameter [$executionType] - must be print or inline"
     exit 1
     ;;
 esac

--- a/tests/e2e_all/scripts/tests/shared/sshnp
+++ b/tests/e2e_all/scripts/tests/shared/sshnp
@@ -4,15 +4,15 @@
 # Individual sshnp test cases call this script with the appropriate parameters.
 scriptName=$(basename -- "$0")
 
-if test -z "$testScriptsDir" ; then
+if test -z "$testScriptsDir"; then
   echo -e "    ${RED}check_env: testScriptsDir is not set${NC}" && exit 1
 fi
 
 source "$testScriptsDir/common/common_functions.include.sh"
 source "$testScriptsDir/common/check_env.include.sh" || exit $?
 
-if test $# != 5 ; then
-  logErrorAndExit "Must supply daemonVersion, clientVersion, sshClient, daemonFeatureSet (v4 / v5 / etc), executionType (print or inline)"
+if test $# != 6; then
+  logErrorAndExit "Must supply daemonVersion, clientVersion, sshClient, daemonFeatureSet (v4 / v5 / etc), executionType (print or inline), testToRun"
 fi
 
 daemonVersion="$1"
@@ -20,13 +20,14 @@ clientVersion="$2"
 sshClient="$3"
 daemonFeatureSet="$4"
 executionType="$5"
+testToRun="$6"
 
 # If client has already been released
 # then it has already have been tested against all released daemon versions
 # So only test it against the 'current' daemon
 # i.e. if client != current and daemon != current then exit 50
 
-if ! grep -q "current" <<< "$clientVersion" && ! grep -q "current" <<< "$daemonVersion" ; then
+if ! grep -q "current" <<<"$clientVersion" && ! grep -q "current" <<<"$daemonVersion"; then
   logInfoAndReport "    N/A  because released client $(getVersionDescription "$clientVersion") has already been tested against released daemon $(getVersionDescription "$daemonVersion")"
   exit 50
 fi
@@ -38,7 +39,7 @@ fi
 
 additionalSshnpFlags=" --ssh-client ${sshClient}"
 
-deviceName=$(getDeviceNameWithFlags "$commitId" "$daemonVersion" )
+deviceName=$(getDeviceNameWithFlags "$commitId" "$daemonVersion")
 
 clientBinaryPath=$(getPathToBinariesForTypeAndVersion "$clientVersion")
 
@@ -55,7 +56,7 @@ fi
 case "$daemonFeatureSet" in
   v4)
     # v5 clients need to unset some flags for backwards compatibility
-    if [[ $(versionIsAtLeast "$clientVersion" "d:5.0.0") == "true" ]] ; then
+    if [[ $(versionIsAtLeast "$clientVersion" "d:5.0.0") == "true" ]]; then
       additionalSshnpFlags="${additionalSshnpFlags} --no-ad --no-et"
     fi
     ;;
@@ -86,14 +87,13 @@ case "$executionType" in
       exit 50 # test rig interprets this exit status as 'test was not applicable'
     fi
     #    if v5 client add the '-x' flag
-    if [[ $(versionIsAtLeast "$clientVersion" "d:5.0.0") == "true" ]] ; then
+    if [[ $(versionIsAtLeast "$clientVersion" "d:5.0.0") == "true" ]]; then
       additionalSshnpFlags="${additionalSshnpFlags} -x"
     fi
     ;;
   "inline")
     # Running inline - requires either (1) sshClient='dart' or (2) v5+ client
-    if [[ "$sshClient" != "dart" ]] && [[ $(versionIsAtLeast "$clientVersion" "d:5.0.0") != "true" ]];
-    then
+    if [[ "$sshClient" != "dart" ]] && [[ $(versionIsAtLeast "$clientVersion" "d:5.0.0") != "true" ]]; then
       logInfoAndReport "    N/A  because sshClient is $sshClient and client version is $clientVersion"
       exit 50 # test rig interprets this exit status as 'test was not applicable'
     fi
@@ -104,22 +104,21 @@ case "$executionType" in
     ;;
 esac
 
-
 # Let's put together the sshnp command we will execute
 sshnpCommand="$baseSshnpCommand -s ${additionalSshnpFlags} "
 
 # We will capture daemon log from now until end of test
 outputDir=$(getOutputDir)
 daemonLogFile="${outputDir}/daemons/${deviceName}.log"
-tail -f -n 0 "$daemonLogFile" >> "$DAEMON_LOG_FRAGMENT_NAME" &
+daemonLogFragmentName="$(getDaemonLogFragmentName $testToRun $daemonVersion $clientVersion)"
+tail -f -n 0 "$daemonLogFile" >>"$daemonLogFragmentName" &
 tailPid=$! # We'll kill this later
 
 # Finally, let's run the sshnp and ssh session
 case "$executionType" in
   "print")
     # If it's 5.0.x then we can't run this from a script because reasons
-    if [[ $(versionIsAtLeast "$clientVersion" "d:5.0.0") == "true" ]] && [[ $(versionIsLessThan "$clientVersion" "d:5.1.0") == "true" ]];
-    then
+    if [[ $(versionIsAtLeast "$clientVersion" "d:5.0.0") == "true" ]] && [[ $(versionIsLessThan "$clientVersion" "d:5.1.0") == "true" ]]; then
       logInfoAndReport "    N/A  because of bug in client versions 5.0.x which prevent running except with a real terminal attached "
       kill $tailPid
       exit 50 # test rig interprets this exit status as 'test was not applicable'
@@ -132,7 +131,7 @@ case "$executionType" in
 
     # 2. Check the exit status
     sshnpExitStatus=$?
-    if (( sshnpExitStatus != 0 )); then
+    if ((sshnpExitStatus != 0)); then
       kill $tailPid
       exit $sshnpExitStatus
     fi
@@ -152,22 +151,24 @@ case "$executionType" in
   "inline")
     # sshnp will itself run the ssh session
     # To test, we will run an expect script for $sshnpCommand
-    SSHNP_COMMAND="$sshnpCommand"; export SSHNP_COMMAND
-    SSHNP_TIMEOUT=$timeoutDuration; export SSHNP_TIMEOUT
-    REMOTE_HOSTNAME="$(hostname -s)"; export REMOTE_HOSTNAME
-    REMOTE_USERNAME=$remoteUsername; export REMOTE_USERNAME
+    SSHNP_COMMAND="$sshnpCommand"
+    export SSHNP_COMMAND
+    SSHNP_TIMEOUT=$timeoutDuration
+    export SSHNP_TIMEOUT
+    REMOTE_HOSTNAME="$(hostname -s)"
+    export REMOTE_HOSTNAME
+    REMOTE_USERNAME=$remoteUsername
+    export REMOTE_USERNAME
 
     echo "$(iso8601Date) | Executing sshnp.expect with sshnpCommand $sshnpCommand" | tee -a "$(getReportFile)"
 
     "$testScriptsDir/tests/shared/sshnp.expect"
     retCode=$?
-    if (( retCode == 0 )); then
+    if ((retCode == 0)); then
       echo 'sshnp.expect TEST PASSED'
     fi
     kill $tailPid
     exit $retCode
     ;;
-  *)
-    ;;
+  *) ;;
 esac
-

--- a/tests/e2e_all/scripts/tests/v4_dart_inline
+++ b/tests/e2e_all/scripts/tests/v4_dart_inline
@@ -2,6 +2,7 @@
 
 # shellcheck disable=SC2034
 scriptName=$(basename -- "$0")
+testToRun="$scriptName"
 
 if test -z "$testScriptsDir"; then
   echo -e "    ${RED}check_env: testScriptsDir is not set${NC}" && exit 1
@@ -19,4 +20,4 @@ if [[ ${daemonVersion:0:1} == "c" ]]; then
 fi
 
 # Execute ssh-client 'dart', v4 daemon features, and it must be 'inline'
-"$testScriptsDir/tests/shared/sshnp" "$1" "$2" "dart" "v4" "inline"
+"$testScriptsDir/tests/shared/sshnp" "$1" "$2" "dart" "v4" "inline" "$testToRun"

--- a/tests/e2e_all/scripts/tests/v4_dart_inline
+++ b/tests/e2e_all/scripts/tests/v4_dart_inline
@@ -15,7 +15,7 @@ daemonVersion="$1"
 clientVersion="$2"
 
 if [[ ${daemonVersion:0:1} == "c" ]]; then
-  logInfoAndReport "    N/A  because c daemon isn't compatible with v4 clients"
+  logInfo "    N/A  because c daemon isn't compatible with v4 clients"
   exit 50
 fi
 

--- a/tests/e2e_all/scripts/tests/v4_openssh_print
+++ b/tests/e2e_all/scripts/tests/v4_openssh_print
@@ -2,6 +2,7 @@
 
 # shellcheck disable=SC2034
 scriptName=$(basename -- "$0")
+testToRun="$scriptName"
 
 if test -z "$testScriptsDir"; then
   echo -e "    ${RED}check_env: testScriptsDir is not set${NC}" && exit 1
@@ -19,4 +20,4 @@ if [[ ${daemonVersion:0:1} == "c" ]]; then
 fi
 
 # Execute ssh-client 'openssh', v4 daemon features, and print the ssh command
-"$testScriptsDir/tests/shared/sshnp" "$1" "$2" "openssh" "v4" "print"
+"$testScriptsDir/tests/shared/sshnp" "$1" "$2" "openssh" "v4" "print" "$testToRun"

--- a/tests/e2e_all/scripts/tests/v4_openssh_print
+++ b/tests/e2e_all/scripts/tests/v4_openssh_print
@@ -15,7 +15,7 @@ daemonVersion="$1"
 clientVersion="$2"
 
 if [[ ${daemonVersion:0:1} == "c" ]]; then
-  logInfoAndReport "    N/A  because c daemon isn't compatible with v4 clients"
+  logInfo "    N/A  because c daemon isn't compatible with v4 clients"
   exit 50
 fi
 

--- a/tests/e2e_all/scripts/tests/v5_dart_inline
+++ b/tests/e2e_all/scripts/tests/v5_dart_inline
@@ -15,7 +15,7 @@ daemonVersion="$1"
 clientVersion="$2"
 
 if [[ ${daemonVersion:0:1} == "c" ]] && [[ $(versionIsLessThan "$clientVersion" "d:5.3.0") == "true" ]]; then
-  logInfoAndReport "    N/A  because c daemon requires clients >= v5.3.0"
+  logInfo "    N/A  because c daemon requires clients >= v5.3.0"
   exit 50
 fi
 

--- a/tests/e2e_all/scripts/tests/v5_dart_inline
+++ b/tests/e2e_all/scripts/tests/v5_dart_inline
@@ -2,8 +2,9 @@
 
 # shellcheck disable=SC2034
 scriptName=$(basename -- "$0")
+testToRun="$scriptName"
 
-if test -z "$testScriptsDir" ; then
+if test -z "$testScriptsDir"; then
   echo -e "    ${RED}check_env: testScriptsDir is not set${NC}" && exit 1
 fi
 
@@ -19,4 +20,4 @@ if [[ ${daemonVersion:0:1} == "c" ]] && [[ $(versionIsLessThan "$clientVersion" 
 fi
 
 # Execute ssh-client 'dart', v5 daemon features, and it must be 'inline'
-"$testScriptsDir/tests/shared/sshnp" "$1" "$2" "dart" "v5" "inline"
+"$testScriptsDir/tests/shared/sshnp" "$1" "$2" "dart" "v5" "inline" "$testToRun"

--- a/tests/e2e_all/scripts/tests/v5_openssh_inline
+++ b/tests/e2e_all/scripts/tests/v5_openssh_inline
@@ -15,7 +15,7 @@ daemonVersion="$1"
 clientVersion="$2"
 
 if [[ ${daemonVersion:0:1} == "c" ]] && [[ $(versionIsLessThan "$clientVersion" "d:5.3.0") == "true" ]]; then
-  logInfoAndReport "    N/A  because c daemon requires clients >= v5.3.0"
+  logInfo "    N/A  because c daemon requires clients >= v5.3.0"
   exit 50
 fi
 

--- a/tests/e2e_all/scripts/tests/v5_openssh_inline
+++ b/tests/e2e_all/scripts/tests/v5_openssh_inline
@@ -2,8 +2,9 @@
 
 # shellcheck disable=SC2034
 scriptName=$(basename -- "$0")
+testToRun="$scriptName"
 
-if test -z "$testScriptsDir" ; then
+if test -z "$testScriptsDir"; then
   echo -e "    ${RED}check_env: testScriptsDir is not set${NC}" && exit 1
 fi
 
@@ -19,4 +20,4 @@ if [[ ${daemonVersion:0:1} == "c" ]] && [[ $(versionIsLessThan "$clientVersion" 
 fi
 
 # Execute ssh-client 'openssh', v5 daemon features, and start the ssh session 'inline'
-"$testScriptsDir/tests/shared/sshnp" "$1" "$2" "openssh" "v5" "inline"
+"$testScriptsDir/tests/shared/sshnp" "$1" "$2" "openssh" "v5" "inline" "$testToRun"

--- a/tests/e2e_all/scripts/tests/v5_openssh_print
+++ b/tests/e2e_all/scripts/tests/v5_openssh_print
@@ -2,8 +2,9 @@
 
 # shellcheck disable=SC2034
 scriptName=$(basename -- "$0")
+testToRun="$scriptName"
 
-if test -z "$testScriptsDir" ; then
+if test -z "$testScriptsDir"; then
   echo -e "    ${RED}check_env: testScriptsDir is not set${NC}" && exit 1
 fi
 
@@ -19,4 +20,4 @@ if [[ ${daemonVersion:0:1} == "c" ]] && [[ $(versionIsLessThan "$clientVersion" 
 fi
 
 # Execute ssh-client 'openssh', v5 daemon features, and print the ssh command
-"$testScriptsDir/tests/shared/sshnp" "$1" "$2" "openssh" "v5" "print"
+"$testScriptsDir/tests/shared/sshnp" "$1" "$2" "openssh" "v5" "print" "$testToRun"

--- a/tests/e2e_all/scripts/tests/v5_openssh_print
+++ b/tests/e2e_all/scripts/tests/v5_openssh_print
@@ -15,7 +15,7 @@ daemonVersion="$1"
 clientVersion="$2"
 
 if [[ ${daemonVersion:0:1} == "c" ]] && [[ $(versionIsLessThan "$clientVersion" "d:5.3.0") == "true" ]]; then
-  logInfoAndReport "    N/A  because c daemon requires clients >= v5.3.0"
+  logInfo "    N/A  because c daemon requires clients >= v5.3.0"
   exit 50
 fi
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Allow the e2e_tests to be run in parallel
- Brought the time to run down from 6:30 to roughly 4:30
- In addition to current test duration, we've decreased the rate of increase in time for each new test / version added.

**- How I did it**

- parallelized the tests so that there is always (or close to it) one test running per daemon

**- How to verify it**
https://github.com/atsign-foundation/noports/actions/runs/10155432677/job/28082431586

**- Description for the changelog**
ci: parallel e2e tests
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
