### PR TITLE
build(deps): Use stable release of RISC-V SDK build image

### DIFF
--- a/tools/multibuild/Dockerfile.package
+++ b/tools/multibuild/Dockerfile.package
@@ -1,8 +1,9 @@
 # Dockerfile.package
 # A dockerfile for packaging SSH No Ports releases using docker buildx
 
-FROM atsigncompany/buildimage:3.5.2_3.6.0-149.3.beta@sha256:df67b9e3271381fc0c5b20e7350cf4de8dad6ac62e075b49b1a866c49af47409 AS build
+FROM atsigncompany/buildimage:3.5.2@sha256:3edb21e4d12e11d7a7a9a52af694b739eb3579c4deff2aa1ca6c31699a8af64c AS build
 # Using atsigncompany/buildimage until official dart image has RISC-V support
+# See https://github.com/atsign-company/at_dockerfiles for source and automated builds
 WORKDIR /noports
 
 # install node for later (keep at the top file to increase cache hits)


### PR DESCRIPTION
Dart SDK for risvc64 is now in the stable channel, so taking up a new buildimage with that in use (and a stable underlying distro)

**- What I did**

Updated build image to use stable SDK and Ubuntu 24.04 LTS.

**- How I did it**

https://github.com/atsign-company/at_dockerfiles/pull/201 has the changes, this just picks up the new image

**- How to verify it**

Will be used for next release.

I've manually checked `sudo docker run -it atsigncompany/dartshowplatform:3.5.2` on my Starfive VisionFive 2:

```log
Unable to find image 'atsigncompany/dartshowplatform:3.5.2' locally
3.5.2: Pulling from atsigncompany/dartshowplatform
Digest: sha256:91ac785a3ecdf06ad8279408c79db0f4b4bf5ad44ac438696d73246d05fd2069
Status: Downloaded newer image for atsigncompany/dartshowplatform:3.5.2
3.5.2 (stable) (Wed Aug 28 10:01:20 2024 +0000) on "linux_riscv64"
```

**- Description for the changelog**

build(deps): Use stable release of RISC-V SDK build image
