### PR TITLE
build(deps): Update dependabot for new Dockerfile location

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
       - "/packages/c/sshnpd/tools/"
       - "/packages/dart/sshnoports/tools/"
       - "/tests/end2end_tests/image/"
+      - "/tools/multibuild/"
     schedule:
       interval: "daily"
     groups:


### PR DESCRIPTION
https://github.com/atsign-foundation/noports/pull/1310 introduced a new Dockerfile location

**- What I did**

Added the new Dockerfile location to Dependabot config so that the Dockerfiles get updated.

**- How to verify it**

Will need to be merged to trunk before we see it in Insights

**- Description for the changelog**

build(deps): Update dependabot for new Dockerfile location