### PR TITLE
fix: 32bit support 

### DIFF
--- a/packages/c/.clangd
+++ b/packages/c/.clangd
@@ -2,7 +2,7 @@ CompileFlags:
   # Use gcc in development for better diagnostics
   # & Ensure that compilation doesn't fail due to warnings
   Compiler: gcc
-  Add: [-Wno-error]
+  Add: [-Wno-error, -xc, -std=c99]
 
 Index:
   # Enable background indexing for better symbol information
@@ -15,4 +15,3 @@ Diagnostics:
   # Avoid running slow clang-tidy checks
   ClangTidy:
     FastCheckFilter: Loose
-

--- a/packages/c/sshnpd/src/background_jobs.c
+++ b/packages/c/sshnpd/src/background_jobs.c
@@ -8,10 +8,13 @@
 #include <sshnpd/background_jobs.h>
 #include <sshnpd/sshnpd.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+
+const int64_t THIRTY_DAYS_MS = (int64_t)30 * 24 * 60 * 60 * 1000;
 
 #define LOGGER_TAG "refresh_device_entry"
 
@@ -70,7 +73,7 @@ void *refresh_device_entry(void *void_refresh_device_entry_params) {
     atclient_atkey_metadata_set_is_encrypted(metadata, true);
     atclient_atkey_metadata_set_ttr(metadata, -1);
     atclient_atkey_metadata_set_ccd(metadata, true);
-    atclient_atkey_metadata_set_ttl(metadata, (long)30 * 24 * 60 * 60 * 1000); // 30 days in ms
+    atclient_atkey_metadata_set_ttl(metadata, THIRTY_DAYS_MS);
 
     buffer_len = strlen(params->params->manager_list[index]) + usernamekey_base_len;
     // example: @client_atsign:device_info.device_name.sshnp@client_atsign


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Changed `long` cast to `int64_t` where we have a timeout which exceeds 4 bytes (30 days in milliseconds for device_info expiry)
- I also snuck in some `.clangd` changes as our recent introduction of the shared clangd settings is using the default std (some c++ version), instead of our desired c99

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: 32bit support 
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
