### PR TITLE
test: running e2e tests for current trunk

### DIFF
--- a/.github/workflows/e2e_all.yaml
+++ b/.github/workflows/e2e_all.yaml
@@ -46,4 +46,4 @@ jobs:
             echo "Running git checkout -f $SHA"
             git checkout -f "$SHA"
             echo "Running tests"
-            tests/e2e_all/scripts/main.sh @apricoteventual @combinedbelgian @rv_am -p
+            tests/e2e_all/scripts/main.sh @apricoteventual @combinedbelgian @rv_am

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.3.0';
+const packageVersion = '5.6.1';

--- a/tests/e2e_all/scripts/main.sh
+++ b/tests/e2e_all/scripts/main.sh
@@ -49,7 +49,7 @@ atDirectoryPort=64
 testsToRun="all"
 
 # defaultDaemonVersions="c:current"
-defaultDaemonVersions="d:4.0.5 d:5.2.0 d:5.5.0 d:current"
+defaultDaemonVersions="d:4.0.5 d:5.2.0 d:5.5.0 d:current c:current"
 defaultClientVersions="d:4.0.5 d:5.2.0 d:5.5.0 d:current"
 
 daemonVersions=$defaultDaemonVersions

--- a/tests/e2e_all/scripts/main.sh
+++ b/tests/e2e_all/scripts/main.sh
@@ -49,7 +49,7 @@ atDirectoryPort=64
 testsToRun="all"
 
 # defaultDaemonVersions="c:current"
-defaultDaemonVersions="d:4.0.5 d:5.2.0 d:5.5.0 d:current c:current"
+defaultDaemonVersions="d:4.0.5 d:5.2.0 d:5.5.0 d:current"
 defaultClientVersions="d:4.0.5 d:5.2.0 d:5.5.0 d:current"
 
 daemonVersions=$defaultDaemonVersions


### PR DESCRIPTION
**- What I did**
Ran a whole bunch of tests trying to figure out why e2e tests were failing on CI machine.

Tentative conclusion: There is some sort of race condition in the e2e tests on Ubuntu using parallelization, and this race condition has started causing problems recently for reasons as yet unknown.

Therefore this PR un-sets the parallelization flag in the github workflow (`e2e_all.yaml`)

**- How I did it**
See details in comments below.

**- How to verify it**
Tests pass

