### PR TITLE
build: pin dependencies in packages/dart/sshnoports

### DIFF
--- a/packages/dart/sshnoports/bin/npp_atserver.dart
+++ b/packages/dart/sshnoports/bin/npp_atserver.dart
@@ -6,7 +6,7 @@ import 'package:at_utils/at_logger.dart';
 import 'package:logging/logging.dart';
 import 'package:noports_core/admin.dart';
 import 'package:noports_core/npa.dart';
-import 'package:noports_core/sshnp_foundation.dart';
+import 'package:noports_core/sshnp_foundation.dart' hide standardAtClientStoragePath;
 import 'package:sshnoports/src/create_at_client_cli.dart';
 
 late AtSignLogger logger;
@@ -32,7 +32,7 @@ void main(List<String> args) async {
     atServiceFactory: ServiceFactoryWithNoOpSyncService(),
     namespace: DefaultArgs.namespace,
     storagePath: standardAtClientStoragePath(
-        homeDirectory: p.homeDirectory,
+        baseDir: p.homeDirectory,
         atSign: p.authorizerAtsign,
         progName: '.${DefaultArgs.namespace}',
         uniqueID: 'single'),

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -5,18 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
+      sha256: "45cfa8471b89fb6643fe9bf51bd7931a76b8f5ec2d65de4fb176dba8d4f22c77"
       url: "https://pub.dev"
     source: hosted
-    version: "67.0.0"
+    version: "73.0.0"
+  _macros:
+    dependency: transitive
+    description: dart
+    source: sdk
+    version: "0.3.2"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
+      sha256: "4959fec185fe70cce007c57e9ab6983101dbe593d2bf8bbfb4453aaec0cf470a"
       url: "https://pub.dev"
     source: hosted
-    version: "6.4.1"
+    version: "6.8.0"
   archive:
     dependency: transitive
     description:
@@ -38,10 +43,10 @@ packages:
     dependency: transitive
     description:
       name: asn1lib
-      sha256: "58082b3f0dca697204dbab0ef9ff208bfaea7767ea771076af9a343488428dda"
+      sha256: bf1a19d6ebea1b3b6151304936955d7d73e1f00b75e544c01a60fb2e832ffe1d
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.3"
+    version: "1.5.6"
   async:
     dependency: transitive
     description:
@@ -102,10 +107,10 @@ packages:
     dependency: transitive
     description:
       name: at_demo_data
-      sha256: "0f59a24b83f0cd6d0e0557021511602ff167ece0ac69f12b8612c03263dff9ea"
+      sha256: "685f237e82af669d1f2f470a0c02b7ba4647b0452412aa41cf5da4faf58ba22b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   at_lookup:
     dependency: transitive
     description:
@@ -302,10 +307,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "576aaab8b1abdd452e0f656c3e73da9ead9d7880e15bdc494189d9c1a1baf0db"
+      sha256: c1fb2dce3c0085f39dc72668e85f8e0210ec7de05345821ff58530567df345a5
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.2"
   cron:
     dependency: transitive
     description:
@@ -350,10 +355,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
+      sha256: "7856d364b589d1f08986e140938578ed36ed948581fbc3bc9aef1805039ac5ab"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.6"
+    version: "2.3.7"
   dartssh2:
     dependency: "direct main"
     description:
@@ -375,18 +380,18 @@ packages:
     dependency: transitive
     description:
       name: ecdsa
-      sha256: b71687a843151255fced9fead63b09816cc59e9ae7b954e6a852bdc344ae1aca
+      sha256: "13b4e01ac140575cf88ef5e5268f92b8dd0a67a26c60a1b74e67d146068dc246"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.2"
   elliptic:
     dependency: transitive
     description:
       name: elliptic
-      sha256: "98e2fa89a714c649174553c823db2612dc9581814477fe1264a499d448237b6b"
+      sha256: "0c303d810603953a65dc39c4c542fb7538defd9e212403c54c266140819523b6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.10"
+    version: "0.3.11"
   encrypt:
     dependency: transitive
     description:
@@ -531,6 +536,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  macros:
+    dependency: transitive
+    description:
+      name: macros
+      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2-main.4"
   matcher:
     dependency: transitive
     description:
@@ -543,18 +556,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      sha256: "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2"
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "2.0.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -710,10 +723,10 @@ packages:
     dependency: transitive
     description:
       name: shelf_static
-      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -758,10 +771,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -854,10 +867,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   watcher:
     dependency: transitive
     description:
@@ -870,10 +883,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   web_socket:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -11,16 +11,16 @@ dependencies:
     path: "../noports_core"
     version: 6.2.0
   at_onboarding_cli: 1.7.0
-  at_cli_commons: ^1.2.0
-  at_client: ^3.2.2
+  at_cli_commons: 1.2.0
+  at_client: 3.2.2
   args: 2.5.0
-  socket_connector: ^2.2.0
+  socket_connector: 2.2.0
   dartssh2: 2.8.2
-  duration: ^4.0.3
+  duration: 4.0.3
   at_utils: 3.0.19
-  logging: ^1.2.0
-  chalkdart: ^2.2.1
-  yaml: ^3.1.2
+  logging: 1.2.0
+  chalkdart: 2.2.1
+  yaml: 3.1.2
 
 dependency_overrides:
   dartssh2:


### PR DESCRIPTION
**- What I did**
build: pin dependencies in packages/dart/sshnoports
fix: fix compile error caused by exposing some additional utility functions through at_cli_commons

**- How I did it**
See commits

**- How to verify it**
analysis & tests pass