### PR TITLE
ci: Reinstate arm64-musl build

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -117,11 +117,8 @@ jobs:
             output-name: sshnpd-linux-x64-musl
           - platform: linux/arm/v7
             output-name: sshnpd-linux-arm-musl
-## 20240806: arm64 failing due to Mbed TLS error:
-## /sshnpd/sshnpd/build/_deps/mbedtls-src/library/aesce.c:87:10:
-## fatal error: 'asm/hwcap.h' file not found
-#          - platform: linux/arm64
-#            output-name: sshnpd-linux-arm64-musl
+          - platform: linux/arm64
+            output-name: sshnpd-linux-arm64-musl
           - platform: linux/riscv64
             output-name: sshnpd-linux-riscv64-musl
     steps:


### PR DESCRIPTION
Now that we're using at_c with MbedTLS 3.6.1 the arm64-musl build should work

**- What I did**

Reinstated arm64-musl build that had been disabled due to a problem with MbedTLS

**- How I did it**

Removed comments around arm64-musl build

**- How to verify it**

**- Description for the changelog**

ci: Reinstate arm64-musl build
