### PR TITLE
build: multibuild.yaml: Exclude riscv64 from other_build's platform list

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -184,14 +184,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [linux/arm/v7, linux/arm64, linux/riscv64]
+        # platform: [linux/arm/v7, linux/arm64, linux/riscv64]
+        platform: [linux/arm/v7, linux/arm64]
         include:
           - platform: linux/arm/v7
             output-name: sshnp-linux-arm
           - platform: linux/arm64
             output-name: sshnp-linux-arm64
-          - platform: linux/riscv64
-            output-name: sshnp-linux-riscv64
+#          - platform: linux/riscv64
+#            output-name: sshnp-linux-riscv64
     steps:
       - if: ${{ ! inputs.main_build_only }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
**- What I did**
build: multibuild.yaml: Exclude riscv64 from other_build's platform list

**- How I did it**
See commit(s)

**- How to verify it**
- Eyeball for sanity
- manual run of multibuild against this branch is [here](https://github.com/atsign-foundation/noports/actions/runs/11890975563)

