### PR TITLE
ci: Don't always cleanup

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -334,7 +334,6 @@ jobs:
     name: Clean up temporary branch
     needs: [main_build, other_build]
     runs-on: ubuntu-latest
-    if: ${{ always() }}
     permissions:
       contents: write # Needed to delete workflow branch
     steps:


### PR DESCRIPTION
When we run the Multibuild workflow it frequently hangs/fails on RISC-V or other jobs in [other_build]

Right now we can't re-run failed jobs, we have to re-run the whole workflow, because the temporary branch we create gets tidied up when jobs fail.

The tradeoff here is we'll need to sometimes to some manual git gardening, but that seems like a worthwhile trade.

**- What I did**

Removed the `always` clause.

**- How to verify it**

Will require a multibuild (re)run

**- Description for the changelog**

ci: Don't always cleanup
