### PR TITLE
ci: Move armv7 build back to amd64 runner

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -183,6 +183,10 @@ jobs:
         include:
           - platform: linux/amd64
             output-name: sshnpd-linux-x64-musl
+          #20250123 armv7 not working correctly on arm64 runners
+          #Moving back to amd64 as a workaround until fix found
+          - platform: linux/arm/v7
+            output-name: sshnpd-linux-arm-musl
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -213,8 +217,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: linux/arm/v7
-            output-name: sshnpd-linux-arm-musl
+          #20250123 armv7 not working correctly on arm64 runners
+          #Moving back to amd64 as a workaround until fix found
+          #- platform: linux/arm/v7
+          #  output-name: sshnpd-linux-arm-musl
           - platform: linux/arm64
             output-name: sshnpd-linux-arm64-musl
           - platform: linux/riscv64

--- a/packages/c/CMakeLists.txt
+++ b/packages/c/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(csshnpd VERSION 0.3.2 LANGUAGES C)
+project(csshnpd VERSION 0.3.3 LANGUAGES C)
 add_subdirectory(sshnpd)

--- a/packages/c/sshnpd/CHANGELOG.md
+++ b/packages/c/sshnpd/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.3
+
+- ci: Move armv7 build back to amd64 runner
+
 ## 0.3.2
 
 - chore: Fix version numbers

--- a/packages/c/sshnpd/include/sshnpd/version.h
+++ b/packages/c/sshnpd/include/sshnpd/version.h
@@ -1,4 +1,4 @@
 #ifndef SSHNPD_VERSION_H
 #define SSHNPD_VERSION_H
-#define SSHNPD_VERSION "0.3.2"
+#define SSHNPD_VERSION "0.3.3"
 #endif


### PR DESCRIPTION
arm-musl builds for C sshnpd aren't working properly and are missing from c0.3.1 and c0.3.2 releases

This is happening because `uname -m` is returning `aarch64` rather than `armv7l` when we run on an arm64 runner with:

```sh
docker buildx build -t atsigncompany/sshnpdcmusl -f sshnpd/tools/Dockerfile.musl \
          --platform linux/arm/v7 -o type=tar,dest=bins.tar .
```

The same command runs correctly on an amd64 runner.

**- What I did**

Moved the linux/arm/v7 platform element from the arm64 runner matrix back to the amd64 matrix.

**- How to verify it**

I'll do a c0.3.3 release.

**- Description for the changelog**

ci: Move armv7 build back to amd64 runner
