### PR TITLE
fix: Ensure that sshnp directory is created

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -74,8 +74,10 @@ jobs:
         with:
           ref: multibuild-${{github.run_number}}
       - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1.6.5
-      # create directory needed for build
-      - run: mkdir tarball
+      # create directories needed for build
+      - run: |
+          mkdir sshnp
+          mkdir tarball
       - if: ${{ matrix.os != 'windows-latest' }}
         run: mkdir sshnp/debug
       # compile binaries


### PR DESCRIPTION
Moving `mkdir -p sshnp/web/admin` to the `web_build` job in #1553 means that the `sshnp` directory wasn't being created

**- What I did**

Added back a line to create `sshnp`

**- How to verify it**

I'll re-release v5.7.0-alpha-8

**- Description for the changelog**

fix: Ensure that sshnp directory is created
