### PR TITLE
ci: Use TARGETARCH so armv7 builds on arm64 runner

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -183,10 +183,6 @@ jobs:
         include:
           - platform: linux/amd64
             output-name: sshnpd-linux-x64-musl
-          #20250123 armv7 not working correctly on arm64 runners
-          #Moving back to amd64 as a workaround until fix found
-          - platform: linux/arm/v7
-            output-name: sshnpd-linux-arm-musl
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -217,10 +213,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          #20250123 armv7 not working correctly on arm64 runners
-          #Moving back to amd64 as a workaround until fix found
-          #- platform: linux/arm/v7
-          #  output-name: sshnpd-linux-arm-musl
+          - platform: linux/arm/v7
+            output-name: sshnpd-linux-arm-musl
           - platform: linux/arm64
             output-name: sshnpd-linux-arm64-musl
           - platform: linux/riscv64

--- a/packages/c/CMakeLists.txt
+++ b/packages/c/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(csshnpd VERSION 0.3.3 LANGUAGES C)
+project(csshnpd VERSION 0.3.4 LANGUAGES C)
 add_subdirectory(sshnpd)

--- a/packages/c/sshnpd/CHANGELOG.md
+++ b/packages/c/sshnpd/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.4
+
+- ci: Use TARGETARCH so armv7 builds on arm64 runner
+
 ## 0.3.3
 
 - ci: Move armv7 build back to amd64 runner

--- a/packages/c/sshnpd/include/sshnpd/version.h
+++ b/packages/c/sshnpd/include/sshnpd/version.h
@@ -1,4 +1,4 @@
 #ifndef SSHNPD_VERSION_H
 #define SSHNPD_VERSION_H
-#define SSHNPD_VERSION "0.3.3"
+#define SSHNPD_VERSION "0.3.4"
 #endif

--- a/packages/c/sshnpd/tools/Dockerfile.musl
+++ b/packages/c/sshnpd/tools/Dockerfile.musl
@@ -4,13 +4,12 @@
 FROM alpine@sha256:56fa17d2a7e7f168a043a2712e63aed1f8543aeafdcee47c58dcffe38ed51099 AS build
 WORKDIR /sshnpd
 COPY . .
+ARG TARGETARCH
 RUN set -eux; \
   apk add clang cmake coreutils git make python3; \
-  case "$(uname -m)" in \
-    aarch64) ARCH="arm64";; \
-    armv7l)  ARCH="arm";;\
-    riscv64) ARCH="riscv64";;\
-    x86_64)  ARCH="x64";;\
+  case "${TARGETARCH}" in \
+    amd64) ARCH="x64";;\
+    *) ARCH=${TARGETARCH};; \
   esac; \
   cd /sshnpd/sshnpd; \
   cmake -B build -S . -DBUILD_SHARED_LIBS=off -DCMAKE_C_COMPILER=clang \


### PR DESCRIPTION
Back to speedier armv7 builds using arm64 runners, moving past workaround in #1683 

**- What I did**

Modified Dockerfile to use TARGETARCH rather than `uname -m`

**- How I did it**

Informed by https://github.com/BretFisher/multi-platform-docker-build

**- How to verify it**

I've done a test build at https://github.com/cpswan/release_automation/releases/tag/c0.3.4

**- Description for the changelog**

ci: Use TARGETARCH so armv7 builds on arm64 runner
