### PR TITLE
fix: error atsign doesn't exist

### DIFF
--- a/packages/dart/npt_flutter/lib/features/onboarding/widgets/activate_atsign_dialog.dart
+++ b/packages/dart/npt_flutter/lib/features/onboarding/widgets/activate_atsign_dialog.dart
@@ -129,6 +129,10 @@ class _ActivateAtsignDialogState extends State<ActivateAtsignDialog> {
       });
     } else {
       if (!mounted) return;
+      if (status == ActivationStatus.preparing) {
+        Navigator.of(context).pop(AtOnboardingResult.error(message: "@${jsonDecode(res.body)["message"]}"));
+        return;
+      }
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           backgroundColor: Colors.red,

--- a/packages/dart/npt_flutter/pubspec.yaml
+++ b/packages/dart/npt_flutter/pubspec.yaml
@@ -16,7 +16,16 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.3+0
+version: 1.1.4+4
+msix_config:
+  display_name: "NoPorts Desktop"
+  publisher_display_name: Atsign Inc
+  identity_name: TheCompany.NoPortsDesktop
+  publisher: CN=BBFE1D0B-F713-4C7F-B375-5EA851CBB1FF
+  msix_version: 1.1.4.4
+  logo_path: "assets/logo.png"
+  capabilities: internetClient
+  store: true
 
 environment:
   sdk: ^3.5.0
@@ -131,16 +140,6 @@ flutter:
   #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/to/font-from-package
-
-msix_config:
-  display_name: "NoPorts Desktop"
-  publisher_display_name: Atsign Inc
-  identity_name: TheCompany.NoPortsDesktop
-  publisher: CN=BBFE1D0B-F713-4C7F-B375-5EA851CBB1FF
-  msix_version: 1.1.3.0
-  logo_path: "assets/logo.png"
-  capabilities: internetClient
-  store: true
 
 flutter_launcher_icons:
   android: "launcher_icon"


### PR DESCRIPTION
- Apple app reviewers don't know how to read or hit a cancel button I guess.

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**



**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: error atsign doesn't exist
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
