### PR TITLE
chore: Fix version numbers

### DIFF
--- a/packages/c/CMakeLists.txt
+++ b/packages/c/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(csshnpd VERSION 0.3.0 LANGUAGES C)
+project(csshnpd VERSION 0.3.2 LANGUAGES C)
 add_subdirectory(sshnpd)

--- a/packages/c/sshnpd/CHANGELOG.md
+++ b/packages/c/sshnpd/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.3.2
+
+- chore: Fix version numbers
+
+## 0.3.1
+
+- chore: explicitly link cjson
+- ci: Use arm64 runners for arm builds
+
 ## 0.3.0
 
 - feat: Add at_activate

--- a/packages/c/sshnpd/include/sshnpd/version.h
+++ b/packages/c/sshnpd/include/sshnpd/version.h
@@ -1,4 +1,4 @@
 #ifndef SSHNPD_VERSION_H
 #define SSHNPD_VERSION_H
-#define SSHNPD_VERSION "0.3.0"
+#define SSHNPD_VERSION "0.3.2"
 #endif


### PR DESCRIPTION
c0.3.1 went out with the wrong version number

**- What I did**

Bumped version numbers

**- How I did it**

Like #1647

**- Description for the changelog**

chore: Fix version numbers
