### PR TITLE
ci: Update to build and package at_activate binary

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -80,8 +80,7 @@ jobs:
           cmake --build build
           mkdir tarball
           mv build/sshnpd .
-          mv build/atactivate .
-          mv build/at_auth_cli .
+          mv build/at_activate .
       # zip the build
       - if: ${{ matrix.os == 'macOS-13' || matrix.os == 'macos-14'}}
         run:

--- a/packages/c/sshnpd/tools/Dockerfile.musl
+++ b/packages/c/sshnpd/tools/Dockerfile.musl
@@ -17,7 +17,7 @@ RUN set -eux; \
   cmake --build build; \
   mkdir /tarball; \
   cd build; \
-  tar -cvzf /tarball/sshnpd-linux-${ARCH}-musl.tgz sshnpd atactivate at_auth_cli
+  tar -cvzf /tarball/sshnpd-linux-${ARCH}-musl.tgz sshnpd at_activate
 
 FROM scratch
 COPY --from=build /tarball/* /

--- a/packages/c/sshnpd/tools/Dockerfile.package
+++ b/packages/c/sshnpd/tools/Dockerfile.package
@@ -14,7 +14,7 @@ RUN set -eux; \
   cmake --build build; \
   mkdir /tarball; \
   cd build; \
-  tar -cvzf /tarball/sshnpd-linux-${ARCH}.tgz sshnpd atactivate at_auth_cli
+  tar -cvzf /tarball/sshnpd-linux-${ARCH}.tgz sshnpd at_activate
 
 FROM scratch
 COPY --from=build /tarball/* /


### PR DESCRIPTION
New at_activate binary replaces old atactivate and at_auth_cli

**- What I did**

Updated workflow and Dockerfiles to use new binary name

**- How I did it**

Based on #1642 

**- How to verify it**

c0.4.0 release

**- Description for the changelog**

ci: Update to build and package at_activate binary
