### PR TITLE
fix: bug in Update universal.sh

### DIFF
--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -193,8 +193,7 @@ parse_env() {
       system_arch="arm64"
       ;;
     arm | armv7l)
-      system_arch="arm."
-      # Note extra '.' is required
+      system_arch="arm"
       ;;
     riscv64)
       system_arch="riscv64"
@@ -460,7 +459,7 @@ get_download_url() {
   fi
 
   echo "$download_urls" | grep "$platform_name" |
-    grep "$system_arch" | cut -d\" -f4
+    grep "$system_arch." | cut -d\" -f4
 }
 
 download_archive() {

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -194,6 +194,7 @@ parse_env() {
       ;;
     arm | armv7l)
       system_arch="arm."
+      # Note extra '.' is required
       ;;
     riscv64)
       system_arch="riscv64"

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -193,7 +193,7 @@ parse_env() {
       system_arch="arm64"
       ;;
     arm | armv7l)
-      system_arch="armv7"
+      system_arch="arm."
       ;;
     riscv64)
       system_arch="riscv64"


### PR DESCRIPTION
Universal.sh was not working on armv7 devices
**- What I did**
Tracked down bug on armv7 device (pi)
**- How I did it**
switched on the -v option seeing a grep missing the download url
**- How to verify it**
fixed the type to arm. which does not clash with arm64 and checked on pi device
**- Description for the changelog**
Fixed universal.sh to work correctly on armv7/l devices..

This not fix all isssues i.e. musl linux builds and possibly others but does fix Pi
