### PR TITLE
chore: Bump version.h and changelog to 0.2.2

### DIFF
--- a/packages/c/sshnpd/CHANGELOG.md
+++ b/packages/c/sshnpd/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+- Fix 32bit support for device_info
+
 ## 0.2.1
 
 - Bump at_c to v0.3.0 to have more explicit int types

--- a/packages/c/sshnpd/include/sshnpd/version.h
+++ b/packages/c/sshnpd/include/sshnpd/version.h
@@ -1,4 +1,4 @@
 #ifndef SSHNPD_VERSION_H
 #define SSHNPD_VERSION_H
-#define SSHNPD_VERSION "0.2.1"
+#define SSHNPD_VERSION "0.2.2"
 #endif


### PR DESCRIPTION
Update version in preparation for release of fix in #1494 

**- What I did**

Bumped version.h and changelog to 0.2.2

**- How to verify it**

Run `sshnpd --help` to see version info

**- Description for the changelog**

chore: Bump version.h and changelog to 0.2.2