### PR TITLE
ci: Use arm64 runners for arm builds

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -102,7 +102,7 @@ jobs:
           path: ./packages/c/sshnpd/tarball
           if-no-files-found: error
 
-  docker_build:
+  docker_build_amd64:
     needs: [verify_tags]
     runs-on: ubuntu-latest
     if: ${{ ! inputs.native_build_only }}
@@ -114,8 +114,6 @@ jobs:
         include:
           - platform: linux/amd64
             output-name: sshnpd-linux-x64
-          - platform: linux/arm64
-            output-name: sshnpd-linux-arm64
     ## 20240806: Clang and CMake that we use aren't packaged for
     ## armv7 or riscv64 (also no Debian 10 for RISC-V)
     #          - platform: linux/arm/v7
@@ -141,7 +139,38 @@ jobs:
             }}-${{  github.run_attempt  }}
           path: ./packages/c/tarballs/${{ matrix.output-name }}.tgz
 
-  musl_build:
+  docker_build_arm64:
+    needs: [verify_tags]
+    runs-on: ubuntu-24.04-arm
+    if: ${{ ! inputs.native_build_only }}
+    defaults:
+      run:
+        working-directory: ./packages/c
+    strategy:
+      matrix:
+        include:
+          - platform: linux/arm64
+            output-name: sshnpd-linux-arm64
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: c_release-${{github.run_number}}
+      - uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
+      - uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+      - run: |
+          docker buildx build -t atsigncompany/sshnpdc -f sshnpd/tools/Dockerfile.package \
+          --platform ${{ matrix.platform }} -o type=tar,dest=bins.tar .
+          mkdir tarballs
+          tar -xvf bins.tar -C tarballs
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name:
+            ${{
+            matrix.output-name  }}-${{  github.ref_name  }}-${{  github.run_number
+            }}-${{  github.run_attempt  }}
+          path: ./packages/c/tarballs/${{ matrix.output-name }}.tgz
+
+  musl_build_amd64:
     needs: [verify_tags]
     runs-on: ubuntu-latest
     if: ${{ ! inputs.native_build_only }}
@@ -154,6 +183,36 @@ jobs:
         include:
           - platform: linux/amd64
             output-name: sshnpd-linux-x64-musl
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: c_release-${{github.run_number}}
+      - uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
+      - uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+      - run: |
+          docker buildx build -t atsigncompany/sshnpdcmusl -f sshnpd/tools/Dockerfile.musl \
+          --platform ${{ matrix.platform }} -o type=tar,dest=bins.tar .
+          mkdir tarballs
+          tar -xvf bins.tar -C tarballs
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name:
+            ${{
+            matrix.output-name  }}-${{  github.ref_name  }}-${{  github.run_number
+            }}-${{  github.run_attempt  }}
+          path: ./packages/c/tarballs/${{ matrix.output-name }}.tgz
+
+  musl_build_arm64:
+    needs: [verify_tags]
+    runs-on: ubuntu-24.04-arm
+    if: ${{ ! inputs.native_build_only }}
+    defaults:
+      run:
+        working-directory: ./packages/c
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - platform: linux/arm/v7
             output-name: sshnpd-linux-arm-musl
           - platform: linux/arm64
@@ -201,7 +260,7 @@ jobs:
   github-release:
     name: >-
       Upload artifacts and generate checksums for provenance
-    needs: [native_build, docker_build, musl_build, source_tarball]
+    needs: [native_build, docker_build_amd64, docker_build_arm64, musl_build_amd64, musl_build_arm64, source_tarball]
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -169,7 +169,7 @@ jobs:
 
   other_build:
     needs: verify_tags
-    runs-on: ubuntu-latest
+    runs-on: uubuntu-24.04-arm
     strategy:
       matrix:
         # platform: [linux/arm/v7, linux/arm64, linux/riscv64]


### PR DESCRIPTION
Arm builds on arm64 runners are ~10x faster than amd64

**- What I did**

Modified workflows to use arm64 runners where we do arm builds

**- How I did it**

Tested at https://github.com/cpswan/release_automation/releases/tag/c0.3.0

**- How to verify it**

Will need C and Dart releases to fully test

**- Description for the changelog**

ci: Use arm64 runners for arm builds
