### PR TITLE
fix: use a more aggressive handler for SIGINT and SIGCHLD

### DIFF
--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -77,32 +77,27 @@ static bool is_child_process = false;
 
 // Signal handling
 static volatile sig_atomic_t should_run = 1;
-// static void exit_handler(int sig) {
-//   atlogger_log("exit_handler", ATLOGGER_LOGGING_LEVEL_WARN, "Received signal: %d\n");
-//   if (should_run == 1) {
-//     atlogger_log("exit_handler", ATLOGGER_LOGGING_LEVEL_WARN, "Received SIGINT, attempting a safe exit\n");
-//     should_run = 0;
-//   } else if (should_run == 0) {
-//     atlogger_log("exit_handler", ATLOGGER_LOGGING_LEVEL_WARN, "Received SIGINT again, exiting forcefully\n");
-//     exit(1);
-//   }
-// }
-// static void child_exit_handler(int sig) {
-//   atlogger_log("child_exit_handler", ATLOGGER_LOGGING_LEVEL_WARN, "Received signal: %d\n");
-//   int status;
-//   pid_t pid = waitpid(-1, &status, WNOHANG);
-//   if (pid > 0 && WIFEXITED(status)) {
-//     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "pid %d exited\n", pid);
-//   }
-// }
+static void exit_handler(int sig) {
+  atlogger_log("exit_handler", ATLOGGER_LOGGING_LEVEL_WARN, "Received signal: %d\n", sig);
+  should_run = 0;
+  exit(1);
+}
+static void child_exit_handler(int sig) {
+  atlogger_log("child_exit_handler", ATLOGGER_LOGGING_LEVEL_WARN, "Received signal: %d\n", sig);
+  int status;
+  pid_t pid = waitpid(-1, &status, WNOHANG);
+  if (pid > 0 && WIFEXITED(status)) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "pid %d exited\n", pid);
+  }
+}
 
 int main(int argc, char **argv) {
   int res = 0;
   int exit_res = 0;
 
   // Catch sigint and pass to the handler
-  // signal(SIGINT, exit_handler);
-  // signal(SIGCHLD, child_exit_handler);
+  signal(SIGINT, exit_handler);
+  signal(SIGCHLD, child_exit_handler);
 
   // 1.  Load default values
   apply_default_values_to_sshnpd_params(&params);

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -32,6 +32,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #define FILENAME_BUFFER_SIZE 500


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Added back the SIGINT and SIGCHLD handlers, but with no double trap

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: use a more aggressive handler for SIGINT and SIGCHLD
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
