### PR TITLE
build(deps): Bump at_c to v0.3.0

### DIFF
--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -3,7 +3,7 @@ if(NOT atsdk_FOUND)
   FetchContent_Declare(
     atsdk
     GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-    GIT_TAG 292e3842bf13e1479ed45e1a02821b806156218d
+    GIT_TAG 0438b3c1752259605b96551806ec339fbaf17b53
   )
   FetchContent_MakeAvailable(atsdk)
   install(TARGETS atclient atchops atlogger)


### PR DESCRIPTION
@XavierChanth thinks this should fix https://github.com/atsign-foundation/Atsign_OpenWRT_packages/issues/22

**- What I did**

Bumped at_c dependency to hash for v0.3.0 release which introduces more explicit int types

**- How to verify it**

Tests should cover the expected cases, but we'll need to do a point release then update the OpenWRT packages repo to build an .ipk that @XavierChanth can then test on his Opal device.

**- Description for the changelog**

build(deps): Bump at_c to v0.3.0
