### PR TITLE
build: exclude policy admin webapp assets from the docker distributions

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -77,6 +77,9 @@ jobs:
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: '20.17.0'
+      # setup required npm version
+      - run: |
+          npm install -g npm@10.8.2
       # create directories need for build
       - run: |
           mkdir -p sshnp/web/admin

--- a/tools/multibuild/Dockerfile.package
+++ b/tools/multibuild/Dockerfile.package
@@ -6,13 +6,6 @@ FROM atsigncompany/buildimage:3.5.4@sha256:0d21c9f6dc856f1e3df933b99dd88a4833057
 # See https://github.com/atsign-company/at_dockerfiles for source and automated builds
 WORKDIR /noports
 
-# install node for later (keep at the top file to increase cache hits)
-# hadolint ignore=DL3008
-RUN apt-get update; \
-  apt-get install -y --no-install-recommends npm; \
-  npm install -g npm@10.8.2
-COPY . .
-
 # Build packages/dart/sshnoports
 WORKDIR /noports/packages/dart/sshnoports
 RUN set -eux; \
@@ -35,16 +28,10 @@ RUN set -eux; \
   cp LICENSE /sshnp/;
 
 # Build apps/admin/admin_api - BETA
+# Note: Only the API; webapp only included in the main platform builds
 WORKDIR /noports/apps/admin/admin_api
 RUN dart pub get --enforce-lockfile; \
   dart compile exe bin/np_admin.dart -v -o /sshnp/np_admin
-
-# Build apps/admin/webapp
-WORKDIR /noports/apps/admin/webapp
-RUN npm ci; \
-  npm run build; \
-  mkdir -p /sshnp/web/admin; \
-  cp -r ./dist/* /sshnp/web/admin/
 
 RUN set -eux; \
   case "$(dpkg --print-architecture)" in \

--- a/tools/multibuild/Dockerfile.package
+++ b/tools/multibuild/Dockerfile.package
@@ -9,7 +9,7 @@ WORKDIR /noports
 # install node for later (keep at the top file to increase cache hits)
 # hadolint ignore=DL3008
 RUN apt-get update; \
-  apt-get install -y --no-install-recommends npm
+  apt-get install -y --no-install-recommends npm; \
   npm install -g npm@10.8.2
 COPY . .
 

--- a/tools/multibuild/Dockerfile.package
+++ b/tools/multibuild/Dockerfile.package
@@ -10,7 +10,7 @@ WORKDIR /noports
 # hadolint ignore=DL3008
 RUN apt-get update; \
   apt-get install -y --no-install-recommends npm
-
+  npm install -g npm@10.8.2
 COPY . .
 
 # Build packages/dart/sshnoports

--- a/tools/multibuild/Dockerfile.package
+++ b/tools/multibuild/Dockerfile.package
@@ -6,6 +6,8 @@ FROM atsigncompany/buildimage:3.5.4@sha256:0d21c9f6dc856f1e3df933b99dd88a4833057
 # See https://github.com/atsign-company/at_dockerfiles for source and automated builds
 WORKDIR /noports
 
+COPY . .
+
 # Build packages/dart/sshnoports
 WORKDIR /noports/packages/dart/sshnoports
 RUN set -eux; \


### PR DESCRIPTION
**- What I did**
- build: include policy admin API but exclude policy admin webapp assets from the docker distributions
- Context: (a) installing node slows down the dockerfile build quite a lot; (b) required version of node is not available as standard (i.e. via apt-get) for the platforms in question so can't (currently) build the webapp anyway (c) if required, the webapp assets can be copied from other downloads

**- How I did it**
- Removed the node install and npm build steps from tools/multibuild/Dockerfile.package
- Additionally, although unrelated, now specifying npm version to use when building the webapp assets in multibuild.yaml main_build

**- How to verify it**
Manually verified by running multibuild workflow against this branch - see https://github.com/atsign-foundation/noports/actions/runs/11878280981/job/33098772780
