### PR TITLE
feat: C SSHNPD `--monitor-read-timeout` flag

### DIFF
--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -3,7 +3,7 @@ if(NOT atsdk_FOUND)
   FetchContent_Declare(
     atsdk
     GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-    GIT_TAG 292e3842bf13e1479ed45e1a02821b806156218d
+    GIT_TAG 86c2e2fe3334050501f8ff820437227bd0a95488
   )
   FetchContent_MakeAvailable(atsdk)
   install(TARGETS atclient atchops atlogger)

--- a/packages/c/sshnpd/include/sshnpd/main.h
+++ b/packages/c/sshnpd/include/sshnpd/main.h
@@ -33,6 +33,4 @@ enum notification_key {
 
 #define NOTIFICATION_KEYS_LEN 5
 
-#define SSHNPD_DEFAUT_MONITOR_READ_TIMEOUT_SECONDS 10
-
 #endif

--- a/packages/c/sshnpd/include/sshnpd/params.h
+++ b/packages/c/sshnpd/include/sshnpd/params.h
@@ -41,6 +41,8 @@ struct _sshnpd_params {
 
   char *key_file;
   char *storage_path;
+
+  int monitor_read_timeout; // the amount of time that the monitor connection will wait for data before giving up and then sending a noop:0 to check if we're still connected
 };
 typedef struct _sshnpd_params sshnpd_params;
 

--- a/packages/c/sshnpd/include/sshnpd/sshnpd.h
+++ b/packages/c/sshnpd/include/sshnpd/sshnpd.h
@@ -33,4 +33,6 @@ enum notification_key {
 
 #define NOTIFICATION_KEYS_LEN 5
 
+#define SSHNPD_DEFAUT_MONITOR_READ_TIMEOUT_SECONDS 10
+
 #endif

--- a/packages/c/sshnpd/src/background_jobs.c
+++ b/packages/c/sshnpd/src/background_jobs.c
@@ -6,7 +6,7 @@
 #include <errno.h>
 #include <pthread.h>
 #include <sshnpd/background_jobs.h>
-#include <sshnpd/sshnpd.h>
+#include <sshnpd/main.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/packages/c/sshnpd/src/handle_npt_request.c
+++ b/packages/c/sshnpd/src/handle_npt_request.c
@@ -1,6 +1,6 @@
+#include "sshnpd/main.h"
 #include "sshnpd/params.h"
 #include "sshnpd/permitopen.h"
-#include "sshnpd/sshnpd.h"
 #include <atchops/aes.h>
 #include <atchops/base64.h>
 #include <atchops/iv.h>

--- a/packages/c/sshnpd/src/handle_ping.c
+++ b/packages/c/sshnpd/src/handle_ping.c
@@ -1,5 +1,5 @@
+#include "sshnpd/main.h"
 #include "sshnpd/params.h"
-#include "sshnpd/sshnpd.h"
 #include <atclient/atkey.h>
 #include <atclient/monitor.h>
 #include <atclient/notify.h>
@@ -29,17 +29,17 @@ void handle_ping(sshnpd_params *params, atclient_monitor_response *message, char
 
   atclient_notify_params notify_params;
   atclient_notify_params_init(&notify_params);
-  if((ret = atclient_notify_params_set_atkey(&notify_params, &pingkey)) != 0) {
+  if ((ret = atclient_notify_params_set_atkey(&notify_params, &pingkey)) != 0) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set atkey in notify params\n");
     goto exit_ping;
   }
 
-  if((ret = atclient_notify_params_set_operation(&notify_params, ATCLIENT_NOTIFY_OPERATION_UPDATE)) != 0) {
+  if ((ret = atclient_notify_params_set_operation(&notify_params, ATCLIENT_NOTIFY_OPERATION_UPDATE)) != 0) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set operation in notify params\n");
     goto exit_ping;
   }
 
-  if((ret = atclient_notify_params_set_value(&notify_params, ping_response)) != 0) {
+  if ((ret = atclient_notify_params_set_value(&notify_params, ping_response)) != 0) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set value in notify params\n");
     goto exit_ping;
   }

--- a/packages/c/sshnpd/src/handle_ssh_request.c
+++ b/packages/c/sshnpd/src/handle_ssh_request.c
@@ -1,5 +1,5 @@
+#include "sshnpd/main.h"
 #include "sshnpd/params.h"
-#include "sshnpd/sshnpd.h"
 #include <atchops/aes.h>
 #include <atchops/base64.h>
 #include <atchops/iv.h>

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -1,10 +1,10 @@
+#include "sshnpd/main.h"
 #include "sshnpd/background_jobs.h"
 #include "sshnpd/handle_npt_request.h"
 #include "sshnpd/handle_ping.h"
 #include "sshnpd/handle_ssh_request.h"
 #include "sshnpd/handle_sshpublickey.h"
 #include "sshnpd/permitopen.h"
-#include "sshnpd/sshnpd.h"
 #include "sshnpd/version.h"
 #include <atchops/aes.h>
 #include <atchops/iv.h>

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -188,6 +188,7 @@ int main(int argc, char **argv) {
     exit_res = res;
     goto cancel_monitor_ctx;
   }
+  atclient_monitor_set_read_timeout(&monitor_ctx, params.monitor_read_timeout*1000);
 
   // 7.b Initialize the worker atclient
   atclient_init(&worker);
@@ -438,6 +439,7 @@ void main_loop() {
           sleep(1);
           break;
         }
+        atclient_monitor_set_read_timeout(&monitor_ctx, params.monitor_read_timeout*1000);
 
         ret = atclient_monitor_start(&monitor_ctx, regex);
         if (ret != 0) {

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -188,7 +188,7 @@ int main(int argc, char **argv) {
     exit_res = res;
     goto cancel_monitor_ctx;
   }
-  atclient_monitor_set_read_timeout(&monitor_ctx, params.monitor_read_timeout*1000);
+  atclient_monitor_set_read_timeout(&monitor_ctx, params.monitor_read_timeout * 1000);
 
   // 7.b Initialize the worker atclient
   atclient_init(&worker);
@@ -439,7 +439,7 @@ void main_loop() {
           sleep(1);
           break;
         }
-        atclient_monitor_set_read_timeout(&monitor_ctx, params.monitor_read_timeout*1000);
+        atclient_monitor_set_read_timeout(&monitor_ctx, params.monitor_read_timeout * 1000);
 
         ret = atclient_monitor_start(&monitor_ctx, regex);
         if (ret != 0) {

--- a/packages/c/sshnpd/src/params.c
+++ b/packages/c/sshnpd/src/params.c
@@ -1,7 +1,7 @@
+#include <sshnpd/main.h>
 #include <sshnpd/params.h>
 #include <sshnpd/permitopen.h>
 #include <sshnpd/version.h>
-#include <sshnpd/sshnpd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -21,6 +21,7 @@ void apply_default_values_to_sshnpd_params(sshnpd_params *params) {
   params->root_domain = "root.atsign.org";
   params->local_sshd_port = 22;
   params->storage_path = NULL;
+  params->monitor_read_timeout = 45;
 }
 
 int parse_sshnpd_params(sshnpd_params *params, int argc, const char **argv) {
@@ -54,7 +55,9 @@ int parse_sshnpd_params(sshnpd_params *params, int argc, const char **argv) {
 
       // Doesn't do anything more, added in case old config would cause a parsing issue
       OPT_BOOLEAN('u', "un-hide", NULL, NULL),
-      OPT_INTEGER(0, "monitor-read-timeout", &params->monitor_read_timeout, "Seconds to block and wait for data to arrive in monitor connection before sending a noop:0 to ping connection if alive (defaults to 10)"),
+      OPT_INTEGER(0, "monitor-read-timeout", &params->monitor_read_timeout,
+                  "Seconds to block and wait for data to arrive in monitor connection before sending a noop:0 to ping "
+                  "connection if alive (defaults to 45)"),
       OPT_END(),
   };
 
@@ -174,11 +177,6 @@ int parse_sshnpd_params(sshnpd_params *params, int argc, const char **argv) {
     params->manager_list_len = sep_count + 1;
   } else {
     params->manager_list_len = 0;
-  }
-
-  // check if the monitor_read_timeout is set
-  if(params->monitor_read_timeout == 0) {
-    params->monitor_read_timeout = SSHNPD_DEFAUT_MONITOR_READ_TIMEOUT_SECONDS; // default is 10 seconds
   }
 
   return 0;

--- a/packages/c/sshnpd/src/params.c
+++ b/packages/c/sshnpd/src/params.c
@@ -176,41 +176,6 @@ int parse_sshnpd_params(sshnpd_params *params, int argc, const char **argv) {
     params->manager_list_len = 0;
   }
 
-  // Repeat for permit-open
-  sep_count = 0;
-  for (int i = 0; i < permitopen_end - 1; i++) {
-    if (permitopen[i] == ',') {
-      sep_count++;
-    }
-  }
-
-  // malloc pointers to each string, but don't malloc any more memory for individual char storage
-  params->permitopen = malloc((sep_count + 1) * sizeof(char *)); // FIXME  leak
-  if (params->permitopen == NULL) {
-    printf("Failed to allocate memory for permitopen\n");
-    free(params->manager_list);
-    free(params->permitopen_str);
-    return 1;
-  }
-
-  params->permitopen[0] = permitopen;
-  pos = 1; // Starts at 1 since we already added the first item to the list
-  for (int i = 0; i < permitopen_end; i++) {
-    if (permitopen[i] == ',') {
-      // Set this comma to a null terminator
-      permitopen[i] = '\0';
-      if (permitopen[i + 1] == '\0') {
-        // Trailing comma, so we over counted by one
-        sep_count--;
-        // The allocated memory has a double trailing null seperator, but that's fine
-        break;
-      }
-      // Keep track of the start of the next item
-      params->permitopen[pos++] = permitopen + i + 1;
-    }
-  }
-  params->permitopen_len = sep_count + 1;
-
   // check if the monitor_read_timeout is set
   if(params->monitor_read_timeout == 0) {
     params->monitor_read_timeout = SSHNPD_DEFAUT_MONITOR_READ_TIMEOUT_SECONDS; // default is 10 seconds

--- a/packages/c/sshnpd/tools/debug_build.sh
+++ b/packages/c/sshnpd/tools/debug_build.sh
@@ -5,6 +5,6 @@ SCRIPT_DIRECTORY="$(dirname "$FULL_PATH_TO_SCRIPT")"
 cd "$SCRIPT_DIRECTORY"
 cd ..
 
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-calloc-transposed-args -Wno-error -pthread -lrt"
+cmake -S . -B build -DENABLE_PROGRAMS=OFF -DENABLE_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-calloc-transposed-args -Wno-error -pthread -lrt"
 
 cmake --build build


### PR DESCRIPTION
**- What I did**
- Implemented `--monitor-read-timeout` option in C SSHNPD
- Defaults to 10 seconds

How it works:

Let's say the monitor read timeout is 10 seconds.

Then the monitor connection will do a blocking read on the network buffer for 10 seconds before giving up. Once it gives up, it will send `noop:0\r\n` to do a check if the monitor connection is alive.

With this new implementation, the monitor connection will only send a `noop:0\r\n` every *`monitor-read-timeout`* seconds, at most.

**- Description for the changelog**
feat: C SSHNPD `--monitor-read-timeout` flag