### PR TITLE
ci: Raise command_timeout to 15m from 10m default

### DIFF
--- a/.github/workflows/e2e_all.yaml
+++ b/.github/workflows/e2e_all.yaml
@@ -37,6 +37,7 @@ jobs:
           username: ubuntu
           key: ${{ secrets.NOPORTS_CICD_SSH_KEY }}
           envs: SHA
+          command_timeout: 15m
           script: |
             cd noports
             rm -rf tests/e2e_all/runtime


### PR DESCRIPTION
e2e_all actions runs such as [this one](https://github.com/atsign-foundation/noports/actions/runs/11322385228/job/31486518866) are failing because the tests aren't completing within the default 10m allowed by the appleboy/ssh-action

**- What I did**

Added a command_timeout parameter set to 15m

**- How I did it**

Referred to documentation at https://github.com/appleboy/ssh-action?tab=readme-ov-file#input-variables

**- How to verify it**

CI run for this PR

**- Description for the changelog**

ci: Raise command_timeout to 15m from 10m default