### PR TITLE
ci: Use Ninja for musl builds

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -99,6 +99,7 @@ jobs:
       run:
         working-directory: ./packages/c
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/packages/c/sshnpd/tools/Dockerfile.musl
+++ b/packages/c/sshnpd/tools/Dockerfile.musl
@@ -6,7 +6,7 @@ WORKDIR /sshnpd
 COPY . .
 ARG TARGETARCH
 RUN set -eux; \
-  apk add clang cmake coreutils git make samurai python3; \
+  apk add clang cmake coreutils git make ninja python3; \
   case "${TARGETARCH}" in \
     amd64) ARCH="x64";;\
     *) ARCH=${TARGETARCH};; \

--- a/packages/c/sshnpd/tools/Dockerfile.musl
+++ b/packages/c/sshnpd/tools/Dockerfile.musl
@@ -12,7 +12,7 @@ RUN set -eux; \
     *) ARCH=${TARGETARCH};; \
   esac; \
   cd /sshnpd/sshnpd; \
-  cmake -B build -G ninja -S . -DBUILD_SHARED_LIBS=off -DCMAKE_C_COMPILER=clang \
+  cmake -B build -G Ninja -S . -DBUILD_SHARED_LIBS=off -DCMAKE_C_COMPILER=clang \
     -DCMAKE_C_FLAGS="-Wno-error -pthread" -DCMAKE_EXE_LINKER_FLAGS="-static"; \
   cmake --build build; \
   mkdir /tarball; \

--- a/packages/c/sshnpd/tools/Dockerfile.musl
+++ b/packages/c/sshnpd/tools/Dockerfile.musl
@@ -6,13 +6,13 @@ WORKDIR /sshnpd
 COPY . .
 ARG TARGETARCH
 RUN set -eux; \
-  apk add clang cmake coreutils git make python3; \
+  apk add clang cmake coreutils git make ninja-build python3; \
   case "${TARGETARCH}" in \
     amd64) ARCH="x64";;\
     *) ARCH=${TARGETARCH};; \
   esac; \
   cd /sshnpd/sshnpd; \
-  cmake -B build -S . -DBUILD_SHARED_LIBS=off -DCMAKE_C_COMPILER=clang \
+  cmake -B build -G ninja -S . -DBUILD_SHARED_LIBS=off -DCMAKE_C_COMPILER=clang \
     -DCMAKE_C_FLAGS="-Wno-error -pthread" -DCMAKE_EXE_LINKER_FLAGS="-static"; \
   cmake --build build; \
   mkdir /tarball; \

--- a/packages/c/sshnpd/tools/Dockerfile.musl
+++ b/packages/c/sshnpd/tools/Dockerfile.musl
@@ -6,13 +6,13 @@ WORKDIR /sshnpd
 COPY . .
 ARG TARGETARCH
 RUN set -eux; \
-  apk add clang cmake coreutils git make ninja-build python3; \
+  apk add clang cmake coreutils git make samurai python3; \
   case "${TARGETARCH}" in \
     amd64) ARCH="x64";;\
     *) ARCH=${TARGETARCH};; \
   esac; \
   cd /sshnpd/sshnpd; \
-  cmake -B build -G Ninja -S . -DBUILD_SHARED_LIBS=off -DCMAKE_C_COMPILER=clang \
+  cmake -B build -G ninja -S . -DBUILD_SHARED_LIBS=off -DCMAKE_C_COMPILER=clang \
     -DCMAKE_C_FLAGS="-Wno-error -pthread" -DCMAKE_EXE_LINKER_FLAGS="-static"; \
   cmake --build build; \
   mkdir /tarball; \


### PR DESCRIPTION
riscv64 builds have been taking ~10m, per @XavierChanth suggestion using Ninja reduces that to 1/3

**- What I did**

Switched to using Ninja for builds in musl Dockerfile

**- How I did it**

Added `ninja` package and specified `-G Ninja` for CMake

**- How to verify it**

[Test run](https://github.com/atsign-foundation/noports/actions/runs/13050793779) against this branch

**- Description for the changelog**

ci: Use Ninja for musl builds