### PR TITLE
fix: don't include dist in path

### DIFF
--- a/tools/multibuild/Dockerfile.package
+++ b/tools/multibuild/Dockerfile.package
@@ -42,7 +42,7 @@ WORKDIR /noports/apps/admin/webapp
 RUN npm install; \
   npm run build; \
   mkdir -p /sshnp/web/admin; \
-  cp -r ./dist /sshnp/web/admin
+  cp -r ./dist/* /sshnp/web/admin/
 
 RUN set -eux; \
   case "$(dpkg --print-architecture)" in \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Copy the files such that `dist/` isn't part of the path
**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
