### PR TITLE
fix: allow leading underscore in device name

### DIFF
--- a/packages/dart/noports_core/lib/src/common/default_args.dart
+++ b/packages/dart/noports_core/lib/src/common/default_args.dart
@@ -54,5 +54,5 @@ class DefaultSshnpdArgs {
   static const String deviceGroupName = '__none__';
   static const String sshPublicKeyPermissions = "";
   static const Duration policyHeartbeatFrequency = Duration(minutes: 5);
-  static const String permitOpen ='localhost:22,localhost:3389';
+  static const String permitOpen = 'localhost:22,localhost:3389';
 }

--- a/packages/dart/noports_core/lib/src/common/validation_utils.dart
+++ b/packages/dart/noports_core/lib/src/common/validation_utils.dart
@@ -8,10 +8,11 @@ import 'package:noports_core/src/common/file_system_utils.dart';
 import 'package:noports_core/src/common/io_types.dart';
 import 'package:path/path.dart' as path;
 
-const String sshnpDeviceNameRegex = r'[a-z0-9][a-z0-9_\-]{1,35}';
+const String sshnpDeviceNameRegex = r'[a-z0-9_][a-z0-9_\-]{1,35}';
 const String invalidDeviceNameMsg = 'Device name must be alphanumeric'
-    ' snake case, max length 36. First char must be a-z or 0-9.';
-const String deviceNameFormatHelp = 'Alphanumeric snake case, max length 36. First char must be a-z or 0-9.';
+    ' snake case, max length 36. First char must be _, a-z, or 0-9.';
+const String deviceNameFormatHelp = 'Alphanumeric snake case, max length 36.'
+    ' First char must be _, a-z, or 0-9.';
 const String invalidSshKeyPermissionsMsg =
     'Detected newline characters in the ssh public key permissions which malforms the authorized_keys file.';
 

--- a/packages/dart/noports_core/test/sshnp/models/sshnp_params_test.dart
+++ b/packages/dart/noports_core/test/sshnp/models/sshnp_params_test.dart
@@ -130,13 +130,33 @@ void main() {
             throwsA(TypeMatcher<ArgumentError>()));
       });
       test('SshnpParams.device invalid must start with a-z or 0-9', () {
-        expect(
-            () => SshnpParams(
-                clientAtSign: '',
-                sshnpdAtSign: '',
-                srvdAtSign: '',
-                device: '_abcde-12345-abcde_12345_abcde_12345'),
-            throwsA(TypeMatcher<ArgumentError>()));
+        final l = [
+          '-abcde',
+          '#abcde',
+          ' abcde',
+          '@abcde',
+          '£abcde',
+          '\$abcde',
+          '^abcde',
+        ];
+        for (final s in l) {
+          expect(
+              () => SshnpParams(
+                  clientAtSign: '',
+                  sshnpdAtSign: '',
+                  srvdAtSign: '',
+                  device: s),
+              throwsA(TypeMatcher<ArgumentError>()));
+        }
+      });
+      test('SshnpParams.device may start with underscore', () {
+        String deviceName = '_my-device-name_12345';
+        final params = SshnpParams(
+            clientAtSign: '',
+            sshnpdAtSign: '',
+            srvdAtSign: '',
+            device: deviceName);
+        expect(params.device, equals(deviceName));
       });
       test('SshnpParams.device test pure snake case', () {
         String deviceName = 'my_device_name_12345';

--- a/packages/dart/noports_core/test/sshnpd/sshnpd_params_test.dart
+++ b/packages/dart/noports_core/test/sshnpd/sshnpd_params_test.dart
@@ -4,10 +4,10 @@ import 'package:test/test.dart';
 
 void main() {
   group('test sshnpd params defaults', () {
-    test('require at least one of managers and policyManager options', () async {
+    test('require at least one of managers and policyManager options',
+        () async {
       List<String> args = '-a @daemon'.split(' ');
-      await expectLater(
-              () => SshnpdParams.fromArgs(args),
+      await expectLater(() => SshnpdParams.fromArgs(args),
           throwsA(TypeMatcher<ArgumentError>()));
     });
     test('just managers option supplied', () async {
@@ -26,7 +26,7 @@ void main() {
       final p = await SshnpdParams.fromArgs(args);
       expect(p.deviceAtsign, '@daemon');
       expect(p.policyManagerAtsign, '@policy');
-      expect(p.managerAtsigns, ['@bob','@chuck']);
+      expect(p.managerAtsigns, ['@bob', '@chuck']);
     });
     test('test permitOpen default without policyManager', () async {
       List<String> args = '-a @daemon -m @bob'.split(' ');


### PR DESCRIPTION
**- What I did**
fix: allow leading underscore in device name to preserve full backwards compatibility re device name validation.

**- How I did it**
- modified regex and associated text strings in validation_utils.dart
- added unit tests to cover the change
- ran dart format

**- How to verify it**
Tests pass

**- Additional context**
Follow-on from https://github.com/atsign-foundation/noports/pull/1420
