### PR TITLE
fix: Use a more portable solution to clean up child processes

### DIFF
--- a/packages/c/sshnpd/include/sshnpd/background_jobs.h
+++ b/packages/c/sshnpd/include/sshnpd/background_jobs.h
@@ -31,4 +31,5 @@ struct refresh_device_entry_params {
  * refresh_device_entry_params a void pointer to a struct refresh_device_entry_params
  */
 void *refresh_device_entry(void *refresh_device_entry_params);
+
 #endif

--- a/packages/c/sshnpd/include/sshnpd/handle_ping.h
+++ b/packages/c/sshnpd/include/sshnpd/handle_ping.h
@@ -2,6 +2,7 @@
 #define HANDLE_PING_H
 #include "sshnpd/params.h"
 #include <atclient/monitor.h>
+#include <pthread.h>
 void handle_ping(sshnpd_params *params, atclient_monitor_message *message, char *ping_response, atclient *atclient,
                  pthread_mutex_t *atclient_lock);
 #endif

--- a/packages/c/sshnpd/include/sshnpd/handle_ssh_request.h
+++ b/packages/c/sshnpd/include/sshnpd/handle_ssh_request.h
@@ -1,14 +1,12 @@
 #ifndef HANDLE_SSH_REQUEST_H
 #define HANDLE_SSH_REQUEST_H
 #include "sshnpd/params.h"
-#include "sshnpd/sshnpd.h"
 #include <atclient/monitor.h>
 #include <pthread.h>
 
 void handle_ssh_request(atclient *atclient, pthread_mutex_t *atclient_lock, sshnpd_params *params,
                         bool *is_child_process, atclient_monitor_message *message, char *home_dir, FILE *authkeys_file,
-                        char *authkeys_filename, atchops_rsakey_privatekey signing_key,
-                        struct sshnpd_process_node *process_head);
+                        char *authkeys_filename, atchops_rsakey_privatekey signing_key);
 
 int verify_envelope_signature(atchops_rsakey_publickey publickey, const unsigned char *payload,
                               unsigned char *signature, const char *hashing_algo, const char *signing_algo);

--- a/packages/c/sshnpd/include/sshnpd/sshnpd.h
+++ b/packages/c/sshnpd/include/sshnpd/sshnpd.h
@@ -32,11 +32,6 @@ enum notification_key {
   NK_NPT_REQUEST,
 };
 
-struct sshnpd_process_node {
-  pid_t process;
-  struct sshnpd_process_node *next;
-};
-
 #define NOTIFICATION_KEYS_LEN 5
 
 #endif

--- a/packages/c/sshnpd/src/background_jobs.c
+++ b/packages/c/sshnpd/src/background_jobs.c
@@ -3,6 +3,7 @@
 #include <atclient/connection.h>
 #include <atclient/metadata.h>
 #include <atlogger/atlogger.h>
+#include <errno.h>
 #include <pthread.h>
 #include <sshnpd/background_jobs.h>
 #include <sshnpd/sshnpd.h>

--- a/packages/c/sshnpd/src/handle_ssh_request.c
+++ b/packages/c/sshnpd/src/handle_ssh_request.c
@@ -25,8 +25,7 @@
 
 void handle_ssh_request(atclient *atclient, pthread_mutex_t *atclient_lock, sshnpd_params *params,
                         bool *is_child_process, atclient_monitor_message *message, char *home_dir, FILE *authkeys_file,
-                        char *authkeys_filename, atchops_rsakey_privatekey signing_key,
-                        struct sshnpd_process_node *process_head) {
+                        char *authkeys_filename, atchops_rsakey_privatekey signing_key) {
   int res = 0;
   char *requesting_atsign = message->notification.from;
 
@@ -485,31 +484,6 @@ void handle_ssh_request(atclient *atclient, pthread_mutex_t *atclient_lock, sshn
     if (WIFEXITED(status)) {
       goto cancel;
     }
-
-    // Allocate a new linked-list node
-    struct sshnpd_process_node *pid_node = malloc(sizeof(struct sshnpd_process_node));
-    if (pid_node == NULL) {
-      atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                   "Unable to allocate memory to keep track of the srv process id");
-      goto cancel;
-    }
-
-    // Assign the linked-list node values
-    pid_node->process = pid;
-    pid_node->next = NULL;
-
-    // Append to the linked-list
-    if (process_head == NULL) {
-      process_head = pid_node;
-    } else {
-      struct sshnpd_process_node *curr_node = process_head;
-      while (curr_node->next != NULL) {
-        curr_node = curr_node->next;
-      }
-      curr_node->next = pid_node;
-    }
-    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG,
-                 "Appended the srv process id node to the end of the process queue");
 
     char *identifier = cJSON_GetStringValue(session_id);
     cJSON *final_res_payload = cJSON_CreateObject();

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -75,26 +75,32 @@ static bool is_child_process = false;
 
 // Signal handling
 static volatile sig_atomic_t should_run = 1;
