### PR TITLE
ci: Reinstantiate riscv64 build (using Arm runner)

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -182,7 +182,6 @@ jobs:
     strategy:
       matrix:
         platform: [linux/arm/v7, linux/riscv64]
-        #platform: [linux/arm/v7]
         include:
           - platform: linux/arm/v7
             output-name: sshnp-linux-arm

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -181,13 +181,13 @@ jobs:
     runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
-        # platform: [linux/arm/v7, linux/riscv64]
-        platform: [linux/arm/v7]
+        platform: [linux/arm/v7, linux/riscv64]
+        #platform: [linux/arm/v7]
         include:
           - platform: linux/arm/v7
             output-name: sshnp-linux-arm
-#          - platform: linux/riscv64
-#            output-name: sshnp-linux-riscv64
+          - platform: linux/riscv64
+            output-name: sshnp-linux-riscv64
     steps:
       - name: Checkout multibuild branch
         if: ${{ ! inputs.main_build_only }}


### PR DESCRIPTION
We removed riscv64 from the build matrix in #1543 

It seems to be more reliable (and a little quicker) on the new arm runners, so bringing it back (even though it will push build times from ~6m to ~20m)

**- What I did**

Restored riscv64 to other_builds matrix

**- How I did it**

Removed the comments introduced by #1543

**- How to verify it**

Multiple builds against this branch done at https://github.com/atsign-foundation/noports/actions/runs/12949833914

**- Description for the changelog**

ci: Reinstantiate riscv64 build (using Arm runner)