### PR TITLE
ci: Use Python 3 in Docker builds for C sshnpd

### DIFF
--- a/packages/c/sshnpd/tools/Dockerfile.musl
+++ b/packages/c/sshnpd/tools/Dockerfile.musl
@@ -5,7 +5,7 @@ FROM alpine@sha256:56fa17d2a7e7f168a043a2712e63aed1f8543aeafdcee47c58dcffe38ed51
 WORKDIR /sshnpd
 COPY . .
 RUN set -eux; \
-  apk add clang cmake coreutils git make; \
+  apk add clang cmake coreutils git make python3; \
   case "$(uname -m)" in \
     aarch64) ARCH="arm64";; \
     armv7l)  ARCH="arm";;\

--- a/packages/c/sshnpd/tools/Dockerfile.package
+++ b/packages/c/sshnpd/tools/Dockerfile.package
@@ -1,7 +1,7 @@
 # Dockerfile.package
 # A dockerfile for packaging SSH No Ports releases using docker buildx
 
-FROM atsigncompany/cbuildimage:CMake-3.30.2@sha256:fe5604fec2c2b62097717ed71eed4a91657c0cab8c99c425d3f7f957330f5bd8 AS build
+FROM atsigncompany/cbuildimage:CMake-3.31.4@sha256:0b443da3bccd746e23323eb374d19ba156b497ecbee6c5e84f97d77954515cbf AS build
 WORKDIR /sshnpd
 COPY . .
 RUN set -eux; \


### PR DESCRIPTION
Fixes #1662 

**- What I did**

* Added `python3` to C buildimage. Rebuilt (using latest CMake). Updated tag and SHA to use that image.
* Added `python3` to packages we install into Alpine for musl builds

**- How I did it**

* https://github.com/atsign-company/at_c_buildimage/pull/13
  * https://github.com/atsign-company/at_c_buildimage/releases/tag/c3.31.4

**- How to verify it**

Re-release c0.3.0 (presently back in draft state)

**- Description for the changelog**

ci: Use Python 3 in Docker builds for C sshnpd
