### PR TITLE
fix: allow activation of atSigns without requiring teapot state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ pubspec_overrides.yaml
 .dart_tool/
 .packages
 
+
+
 # Binaries build from dart/sshnoports
 packages/dart/sshnoports/bin/activate_cli
 packages/dart/sshnoports/bin/at_activate
@@ -18,6 +20,9 @@ packages/dart/sshnoports/bin/sshnp
 packages/dart/sshnoports/bin/sshnpd
 
 packages/dart/sshnoports/build/
+
+# Visual Studio
+.vs/*
 
 # Jetbrains
 .idea/*

--- a/tools/windows-installer/NoPortsInstaller/ActivateController.cs
+++ b/tools/windows-installer/NoPortsInstaller/ActivateController.cs
@@ -125,7 +125,7 @@ namespace NoPortsInstaller
             {
                 return AtsignStatus.Activated;
             }
-            if (exitCode == "1")
+            if (exitCode == "1" || exitCode == "3")
             {
                 return AtsignStatus.NotActivated;
             }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Detect both teapot (code 1) state & initial atServer (code 3) state as "not activated" in the controller
- ignore visual studio files

**- How I did it**

**- How to verify it**

- I tested activation of an atSign and the atSign management screen
  - Did not test the rest, but that area should be unchanged, other than updating the bundled binaries

**- Description for the changelog**
fix: allow activation of atSigns without requiring teapot state
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
