### PR TITLE
fix: Implement no-encrypt-traffic in npt

### DIFF
--- a/packages/dart/sshnoports/bin/npt.dart
+++ b/packages/dart/sshnoports/bin/npt.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 
 // other packages
 import 'package:args/args.dart';
-
 // atPlatform packages
 import 'package:at_cli_commons/at_cli_commons.dart' as cli;
 import 'package:at_utils/at_utils.dart';
@@ -12,7 +11,6 @@ import 'package:duration/duration.dart';
 import 'package:noports_core/npt.dart';
 import 'package:noports_core/sshnp_foundation.dart';
 import 'package:sshnoports/src/extended_arg_parser.dart';
-
 // local packages
 import 'package:sshnoports/src/print_version.dart';
 
@@ -203,6 +201,16 @@ void main(List<String> args) async {
             ' it has started its session.',
       );
 
+      parser.addFlag(
+        'encrypt-rvd-traffic',
+        aliases: ['et'],
+        help: 'When true, traffic via the socket rendezvous is encrypted,'
+            ' in addition to whatever encryption the traffic already has'
+            ' (e.g. an ssh session)',
+        defaultsTo: DefaultArgs.encryptRvdTraffic,
+        negatable: true,
+      );
+
       // Parse Args
       ArgResults parsedArgs = parser.parse(args);
 
@@ -321,6 +329,7 @@ void main(List<String> args) async {
         inline: inline,
         daemonPingTimeout:
             Duration(seconds: int.parse(parsedArgs['daemon-ping-timeout'])),
+        encryptRvdTraffic: parsedArgs['encrypt-rvd-traffic'],
         timeout: parseDuration(timeoutArg),
       );
 

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.6.1';
+const packageVersion = '5.6.2';

--- a/tests/e2e_all/scripts/common/common_functions.include.sh
+++ b/tests/e2e_all/scripts/common/common_functions.include.sh
@@ -64,11 +64,9 @@ getBaseNptCommand() {
   l2=" -t $daemonAtSign -r $srvAtSign"
   l3=" --root-domain $atDirectoryHost"
   if [ -z "$2" ]; then
-    echo "npt command running with encrypt traffic"
     echo "$l1" "$l2" "$l3"
   else
-    echo "npt command running with no-encrypt traffic"
-    echo "$l1" "$l2" "$l3" "--no-encrypt-rvd-traffic"
+    echo "$l1" "$l2" "$l3" "$2"
   fi
 }
 

