### PR TITLE
build(deps): Use v0.2.0 of at_c

### DIFF
--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -3,7 +3,7 @@ if(NOT atsdk_FOUND)
   FetchContent_Declare(
     atsdk
     GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-    GIT_TAG dc9fc44e789b91887a5be13c433d6039b72aaea6
+    GIT_TAG 0b0be7bfcf5765819156b55a9a81aaa3b30945bf
   )
   FetchContent_MakeAvailable(atsdk)
   install(TARGETS atclient atchops atlogger)


### PR DESCRIPTION
fixes #1309

**- What I did**

Changed at_c ref to point to v0.2.0 (which uses MbedTLS 3.6.1)

**- How I did it**

**- How to verify it**

**- Description for the changelog**

build(deps): Use v0.2.0 of at_c
