### PR TITLE
fix: #1725 Profile unfavourite functionality not working

### DIFF
--- a/packages/dart/npt_flutter/lib/features/favorite/bloc/favorite_bloc.dart
+++ b/packages/dart/npt_flutter/lib/features/favorite/bloc/favorite_bloc.dart
@@ -53,7 +53,7 @@ class FavoriteBloc extends LoggingBloc<FavoriteEvent, FavoritesState> {
     }
 
     emit(FavoritesLoaded(
-      (state as FavoritesLoaded).favorites.toSet().difference(event.toRemove.toSet()),
+      (state as FavoritesLoaded).favorites.toSet().difference(event.toRemove.toSet()).toList(),
     ));
 
     try {


### PR DESCRIPTION
**- What I did**
Converted emitted state from a `set` to a `list`

**- How to verify it**
Favourite then unfavourite a profile

**- Description for the changelog**
Fixed profile unfavourite functionality not working
