### PR TITLE
ci: Workaround for armv7 on arm64 runners

### DIFF
--- a/.github/workflows/dockerhub_sshnpd.yml
+++ b/.github/workflows/dockerhub_sshnpd.yml
@@ -10,52 +10,6 @@ permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
 
 jobs:
-  docker_amd64:
-    strategy:
-      matrix:
-        include:
-          - name: sshnpd
-            dockerfile: ./packages/dart/sshnoports/tools/Dockerfile
-          - name: activate_sshnpd
-            dockerfile: ./packages/dart/sshnoports/tools/Dockerfile.activate
-          - name: sshnpd-slim
-            dockerfile: ./packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Ensure pubspec.yaml matches git ref (if current git ref is a version tag)
-        shell: bash
-        if: startsWith(github.ref, 'refs/tags/v')
-        working-directory: ./packages/dart/sshnoports
-        run: |
-          REF=${{ github.ref }}
-          VER=${REF:11}
-          sed -i "0,/version:/{s/version: \(.*\)/version: "${VER}"/}" pubspec.yaml
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
-      - name: Login to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      # Extract version for docker tag
-      - name: Get version
-        run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
-      - name: Build and push
-        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm/v7
-          push: true
-          provenance: false
-          tags: |
-            atsigncompany/${{ matrix.name }}:${{ env.VERSION }}
-            atsigncompany/${{ matrix.name }}:release-${{ env.VERSION }}
-
   docker_arm64:
     strategy:
       matrix:
@@ -95,12 +49,58 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
-          platforms: linux/arm64
+          platforms: linux/arm64,linux/arm/v7
           push: true
           provenance: false
           tags: |
-            atsigncompany/${{ matrix.name }}:arm64-${{ env.VERSION }}
-            atsigncompany/${{ matrix.name }}:arm64-release-${{ env.VERSION }}
+            atsigncompany/${{ matrix.name }}:${{ env.VERSION }}
+            atsigncompany/${{ matrix.name }}:release-${{ env.VERSION }}
+
+  docker_amd64:
+    strategy:
+      matrix:
+        include:
+          - name: sshnpd
+            dockerfile: ./packages/dart/sshnoports/tools/Dockerfile
+          - name: activate_sshnpd
+            dockerfile: ./packages/dart/sshnoports/tools/Dockerfile.activate
+          - name: sshnpd-slim
+            dockerfile: ./packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Ensure pubspec.yaml matches git ref (if current git ref is a version tag)
+        shell: bash
+        if: startsWith(github.ref, 'refs/tags/v')
+        working-directory: ./packages/dart/sshnoports
+        run: |
+          REF=${{ github.ref }}
+          VER=${REF:11}
+          sed -i "0,/version:/{s/version: \(.*\)/version: "${VER}"/}" pubspec.yaml
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+      - name: Login to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Extract version for docker tag
+      - name: Get version
+        run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      - name: Build and push
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          tags: |
+            atsigncompany/${{ matrix.name }}:amd64-${{ env.VERSION }}
+            atsigncompany/${{ matrix.name }}:amd64-release-${{ env.VERSION }}
 
   docker_combine:
     needs: [docker_amd64, docker_arm64]
@@ -127,10 +127,10 @@ jobs:
         run: |
           docker buildx imagetools create \
             -t atsigncompany/${{ matrix.name }}:${{ env.VERSION }} \
-            --append atsigncompany/${{ matrix.name }}:arm64-${{ env.VERSION }}
+            --append atsigncompany/${{ matrix.name }}:amd64-${{ env.VERSION }}
           docker buildx imagetools create \
             -t atsigncompany/${{ matrix.name }}:release-${{ env.VERSION }} \
-            --append atsigncompany/${{ matrix.name }}:arm64-release-${{ env.VERSION }}
+            --append atsigncompany/${{ matrix.name }}:amd64-release-${{ env.VERSION }}
       # Promote to latest so long as this isn't a pre-release
       - name: Update latest tag
         run: |

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
@@ -10,6 +10,7 @@
 #FROM dart:beta-sdk AS buildimage
 
 FROM dart:3.6.1@sha256:a071f0322c7c80469842f7c8258de51d1946ba9b79d09bb8fc4dc969487a68ca  AS buildimage
+ARG TARGETARCH
 ENV PACKAGEDIR=packages/dart/sshnoports
 ENV OPENSSH=tools/static-openssh
 ENV BINARYDIR=/usr/local/at
@@ -39,7 +40,7 @@ RUN \
   # build static openssh binaries
   apt update && apt install -y curl gcc make autoconf ; \
   cd ${WORKDIR}/${OPENSSH} ; \
-  ./static-openssh.sh ; \
+  ARCH=${TARGETARCH} ./static-openssh.sh ; \
   cp build/openssh-portable*/ssh-keygen ${BINARYDIR}/ ; \ 
   cp build/openssh-portable*/ssh ${BINARYDIR}/ ; \
   chmod 755 ${BINARYDIR}/ssh-keygen ; \

--- a/tools/static-openssh/static-openssh.sh
+++ b/tools/static-openssh/static-openssh.sh
@@ -44,7 +44,6 @@ cd "$build"/openssl-*
 # Debian 12 / Ubuntu 20.x.x break the autoconf in ./config on armv7 devices
 # $ARCH passed in from Dockerfile
 # Don't use `uname -m` as we get the wrong answer on arm64 runners
-echo "ARCH is ${ARCH}"
 if [[ $ARCH == "arm" ]]
   then
     echo "Found arm architecture, configuring explicitly"

--- a/tools/static-openssh/static-openssh.sh
+++ b/tools/static-openssh/static-openssh.sh
@@ -42,13 +42,17 @@ gzip -dc $dist/openssl-*.tar.gz |(cd "$build" && tar xf -)
 fi
 cd "$build"/openssl-*
 # Debian 12 / Ubuntu 20.x.x break the autoconf in ./config on armv7 devices
-  CPU=$(uname -m)
-  if [[ $CPU == "armv7l" ]]
-     then  
-     ./Configure linux-armv4 --prefix="$root"  no-shared no-tests
-     else
-     ./config --prefix="$root"  no-shared no-tests
-  fi
+# $ARCH passed in from Dockerfile
+# Don't use `uname -m` as we get the wrong answer on arm64 runners
+echo "ARCH is ${ARCH}"
+if [[ $ARCH == "arm" ]]
+  then
+    echo "Found arm architecture, configuring explicitly"
+    ./Configure linux-armv4 --prefix="$root"  no-shared no-tests
+  else
+    echo "Found ${ARCH} architecture, using default config script"
+    ./config --prefix="$root"  no-shared no-tests
+fi
 make
 make install
 cd "$top"


### PR DESCRIPTION
#1696 got us working again, but armv7 build takes ~1hr, this should get us back to ~5m

**- What I did**

Rather than using `uname -m` to determine the architecture pass in $TARGETARCH from the Dockerfile

**- How I did it**

Picked apart scripts to see how configure was getting flags for arch. @cconstab already had a conditional there, but the move to arm64 (and the incorrect `aarch64` response to `uname -m` was breaking it).

**- How to verify it**

Tested (without push) at https://github.com/cpswan/release_automation/actions/runs/12991786717/job/36230141689

**- Description for the changelog**

ci: Workaround for armv7 on arm64 runners