### PR TITLE
fix: tid set to null

### DIFF
--- a/packages/c/srv/src/srv.c
+++ b/packages/c/srv/src/srv.c
@@ -298,6 +298,7 @@ int socket_to_socket(const srv_params_t *params, const char *auth_string, chunke
 
   res = pthread_create(&threads[1], NULL, srv_side_handle, &sides[1]);
   if (res != 0) {
+    atlogger_log(TAG, ERROR, "Failed to create thread: 1\n");
     cancel_first = true;
     exit_res = res;
     goto cancel;

--- a/packages/c/srv/src/srv.c
+++ b/packages/c/srv/src/srv.c
@@ -269,8 +269,8 @@ int socket_to_socket(const srv_params_t *params, const char *auth_string, chunke
 
   int fds[2], tidx;
   int exit_res = 0;
-  pthread_t threads[2];
-  pthread_t tid = NULL;
+  pthread_t threads[2], tid;
+  bool cancel_first = false;
   pipe(fds);
 
   srv_link_sides(&sides[0], &sides[1], fds);
@@ -298,7 +298,7 @@ int socket_to_socket(const srv_params_t *params, const char *auth_string, chunke
 
   res = pthread_create(&threads[1], NULL, srv_side_handle, &sides[1]);
   if (res != 0) {
-    atlogger_log(TAG, ERROR, "Failed to create thread: 1\n");
+    cancel_first = true;
     exit_res = res;
     goto cancel;
   }
@@ -316,10 +316,13 @@ int socket_to_socket(const srv_params_t *params, const char *auth_string, chunke
   read(fds[0], &tid, sizeof(pthread_t));
 
   atlogger_log(TAG, DEBUG, "Joining exited thread\n");
+
+  // When a thread exits, join it.
   res = pthread_join(tid, (void *)&retval);
 
 cancel:
-  if (pthread_equal(threads[0], tid) > 0) {
+  // Then figure out which thread didn't close
+  if (!cancel_first && pthread_equal(threads[0], tid) > 0) {
     // If threads[0] exited normally then we will cancel threads[1]
     // In all other cases, cancel threads[0] (could be because threads[1] exited or errored)
     tidx = 1;
@@ -327,6 +330,7 @@ cancel:
     tidx = 0;
   }
 
+  // Then cancel the other thread
   atlogger_log(TAG, DEBUG, "Cancelling remaining open thread: %d\n", tidx);
   if (pthread_cancel(threads[tidx]) != 0) {
     atlogger_log(TAG, WARN, "Failed to cancel thread: %d\n", tidx);


### PR DESCRIPTION
fixes #1524 
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

The problem:
- If the first thread for srv is created, but the second one fails, then the thread_id for joined thread is not set.

**- What I did**

- I reverted my changes setting tid to NULL, which didn't actually fix the problem, this was a one-off in a bulk of changes to struct initializers.
- I instead added a boolean value which, if the second thread fails to create, skips checking which thread tid is. It instead triggers the cancel for the first thread, since we know the first thread is the open one at this point.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: tid set to null
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
