### PR TITLE
chore: Bump version to 0.2.3

### DIFF
--- a/packages/c/sshnpd/include/sshnpd/version.h
+++ b/packages/c/sshnpd/include/sshnpd/version.h
@@ -1,4 +1,4 @@
 #ifndef SSHNPD_VERSION_H
 #define SSHNPD_VERSION_H
-#define SSHNPD_VERSION "0.2.2"
+#define SSHNPD_VERSION "0.2.3"
 #endif


### PR DESCRIPTION
`version.h` wasn't updated in #1511 

**- What I did**

Bumped version

**- How to verify it**

Build csshnpd and run `sshnpd --help`

**- Description for the changelog**

chore: Bump version to 0.2.3
