### PR TITLE
fix: Use restart for systemd service

### DIFF
--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -910,7 +910,7 @@ device() {
       write_systemd_environment "$systemd_service" "device_name" "$device_name"
 
       systemctl enable sshnpd
-      systemctl start sshnpd
+      systemctl restart sshnpd
 
       echo "sshnpd installed with systemd. To see logs use:"
       echo "journalctl -u sshnpd.service -f"


### PR DESCRIPTION
Fixes #1243

**- What I did**

Use `restart` rather than `start`, as this will:

* Start for the first time when a new daemon ins installed
* Restart when the daemon is upgraded

**- How I did it**

Added `re` into `systemctl start` after verifying that it would still start the service on first use.

**- How to verify it**

Run `universal.sh` to upgrade an existing sshnpd

**- Description for the changelog**

fix: Use restart for systemd service