### PR TITLE
ci: Use arm runner for arm64 and armv7 images

### DIFF
--- a/.github/workflows/dockerhub_sshnpd.yml
+++ b/.github/workflows/dockerhub_sshnpd.yml
@@ -10,7 +10,53 @@ permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
 
 jobs:
-  docker:
+  docker_arm64:
+    strategy:
+      matrix:
+        include:
+          - name: sshnpd
+            dockerfile: ./packages/dart/sshnoports/tools/Dockerfile
+          - name: activate_sshnpd
+            dockerfile: ./packages/dart/sshnoports/tools/Dockerfile.activate
+          - name: sshnpd-slim
+            dockerfile: ./packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Ensure pubspec.yaml matches git ref (if current git ref is a version tag)
+        shell: bash
+        if: startsWith(github.ref, 'refs/tags/v')
+        working-directory: ./packages/dart/sshnoports
+        run: |
+          REF=${{ github.ref }}
+          VER=${REF:11}
+          sed -i "0,/version:/{s/version: \(.*\)/version: "${VER}"/}" pubspec.yaml
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+      - name: Login to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Extract version for docker tag
+      - name: Get version
+        run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      - name: Build and push
+        uses: docker/build-push-action@67a2d409c0a876cbe6b11854e3e25193efe4e62d # v6.12.0
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/arm64,linux/arm/v7
+          push: true
+          provenance: false
+          tags: |
+            atsigncompany/${{ matrix.name }}:${{ env.VERSION }}
+            atsigncompany/${{ matrix.name }}:release-${{ env.VERSION }}
+
+  docker_amd64:
     strategy:
       matrix:
         include:
@@ -49,14 +95,44 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64
           push: true
           provenance: false
           tags: |
-            atsigncompany/${{ matrix.name }}:${{ env.VERSION }}
-            atsigncompany/${{ matrix.name }}:release-${{ env.VERSION }}
+            atsigncompany/${{ matrix.name }}:amd64-${{ env.VERSION }}
+            atsigncompany/${{ matrix.name }}:amd64-release-${{ env.VERSION }}
+
+  docker_combine:
+    needs: [docker_amd64, docker_arm64]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: sshnpd
+          - name: activate_sshnpd
+          - name: sshnpd-slim
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+      - name: Login to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Extract version for docker tag
+      - name: Get version
+        run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      - name: Combine build images
+        id: docker_manifest_build
+        run: |
+          docker buildx imagetools create \
+            -t atsigncompany/${{ matrix.name }}:${{ env.VERSION }} \
+            --append atsigncompany/${{ matrix.name }}:amd64-${{ env.VERSION }}
+          docker buildx imagetools create \
+            -t atsigncompany/${{ matrix.name }}:release-${{ env.VERSION }} \
+            --append atsigncompany/${{ matrix.name }}:amd64-release-${{ env.VERSION }}
       # Promote to latest so long as this isn't a pre-release
-      - name: Tag latest
+      - name: Update latest tag
         run: |
           RELEASE_JSON=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ env.VERSION }}")


### PR DESCRIPTION
Might fix #1689 will at least make it fail faster

**- What I did**

* Split the build into amd64 and arm64 runners for the respective platform targets we build inside them
* Added job to combine the image tags

**- How I did it**

Based on at_dockerfiles

**- How to verify it**

Will need another release

**- Description for the changelog**

ci: Use arm runner for arm64 and armv7 images
