### PR TITLE
ci: Move armv7 build back to x64 runner

### DIFF
--- a/.github/workflows/dockerhub_sshnpd.yml
+++ b/.github/workflows/dockerhub_sshnpd.yml
@@ -10,52 +10,6 @@ permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
 
 jobs:
-  docker_arm64:
-    strategy:
-      matrix:
-        include:
-          - name: sshnpd
-            dockerfile: ./packages/dart/sshnoports/tools/Dockerfile
-          - name: activate_sshnpd
-            dockerfile: ./packages/dart/sshnoports/tools/Dockerfile.activate
-          - name: sshnpd-slim
-            dockerfile: ./packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
-    runs-on: ubuntu-24.04-arm
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Ensure pubspec.yaml matches git ref (if current git ref is a version tag)
-        shell: bash
-        if: startsWith(github.ref, 'refs/tags/v')
-        working-directory: ./packages/dart/sshnoports
-        run: |
-          REF=${{ github.ref }}
-          VER=${REF:11}
-          sed -i "0,/version:/{s/version: \(.*\)/version: "${VER}"/}" pubspec.yaml
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
-      - name: Login to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      # Extract version for docker tag
-      - name: Get version
-        run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
-      - name: Build and push
-        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          platforms: linux/arm64,linux/arm/v7
-          push: true
-          provenance: false
-          tags: |
-            atsigncompany/${{ matrix.name }}:${{ env.VERSION }}
-            atsigncompany/${{ matrix.name }}:release-${{ env.VERSION }}
-
   docker_amd64:
     strategy:
       matrix:
@@ -95,12 +49,58 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm/v7
           push: true
           provenance: false
           tags: |
-            atsigncompany/${{ matrix.name }}:amd64-${{ env.VERSION }}
-            atsigncompany/${{ matrix.name }}:amd64-release-${{ env.VERSION }}
+            atsigncompany/${{ matrix.name }}:${{ env.VERSION }}
+            atsigncompany/${{ matrix.name }}:release-${{ env.VERSION }}
+
+  docker_arm64:
+    strategy:
+      matrix:
+        include:
+          - name: sshnpd
+            dockerfile: ./packages/dart/sshnoports/tools/Dockerfile
+          - name: activate_sshnpd
+            dockerfile: ./packages/dart/sshnoports/tools/Dockerfile.activate
+          - name: sshnpd-slim
+            dockerfile: ./packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Ensure pubspec.yaml matches git ref (if current git ref is a version tag)
+        shell: bash
+        if: startsWith(github.ref, 'refs/tags/v')
+        working-directory: ./packages/dart/sshnoports
+        run: |
+          REF=${{ github.ref }}
+          VER=${REF:11}
+          sed -i "0,/version:/{s/version: \(.*\)/version: "${VER}"/}" pubspec.yaml
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+      - name: Login to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Extract version for docker tag
+      - name: Get version
+        run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      - name: Build and push
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/arm64
+          push: true
+          provenance: false
+          tags: |
+            atsigncompany/${{ matrix.name }}:arm64-${{ env.VERSION }}
+            atsigncompany/${{ matrix.name }}:arm64-release-${{ env.VERSION }}
 
   docker_combine:
     needs: [docker_amd64, docker_arm64]
@@ -127,10 +127,10 @@ jobs:
         run: |
           docker buildx imagetools create \
             -t atsigncompany/${{ matrix.name }}:${{ env.VERSION }} \
-            --append atsigncompany/${{ matrix.name }}:amd64-${{ env.VERSION }}
+            --append atsigncompany/${{ matrix.name }}:arm64-${{ env.VERSION }}
           docker buildx imagetools create \
             -t atsigncompany/${{ matrix.name }}:release-${{ env.VERSION }} \
-            --append atsigncompany/${{ matrix.name }}:amd64-release-${{ env.VERSION }}
+            --append atsigncompany/${{ matrix.name }}:arm64-release-${{ env.VERSION }}
       # Promote to latest so long as this isn't a pre-release
       - name: Update latest tag
         run: |


### PR DESCRIPTION
#1692 caused failures with armv7 builds as noted in https://github.com/atsign-foundation/noports/issues/1688#issuecomment-2613056791

**- What I did**

Moved armv7 build back to the x64 runner

**- How I did it**

The arm64 build is now the straggler that needs to be combined in the final job

**- How to verify it**

Will need another release (v5.8.5)

**- Description for the changelog**

ci: Move armv7 build back to x64 runner
