### PR TITLE
build: require npm version 10.9.0 for the policy webapp. Addresses #1411

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,3 +44,7 @@ updates:
     directory: "/apps/admin/webapp/"
     schedule:
       interval: "daily"
+    groups:
+      npm:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,7 @@ updates:
       pip:
         patterns:
           - "*"
+  - package-ecosystem: 'npm'
+    directory: "/apps/admin/webapp/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -103,6 +103,7 @@ jobs:
       - name: build admin webapp
         working-directory: ./apps/admin/webapp
         run: |
+          npm install -g npm@10.9.0
           npm install
           npm run build
       - if: ${{ matrix.os != 'windows-latest' }}

--- a/apps/admin/webapp/.npmrc
+++ b/apps/admin/webapp/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/apps/admin/webapp/package-lock.json
+++ b/apps/admin/webapp/package-lock.json
@@ -8,9 +8,9 @@
       "name": "webapp_proto",
       "version": "0.0.0",
       "devDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^3.1.1",
-        "svelte": "^4.2.19",
-        "vite": "^5.4.6"
+        "@sveltejs/vite-plugin-svelte": "3.1.1",
+        "svelte": "4.2.19",
+        "vite": "5.4.6"
       },
       "engines": {
         "node": ">=v20.15.0 <23",

--- a/apps/admin/webapp/package-lock.json
+++ b/apps/admin/webapp/package-lock.json
@@ -11,6 +11,10 @@
         "@sveltejs/vite-plugin-svelte": "^3.1.1",
         "svelte": "^4.2.19",
         "vite": "^5.4.6"
+      },
+      "engines": {
+        "node": ">=v20.15.0 <23",
+        "npm": "10.9.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/apps/admin/webapp/package.json
+++ b/apps/admin/webapp/package.json
@@ -12,5 +12,9 @@
     "@sveltejs/vite-plugin-svelte": "^3.1.1",
     "svelte": "^4.2.19",
     "vite": "^5.4.6"
+  },
+  "engines": {
+    "node": ">=v20.15.0 <23",
+    "npm": "10.9.0"
   }
 }

--- a/apps/admin/webapp/package.json
+++ b/apps/admin/webapp/package.json
@@ -9,9 +9,9 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^3.1.1",
-    "svelte": "^4.2.19",
-    "vite": "^5.4.6"
+    "@sveltejs/vite-plugin-svelte": "3.1.1",
+    "svelte": "4.2.19",
+    "vite": "5.4.6"
   },
   "engines": {
     "node": ">=v20.15.0 <23",

--- a/packages/dart/sshnoports/buildArchive
+++ b/packages/dart/sshnoports/buildArchive
@@ -38,6 +38,7 @@ echo "Compiling admin_api"; dart compile exe --verbosity error bin/np_admin.dart
 wait
 cd ../webapp || exit 1
 echo "Building admin webapp"
+npm install -g npm@10.9.0 || exit 1
 npm install || exit 1
 npm run build || exit 1
 

--- a/tools/multibuild/Dockerfile.package
+++ b/tools/multibuild/Dockerfile.package
@@ -9,7 +9,8 @@ WORKDIR /noports
 # install node for later (keep at the top file to increase cache hits)
 # hadolint ignore=DL3008
 RUN apt-get update; \
-  apt-get install -y --no-install-recommends npm
+  apt-get install -y --no-install-recommends npm; \
+  npm install -g npm@10.9.0
 
 COPY . .
 


### PR DESCRIPTION
**- What I did**
build: require npm version 10.9.0 for the policy webapp. Addresses #1411

**- How I did it**
- run `npm install -g npm@10.9.0` everywhere before running `npm install`
- add .npmrc with `engine-strict=true`
- pin required npm version to 10.9.0 in package.json

**- How to verify it**
Code-scanning alerts referenced in #1411 should be resolved