-static void sig_handler(int _) {
-  (void)_;
+static void exit_handler(int sig) {
+  atlogger_log("exit_handler", ATLOGGER_LOGGING_LEVEL_WARN, "Received signal: %d\n");
   if (should_run == 1) {
-    atlogger_log("sig_handler", ATLOGGER_LOGGING_LEVEL_WARN, "Received SIGINT, exiting safely\n");
+    atlogger_log("exit_handler", ATLOGGER_LOGGING_LEVEL_WARN, "Received SIGINT, attempting a safe exit\n");
     should_run = 0;
   } else if (should_run == 0) {
-    atlogger_log("sig_handler", ATLOGGER_LOGGING_LEVEL_WARN, "Received SIGINT again, exiting forcefully\n");
+    atlogger_log("exit_handler", ATLOGGER_LOGGING_LEVEL_WARN, "Received SIGINT again, exiting forcefully\n");
+    exit(1);
   }
 }
-
-// Queue for all srv processes
-static struct sshnpd_process_node *process_head;
-static void free_sshnpd_process_nodes(struct sshnpd_process_node *process_head);
+static void child_exit_handler(int sig) {
+  atlogger_log("child_exit_handler", ATLOGGER_LOGGING_LEVEL_WARN, "Received signal: %d\n");
+  int status;
+  pid_t pid = waitpid(-1, &status, WNOHANG);
+  if (pid > 0 && WIFEXITED(status)) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "pid %d exited\n", pid);
+  }
+}
 
 int main(int argc, char **argv) {
   int res = 0;
   int exit_res = 0;
 
   // Catch sigint and pass to the handler
-  signal(SIGINT, sig_handler);
+  signal(SIGINT, exit_handler);
+  signal(SIGCHLD, child_exit_handler);
 
   // 1.  Load default values
   apply_default_values_to_sshnpd_params(&params);
@@ -251,15 +257,18 @@ int main(int argc, char **argv) {
     goto cancel_atclient;
   }
 
+  for (int i = 0; i < params.manager_list_len; i++) {
+    atclient_atkey_init(infokeys + i);
+  }
+
   atclient_atkey *usernamekeys = malloc(sizeof(atclient_atkey) * params.manager_list_len);
   if (usernamekeys == NULL) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to allocate memory for usernamekeys\n");
     exit_res = 1;
-    goto clean_atkeys;
+    goto clean_info_keys;
   }
 
   for (int i = 0; i < params.manager_list_len; i++) {
-    atclient_atkey_init(infokeys + i);
     atclient_atkey_init(usernamekeys + i);
   }
 
@@ -269,11 +278,11 @@ int main(int argc, char **argv) {
   if (res != 0) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to start refresh device entry thread\n");
     exit_res = res;
-    goto cancel_atclient;
+    goto clean_username_keys;
   }
 
   if (!should_run) {
-    goto cancel_atclient;
+    goto cancel_refresh;
   }
 
   // 10. Start monitor
