### PR TITLE
fix: clang-tidy using private macos headers

### DIFF
--- a/packages/c/.clangd
+++ b/packages/c/.clangd
@@ -11,7 +11,7 @@ Index:
 Diagnostics:
   # IWYU for header files
   UnusedIncludes: Strict
-  MissingIncludes: Strict
+  # MissingIncludes: Strict
   # Avoid running slow clang-tidy checks
   ClangTidy:
     FastCheckFilter: Loose

--- a/packages/c/sshnpd/src/file_utils.c
+++ b/packages/c/sshnpd/src/file_utils.c
@@ -1,12 +1,12 @@
 #include "sshnpd/file_utils.h"
 #include <atlogger/atlogger.h>
+#include <errno.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/errno.h>
 #include <unistd.h>
 
 int authorize_ssh_public_key(authkeys_params *params) {

--- a/packages/c/sshnpd/src/handle_npt_request.c
+++ b/packages/c/sshnpd/src/handle_npt_request.c
@@ -10,15 +10,13 @@
 #include <atclient/notify.h>
 #include <atclient/string_utils.h>
 #include <atlogger/atlogger.h>
+#include <errno.h>
 #include <pthread.h>
 #include <sshnpd/handle_ssh_request.h>
 #include <sshnpd/handler_commons.h>
 #include <sshnpd/run_srv_process.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/errno.h>
-#include <sys/types.h>
-#include <sys/wait.h>
 #include <unistd.h>
 
 #define LOGGER_TAG "NPT_REQUEST"

--- a/packages/c/sshnpd/src/handle_ssh_request.c
+++ b/packages/c/sshnpd/src/handle_ssh_request.c
@@ -9,15 +9,13 @@
 #include <atclient/notify.h>
 #include <atclient/string_utils.h>
 #include <atlogger/atlogger.h>
+#include <errno.h>
 #include <pthread.h>
 #include <sshnpd/handle_ssh_request.h>
 #include <sshnpd/handler_commons.h>
 #include <sshnpd/run_srv_process.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/errno.h>
-#include <sys/types.h>
-#include <sys/wait.h>
 #include <unistd.h>
 
 #define LOGGER_TAG "SSH_REQUEST"

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -23,6 +23,7 @@
 #include <atclient/notify.h>
 #include <atclient/string_utils.h>
 #include <atlogger/atlogger.h>
+#include <errno.h>
 #include <libgen.h>
 #include <pthread.h>
 #include <signal.h>
@@ -31,8 +32,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/errno.h>
-#include <sys/wait.h>
 #include <unistd.h>
 
 #define FILENAME_BUFFER_SIZE 500

--- a/packages/c/sshnpd/src/run_srv_process.c
+++ b/packages/c/sshnpd/src/run_srv_process.c
@@ -3,9 +3,9 @@
 #include <atclient/cjson.h>
 #include <atclient/string_utils.h>
 #include <atlogger/atlogger.h>
+#include <errno.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/errno.h>
 #include <unistd.h>
 
 #define LOGGER_TAG "RUN SRV"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Corrected any headers starting with "sys/"
- Disabled the aggressive clang-tidy rule

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: clang-tidy using private macos headers
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
