### PR TITLE
ci: Refactor web admin to separate noarch job

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -74,16 +74,8 @@ jobs:
         with:
           ref: multibuild-${{github.run_number}}
       - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1.6.5
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-        with:
-          node-version: '20.17.0'
-      # setup required npm version
-      - run: |
-          npm install -g npm@10.8.2
-      # create directories need for build
-      - run: |
-          mkdir -p sshnp/web/admin
-          mkdir tarball
+      # create directory needed for build
+      - run: mkdir tarball
       - if: ${{ matrix.os != 'windows-latest' }}
         run: mkdir sshnp/debug
       # compile binaries
@@ -103,11 +95,6 @@ jobs:
         run: |
           dart pub get --enforce-lockfile
           dart compile exe bin/np_admin.dart -v -o ../../../packages/dart/sshnoports/sshnp/np_admin${{ matrix.ext }}
-      - name: build admin webapp
-        working-directory: ./apps/admin/webapp
-        run: |
-          npm ci
-          npm run build
       - if: ${{ matrix.os != 'windows-latest' }}
         run: |
           dart compile exe bin/srvd.dart -v -o sshnp/srvd${{ matrix.ext }}
@@ -116,7 +103,6 @@ jobs:
       - run: |
           cp -r bundles/core/* sshnp/
           cp -r bundles/${{ matrix.bundle }}/* sshnp/
-          cp -r ../../../apps/admin/webapp/dist/* sshnp/web/admin/
           cp LICENSE sshnp
       # codesign for apple
       - if: ${{ matrix.os == 'macos-13' || matrix.os == 'macos-14' }}
@@ -217,6 +203,38 @@ jobs:
           path: ./tarballs/${{ matrix.output-name }}.tgz
           if-no-files-found: error
 
+  web_build:
+    needs: verify_tags
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: multibuild-${{github.run_number}}
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '20.17.0'
+      # setup required npm version
+      - run: |
+          npm install -g npm@10.8.2
+      # create directory needed for build
+      - name: build admin webapp
+        working-directory: ./apps/admin/webapp
+        run: |
+          mkdir -p sshnp/web/admin
+          mkdir tarball
+          npm ci
+          npm run build
+          cp -r dist/* sshnp/web/admin/
+          tar -cvzf tarball/sshnp-web-admin-noarch.tgz sshnp
+      # upload the build
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name:
+            sshnp-web-admin-noarch-${{github.ref_name}}-${{github.run_number
+            }}-${{github.run_attempt}}
+          path: ./apps/admin/webapp/tarball
+          if-no-files-found: error
+
   universal_sh:
     if: startsWith(github.ref, 'refs/tags/v')
     defaults:
@@ -261,7 +279,7 @@ jobs:
   github-release:
     name: >-
       Upload artifacts and generate SBOMs and checksums for provenance
-    needs: [main_build, other_build, universal_sh, universal_ps1]
+    needs: [main_build, other_build, web_build, universal_sh, universal_ps1]
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}


### PR DESCRIPTION
Web admin console wasn't building properly in some architecture specific jobs, hence #1539

But the web admin console doesn't create any architecture specific binaries, and so it's better to split it off as a noarch tarball

**- What I did**

Created a new job `web_build` and refactored web admin components into that.

**- How to verify it**

We'll have to do a (pre)release

**- Description for the changelog**

ci: Refactor web admin to separate noarch job