@@ -281,7 +290,7 @@ int main(int argc, char **argv) {
   if (regex == NULL) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to allocate memory for the monitor regex\n");
     exit_res = 1;
-    goto cancel_atclient;
+    goto cancel_refresh;
   }
 
   sprintf(regex, "%s.%s@", params.device, SSHNP_NS);
@@ -328,21 +337,9 @@ int main(int argc, char **argv) {
   main_loop();
   atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Exited main loop\n");
 
-  free_sshnpd_process_nodes(process_head);
-
-clean_device_info_keys:
-  for (int i = 0; i < params.manager_list_len; i++) {
-    atclient_atkey_free(infokeys + i);
-    atclient_atkey_free(usernamekeys + i);
-  }
-
-  free(infokeys);
-  free(usernamekeys);
-
 close_authkeys:
   fclose(authkeys_file);
   free(authkeys_filename);
-
 cancel_refresh:
   free(regex);
   atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Joining device entry refresh thread\n");
@@ -352,6 +349,16 @@ cancel_refresh:
   } else {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Joined device entry refresh thread\n");
   }
+clean_username_keys:
+  for (int i = 0; i < params.manager_list_len; i++) {
+    atclient_atkey_free(usernamekeys + i);
+  }
+  free(usernamekeys);
+clean_info_keys:
+  for (int i = 0; i < params.manager_list_len; i++) {
+    atclient_atkey_free(infokeys + i);
+  }
+  free(infokeys);
 cancel_atclient:
   if (free_ping_response) {
     free(ping_response);
@@ -360,7 +367,6 @@ cancel_atclient:
     atclient_connection_disconnect(&worker.atserver_connection);
     atclient_free(&worker);
   }
-
 cancel_monitor_ctx:
   if (!is_child_process) {
     atclient_connection_disconnect(&monitor_ctx.atserver_connection);
@@ -393,27 +399,6 @@ void main_loop() {
   while (should_run) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Waiting for next monitor thread message\n");
     atclient_monitor_message_init(&message);
-
-    int status;
-    struct sshnpd_process_node *prev_process = NULL;
-
-    // Loop through background instances of sshnpd to see if they are ready to exit
-    for (struct sshnpd_process_node *curr_process = process_head; curr_process != NULL;
-         curr_process = curr_process->next) {
-      waitpid(curr_process->process, &status, WNOHANG);
-      if (WIFEXITED(status)) {
-        if (curr_process != process_head) { // curr is not the first element
-          prev_process->next = curr_process->next;
-        } else if (process_head->next != NULL) { // curr is the first element
-          process_head = curr_process->next;
-        } else { // curr is the only element
-          process_head = NULL;
-        }
-        curr_process->next = NULL; // unlink this element so we only free this single node
-        free_sshnpd_process_nodes(curr_process);
-      }
-      prev_process = curr_process; // set current to prev before next iteration
-    }
 
     // Read the next monitor message
     res = atclient_monitor_read(&monitor_ctx, &worker, &message, &monitor_hooks);
@@ -528,7 +513,7 @@ void main_loop() {
         case NK_SSH_REQUEST:
           atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Executing handle_ssh_request\n");
           handle_ssh_request(&worker, &atclient_lock, &params, &is_child_process, &message, home_dir, authkeys_file,
-                             authkeys_filename, signingkey, process_head);
+                             authkeys_filename, signingkey);
           if (is_child_process) {
             atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Exiting child process\n");
             atclient_monitor_message_free(&message);
@@ -604,11 +589,4 @@ static int reconnect_atclient(const unsigned char *src, const size_t srclen, uns
 
 exit:
   return ret;
-}
-
-static void free_sshnpd_process_nodes(struct sshnpd_process_node *process_head) {
-  if (process_head != NULL && process_head->next != NULL) {
-    free_sshnpd_process_nodes(process_head->next);
-  }
-  free(process_head);
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Undo #1223  and it's ancestor PRs
- Use SIGCHLD signal to detect when srv processes are finished, and then close them.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: Use a more portable solution to clean up child processes
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