--- a/tests/e2e_all/scripts/common/common_functions.include.sh
+++ b/tests/e2e_all/scripts/common/common_functions.include.sh
@@ -56,14 +56,20 @@ getBaseSshnpCommand() {
 }
 
 getBaseNptCommand() {
-  if (($# != 1)); then
-    logErrorAndExit "getBaseNptCommand requires 1 argument (clientBinaryPath)"
+  if (($# < 1 || $# > 2)); then
+      logErrorAndExit "getBaseNptCommand requires 1 mandatory argument (clientBinaryPath) and optionally a second argument (encryptRvdTraffic)"
   fi
   clientBinaryPath="$1"
   l1="$clientBinaryPath/npt -f $clientAtSign -d $deviceName"
   l2=" -t $daemonAtSign -r $srvAtSign"
   l3=" --root-domain $atDirectoryHost"
-  echo "$l1" "$l2" "$l3"
+  if [ -z "$2" ]; then
+    echo "npt command running with encrypt traffic"
+    echo "$l1" "$l2" "$l3"
+  else
+    echo "npt command running with no-encrypt traffic"
+    echo "$l1" "$l2" "$l3" "--no-encrypt-rvd-traffic"
+  fi
 }
 
 getTestSshCommand() {

--- a/tests/e2e_all/scripts/tests/npt_to_port_22_no_encrypt_traffic
+++ b/tests/e2e_all/scripts/tests/npt_to_port_22_no_encrypt_traffic
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+scriptName=$(basename -- "$0")
+testToRun="$scriptName"
+
+if test -z "$testScriptsDir"; then
+  echo -e "    ${RED}check_env: testScriptsDir is not set${NC}" && exit 1
+fi
+
+source "$testScriptsDir/common/common_functions.include.sh"
+source "$testScriptsDir/common/check_env.include.sh" || exit $?
+
+daemonVersion="$1"
+clientVersion="$2"
+extraFlags="--remote-port 22 --exit-when-connected"
+
+if [[ $(versionIsAtLeast "$clientVersion" "d:5.3.0") == "true" ]]; then
+  apkamApp=$(getApkamAppName)
+  apkamDev=$(getApkamDeviceName "client" "$commitId")
+  keysFile=$(getApkamKeysFile "$clientAtSign" "$apkamApp" "$apkamDev")
+  extraFlags="$extraFlags -k $keysFile"
+fi
+
+# If client has already been released
+# then it has already have been tested against all released daemon versions
+# So only test it against the 'current' daemon
+# i.e. if client != current and daemon != current then exit 50
+
+if ! grep -q "current" <<<"$clientVersion" && ! grep -q "current" <<<"$daemonVersion"; then
+  logInfo "    N/A  because released client $(getVersionDescription "$clientVersion") has already been tested against released daemon $(getVersionDescription "$daemonVersion")"
+  exit 50
+fi
+
+# Require a v5.1+ client to test v5.1+ features
+if [[ $(versionIsLessThan "$clientVersion" "d:5.1.0") == "true" ]] ||
+  [[ $(versionIsLessThan "$daemonVersion" "d:5.1.0") == "true" ]]; then
+  logInfo "    N/A  because npt requires client and daemon versions >= v5.1.x"
+  exit 50 # test rig interprets this exit status as 'test was not applicable'
+fi
+
+deviceName=$(getDeviceNameWithFlags "$commitId" "$daemonVersion")
+
+# We will capture daemon log from now until end of test
+outputDir=$(getOutputDir)
+daemonLogFile="${outputDir}/daemons/${deviceName}.log"
+daemonLogFragmentName="$(getDaemonLogFragmentName $testToRun $daemonVersion $clientVersion)"
+tail -f -n 0 "$daemonLogFile" >>"$daemonLogFragmentName" &
+tailPid=$! # We'll kill this later
+
+clientBinaryPath=$(getPathToBinariesForTypeAndVersion "$clientVersion")
+
+baseNptCommand=$(getBaseNptCommand "$clientBinaryPath" "--no-encrypt-rvd-traffic")
+
+# Let's put together the npt command we will execute
+nptCommand="$baseNptCommand $extraFlags --verbose"
+
+# 1. Execute the npt command - its output is the port that npt is using
+echo "$(iso8601Date) | Executing $nptCommand"
+nptPort=$($nptCommand)
+
+# 2. Check the exit status
+nptExitStatus=$?
+if ((nptExitStatus != 0)); then
+  # Kill the daemon log tail, and exit with the exit status of the npt command
+  kill "$tailPid"
+  exit $nptExitStatus
+fi
+
+echo "$(iso8601Date) | npt OK, local port is $nptPort"
+echo "$(iso8601Date) | Running ps for the spawned srv process with port $nptPort BEFORE running ssh"
+ps -ef | grep "srv " | grep "$nptPort"
+
+# 3. Execute an ssh
+sshCommand="ssh -p $nptPort -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes"
+sshCommand="${sshCommand} ${remoteUsername}@localhost -i $identityFilename"
+
+echo "$(iso8601Date) | Executing $sshCommand"
+
+# shellcheck disable=SC2091
+$(getTestSshCommand "$sshCommand")
+sshExitStatus=$?
+
+echo "$(iso8601Date) | Running ps for the spawned srv process with port $nptPort AFTER running ssh"
+ps -ef | grep "srv " | grep "$nptPort"
+
+# 4. Kill the daemon log tail, and exit with the exit status of the ssh command
+kill "$tailPid"
+exit $sshExitStatus

--- a/tests/e2e_all/scripts/tests/npt_to_port_22_no_encrypt_traffic
+++ b/tests/e2e_all/scripts/tests/npt_to_port_22_no_encrypt_traffic
@@ -31,10 +31,9 @@ if ! grep -q "current" <<<"$clientVersion" && ! grep -q "current" <<<"$daemonVer
   exit 50
 fi
 
-# Require a v5.1+ client to test v5.1+ features
-if [[ $(versionIsLessThan "$clientVersion" "d:5.1.0") == "true" ]] ||
-  [[ $(versionIsLessThan "$daemonVersion" "d:5.1.0") == "true" ]]; then
-  logInfo "    N/A  because npt requires client and daemon versions >= v5.1.x"
+# The -no-encrypt-rvd-traffic is supported from 5.6.2 release which is the current as of now.
+if [[ "$clientVersion" != "d:current" ]] || [[ "$daemonVersion" != "d:current" ]]; then
+  logInfo "    N/A  The feature is supported on client and daemon version >= 5.6.2"
   exit 50 # test rig interprets this exit status as 'test was not applicable'
 fi
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Enabled the --no-encrypt-rvd-traffic flag, which allows data transmission between the client and the daemon in plain text format

**- How I did it**
- In bin/npt.dart, introduced the encrypt-rvd-traffic flag, allowing users to toggle whether data transmission should be encrypted or sent in plain text.

- In srv_impl.dart, modified the run() method in the SrvImplDart class to support data transmission in plain text. Previously, the run() method only supported encrypted transmission.

- Changes in _runClientSideMulti() and _runDaemonSideMulti() methods:
     - With the existing behaviour, data transmission always remains encrypted.
     - Now, encryption is applied if both sessionAESKeyString and sessionIVString are non-null.
     - The existing encrypted transmission logic has been refactored into:
          - _clientSideEncryptedSocket() on the client side.
          - _daemonSideEncryptedSocket() on the daemon side.
    - Introduced new methods for plain text transmission:
        - _clientSidePlainSocket(): Sends the command "connect:no:encrypt" to the sessionControlSocket on the daemon side. Aligned the connect command format with the existing "connect:sessionAESKey:sessionIV"
        - _daemonSidePlainSocket(): Handles plain text transmission on the daemon side.
    - In _runDaemonSideMulti(), moved the controlStream.listen() logic to a reusable method, "_sessionControlSocketListener", which is shared between encrypted and plain text transmission.
  - In _handleMultiConnectRequest(), added support for the connect:no:encrypt command, which the client sends when encryption is not needed.

**- How to verify it**
- Tested the below scenarios manually:
  - Ran npt command with " --no-encrypt-rvd-traffic" able to run command successfully and connect to remote machine with SSH command.
  - Able to launch the multiple SSH teminal.

- Attaching the demon and client logs:
-  Daemon logs
```
INFO|2024-09-27 13:32:47.181029|SrvImplExec|SrvImplExec.run(): executing /home/sitaram/IdeaProjects/atsign/noports/packages/dart/sshnoports/bin/srv -h 127.0.0.1 -p 42397 --local-port 22 --local-host localhost --timeout 30 --multi --rv-auth
INFO|2024-09-27 13:32:47.186497|SrvImplExec|rv stderr | INFO|2024-09-27 13:32:47.186177| SrvImplDart |New SrvImplDart - localPort 22
INFO|2024-09-27 13:32:47.186893|SrvImplExec|rv stderr | INFO|2024-09-27 13:32:47.186768| SrvImplDart |_runDaemonSideMulti authenticating control socket connection to rvd
INFO|2024-09-27 13:32:47.186940|SrvImplExec|rv stderr | INFO|2024-09-27 13:32:47.186856| SrvImplDart |_runDaemonSideMulti: On the daemon side traffic is transmitted in plain text
INFO|2024-09-27 13:32:47.186960|SrvImplExec|rv stderr | rv started successfully
INFO|2024-09-27 13:32:47.187021|SrvImplExec|rv stderr |
INFO|2024-09-27 13:32:47.288131| sshnpd |Started rv - pid is 18521
``` 
- Client logs:
```
INFO|2024-09-27 13:32:47.464032| SshnpdChannel |sshnpdAck: SshnpdAck.acknowledged
INFO|2024-09-27 13:32:47.471544| SrvImplDart |New SrvImplDart - localPort 45863
INFO|2024-09-27 13:32:47.472116| SrvImplDart |_runClientSideMulti authenticating control socket connection to rvd
INFO|2024-09-27 13:32:47.472184| SrvImplDart |_runClientSideMulti: On the client-side traffic is transmitted in plain text
INFO|2024-09-27 13:32:47.472274| SrvImplDart |_runClientSideMulti serverToSocket is ready
INFO|2024-09-27 13:33:00.073582| SrvImplDart |_runClientSideMulti Sending connect request
INFO|2024-09-27 13:33:00.073744| SrvImplDart |_runClientSideMulti authenticating new connection to rvd
```
- Ran npt command without " --no-encrypt-rvd-traffic" able to run command successfully and connect to remote machine with SSH command. This is to verify the existing behaviour.

- Daemon logs:
```
INFO|2024-09-27 13:33:46.724168|SrvImplExec|SrvImplExec.run(): executing /home/sitaram/IdeaProjects/atsign/noports/packages/dart/sshnoports/bin/srv -h 127.0.0.1 -p 43819 --local-port 22 --local-host localhost --timeout 30 --multi --rv-auth --rv-e2ee
INFO|2024-09-27 13:33:46.729217|SrvImplExec|rv stderr | INFO|2024-09-27 13:33:46.729029| SrvImplDart |New SrvImplDart - localPort 22
INFO|2024-09-27 13:33:46.729729|SrvImplExec|rv stderr | INFO|2024-09-27 13:33:46.729647| SrvImplDart |_runDaemonSideMulti authenticating control socket connection to rvd
INFO|2024-09-27 13:33:46.729807|SrvImplExec|rv stderr | INFO|2024-09-27 13:33:46.729746| SrvImplDart |_runDaemonSideMulti: On the daemon side traffic is encrypted
INFO|2024-09-27 13:33:46.729830|SrvImplExec|rv stderr | rv started successfully
INFO|2024-09-27 13:33:46.830295| sshnpd |Started rv - pid is 19449
```
- Client logs:
```
INFO|2024-09-27 13:33:47.011133| SshnpdChannel |sshnpdAck: SshnpdAck.acknowledged
INFO|2024-09-27 13:33:47.015811| SrvImplDart |New SrvImplDart - localPort 46751
INFO|2024-09-27 13:33:47.016365| SrvImplDart |_runClientSideMulti authenticating control socket connection to rvd
INFO|2024-09-27 13:33:47.016428| SrvImplDart |_runClientSideMulti: On the client-side traffic is encrypted
INFO|2024-09-27 13:33:47.016454| SrvImplDart |_runClientSideMulti calling SocketConnector.serverToSocket
INFO|2024-09-27 13:33:47.016544| SrvImplDart |_runClientSideMulti serverToSocket is ready
INFO|2024-09-27 13:34:02.792352| SrvImplDart |_runClientSideMulti Sending connect request
INFO|2024-09-27 13:34:02.792563| SrvImplDart |_runClientSideMulti authenticating new connection to rvd
```

- Added an End-to-End test : npt_to_port_22_no_encrypt_traffic to verify the changes
**- Description for the changelog**
- fix: Implement no-encrypt-traffic in npt
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
