### PR TITLE
fix: sshnpd main process leaks

### DIFF
--- a/packages/c/.gitignore
+++ b/packages/c/.gitignore
@@ -5,6 +5,6 @@ compile_commands.json
 
 just.env
 
-valgrind-sshnpd-*.log
+valgrind-sshnpd-*
 core
 Testing/

--- a/packages/c/CMakeLists.txt
+++ b/packages/c/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(csshnpd VERSION 0.4.3 LANGUAGES C)
+project(csshnpd VERSION 1.0.0 LANGUAGES C)
 add_subdirectory(sshnpd)
 add_subdirectory(graceful-shutdown-tool)

--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -3,7 +3,7 @@ if(NOT atsdk_FOUND)
   FetchContent_Declare(
     atsdk
     GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-    GIT_TAG 54e4cc64654eeed19bb92989e4619df103f14675
+    GIT_TAG 053b40b77da2966adb377aab0fcbbd08691525de
   )
   FetchContent_MakeAvailable(atsdk)
   install(

--- a/packages/c/justfile
+++ b/packages/c/justfile
@@ -56,7 +56,7 @@ memcheck +ARGS='': build-dev
   --leak-check=full \
   --show-leak-kinds=all \
   {{dev_dir}}/sshnpd/sshnpd -a $TO_ATSIGN -m $FROM_ATSIGN -d $DEVICE_NAME \
-  --permit-open "*:*" -v
+  --permit-open "*:*" -v {{ARGS}}
   echo "memcheck log saved to: $file"
 
 # CONTAINER COMMANDS

--- a/packages/c/justfile
+++ b/packages/c/justfile
@@ -69,17 +69,17 @@ memcheck-docker +ARGS='':
   docker run --rm --platform linux/amd64 -ti \
   --network=host \
   --mount type=bind,src=$PWD,dst=/mnt/workdir \
-  --mount type=bind,src=$HOME/.atsign/keys,dst=/root/.atsign/keys \
+  --mount type=bind,src=$HOME/.atsign/keys,dst=/home/atsign/.atsign/keys \
   atsigncompany/valgrind:latest  \
-  /bin/bash -c "mkdir /root/.ssh/; touch /root/.ssh/authorized_keys; export USER=root; export HOME=/root; just memcheck {{ARGS}}"
+  /bin/bash -c "mkdir -p /home/atsign/.ssh/; touch /home/atsign/.ssh/authorized_keys; just memcheck {{ARGS}}"
 
 valgrind-docker:
   docker run --rm --platform linux/amd64 -ti \
   --network=host \
   --mount type=bind,src=$PWD,dst=/mnt/workdir \
-  --mount type=bind,src=$HOME/.atsign/keys,dst=/root/.atsign/keys \
+  --mount type=bind,src=$HOME/.atsign/keys,dst=/home/atsign/.atsign/keys \
   atsigncompany/valgrind:latest  \
-  /bin/bash -c "export USER=root; export HOME=/root; /bin/bash --login"
+  /bin/bash -c "/bin/bash --login"
 
 # CONFIGURE COMMANDS
 

--- a/packages/c/srv/CMakeLists.txt
+++ b/packages/c/srv/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
 
-project(srv VERSION 0.4.3 LANGUAGES C)
+project(srv VERSION 1.0.0 LANGUAGES C)
 
 # 1. Variables - you are free to edit anything in this step
 

--- a/packages/c/sshnpd/CHANGELOG.md
+++ b/packages/c/sshnpd/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+- fix: memory leaks on the main daemon process
+
 ## 0.4.1
 
 - feat: add Dart compliant at_activate binary in place of existing ones

--- a/packages/c/sshnpd/CMakeLists.txt
+++ b/packages/c/sshnpd/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(sshnpd VERSION 0.4.3 LANGUAGES C)
+project(sshnpd VERSION 1.0.0 LANGUAGES C)
 
 # 1. Variables - you are free to edit anything in this step
 

--- a/packages/c/sshnpd/include/sshnpd/version.h
+++ b/packages/c/sshnpd/include/sshnpd/version.h
@@ -1,4 +1,4 @@
 #ifndef SSHNPD_VERSION_H
 #define SSHNPD_VERSION_H
-#define SSHNPD_VERSION "0.4.3"
+#define SSHNPD_VERSION "1.0.0"
 #endif

--- a/packages/c/sshnpd/src/handle_npt_request.c
+++ b/packages/c/sshnpd/src/handle_npt_request.c
@@ -33,7 +33,11 @@ void handle_npt_request(atclient *atclient, pthread_mutex_t *atclient_lock, sshn
   // allocated: envelope
 
   // log envelope
-  atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Received envelope: %s\n", cJSON_Print(envelope));
+  if (atlogger_get_logging_level() >= ATLOGGER_LOGGING_LEVEL_DEBUG) {
+    char *envelope_str = cJSON_Print(envelope);
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Received envelope: %s\n", envelope_str);
+    free(envelope_str);
+  }
 
   char *requesting_atsign = message->notification->from;
   res = verify_envelope_signature_from(envelope, requesting_atsign, atclient, atclient_lock);

--- a/packages/c/sshnpd/src/handle_ssh_request.c
+++ b/packages/c/sshnpd/src/handle_ssh_request.c
@@ -33,7 +33,11 @@ void handle_ssh_request(atclient *atclient, pthread_mutex_t *atclient_lock, sshn
   // allocated: envelope
 
   // log envelope
-  atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Received envelope: %s\n", cJSON_Print(envelope));
+  if (atlogger_get_logging_level() >= ATLOGGER_LOGGING_LEVEL_DEBUG) {
+    char *envelope_str = cJSON_Print(envelope);
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Received envelope: %s\n", envelope_str);
+    free(envelope_str);
+  }
 
   char *requesting_atsign = message->notification->from;
   res = verify_envelope_signature_from(envelope, requesting_atsign, atclient, atclient_lock);
@@ -109,7 +113,9 @@ void handle_ssh_request(atclient *atclient, pthread_mutex_t *atclient_lock, sshn
 
     int res = run_srv_process(rvd_host_str, rvd_port_int, requested_host_str, requested_port_int, authenticate_to_rvd,
                               rvd_auth_string, encrypt_rvd_traffic, multi, session_aes_key, session_iv);
-
+    if (res != 0) {
+      atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "srv process exited with code: %d\n", res);
+    }
     *is_child_process = true;
 
     if (encrypt_rvd_traffic) {
@@ -119,8 +125,7 @@ void handle_ssh_request(atclient *atclient, pthread_mutex_t *atclient_lock, sshn
     if (authenticate_to_rvd) {
       cJSON_free(rvd_auth_string);
     }
-    cJSON_Delete(envelope);
-    exit(res);
+    return;
     // end of child process
   } else if (pid > 0) {
     // parent process
@@ -157,15 +162,17 @@ void handle_ssh_request(atclient *atclient, pthread_mutex_t *atclient_lock, sshn
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to fork the srv process: %s\n", strerror(errno));
   }
 cancel:
-  if (authenticate_to_rvd) {
-    cJSON_free(rvd_auth_string);
+  if (!*is_child_process) {
+    if (authenticate_to_rvd) {
+      cJSON_free(rvd_auth_string);
+    }
+    if (encrypt_rvd_traffic) {
+      free(session_iv);
+      free(session_aes_key);
+      free(session_iv_base64);
+      free(session_aes_key_base64);
+    }
+    cJSON_Delete(envelope);
   }
-  if (encrypt_rvd_traffic) {
-    free(session_iv);
-    free(session_aes_key);
-    free(session_iv_base64);
-    free(session_aes_key_base64);
-  }
-  cJSON_Delete(envelope);
   return;
 }

--- a/packages/c/sshnpd/src/handle_ssh_request.c
+++ b/packages/c/sshnpd/src/handle_ssh_request.c
@@ -125,6 +125,7 @@ void handle_ssh_request(atclient *atclient, pthread_mutex_t *atclient_lock, sshn
     if (authenticate_to_rvd) {
       cJSON_free(rvd_auth_string);
     }
+    cJSON_Delete(envelope);
     return;
     // end of child process
   } else if (pid > 0) {

--- a/packages/c/sshnpd/src/handler_commons.c
+++ b/packages/c/sshnpd/src/handler_commons.c
@@ -524,18 +524,25 @@ int send_success_payload(cJSON *payload, atclient *atclient, pthread_mutex_t *at
   size_t keynamelen = strlen(identifier) + strlen(params->device) + 2; // + 1 for '.' +1 for '\0'
   char *keyname = malloc(sizeof(char) * keynamelen);
   if (keyname == NULL) {
-    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to allocate memory for keyname");
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to allocate memory for keyname\n");
     goto clean_final_res_value;
   }
 
   snprintf(keyname, keynamelen, "%s.%s", identifier, params->device);
-  atclient_atkey_create_shared_key(&final_res_atkey, keyname, params->atsign, requesting_atsign, SSHNP_NS);
+  int ret = atclient_atkey_create_shared_key(&final_res_atkey, keyname, params->atsign, requesting_atsign, SSHNP_NS);
+  if (ret != 0) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to create success shared key\n");
+    goto clean_final_res_value;
+  }
 
   // print final_res_atkey
   char *final_res_atkey_str = NULL;
-  atclient_atkey_to_string(&final_res_atkey, &final_res_atkey_str);
-  atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Final response atkey: %s\n", final_res_atkey_str);
-  free(final_res_atkey_str);
+  ret = atclient_atkey_to_string(&final_res_atkey, &final_res_atkey_str);
+  if (ret == 0) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Final response atkey: %s\n", final_res_atkey_str);
+  } else {
+    goto clean_res;
+  }
 
   atclient_atkey_metadata *metadata = &final_res_atkey.metadata;
   atclient_atkey_metadata_set_is_public(metadata, false);
@@ -546,27 +553,22 @@ int send_success_payload(cJSON *payload, atclient *atclient, pthread_mutex_t *at
   atclient_notify_params_init(&notify_params);
   if ((res = atclient_notify_params_set_atkey(&notify_params, &final_res_atkey)) != 0) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set atkey in notify params\n");
-    goto clean_res;
+    goto clean_notify;
   }
   if ((res = atclient_notify_params_set_value(&notify_params, final_res_value)) != 0) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set value in notify params\n");
-    goto clean_res;
+    goto clean_notify;
   }
   if ((res = atclient_notify_params_set_operation(&notify_params, ATCLIENT_NOTIFY_OPERATION_UPDATE)) != 0) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set operation in notify params\n");
-    goto clean_res;
+    goto clean_notify;
   }
 
-  char *final_keystr = NULL;
-  atclient_atkey_to_string(&final_res_atkey, &final_keystr);
-  atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Final response atkey: %s\n", final_res_atkey_str);
-  free(final_keystr);
-
-  int ret = pthread_mutex_lock(atclient_lock);
+  ret = pthread_mutex_lock(atclient_lock);
   if (ret != 0) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
                  "Failed to get a lock on atclient for sending a notification\n");
-    goto clean_res;
+    goto clean_notify;
   }
 
   ret = atclient_notify(atclient, &notify_params, NULL);
@@ -581,7 +583,14 @@ int send_success_payload(cJSON *payload, atclient *atclient, pthread_mutex_t *at
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Released the atclient lock\n");
   }
 
-clean_res: { free(keyname); }
+clean_notify:
+  atclient_notify_params_free(&notify_params);
+clean_res: {
+  if (final_res_atkey_str != NULL) {
+    free(final_res_atkey_str);
+  }
+  free(keyname);
+}
 clean_final_res_value: {
   atclient_atkey_free(&final_res_atkey);
   cJSON_free(final_res_value);

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -64,6 +64,7 @@ static int unlock_atclient(int);
 
 static int reconnect_atclient();
 static int reconnect_monitor();
+static void free_atclient_without_disconnect(atclient *atclient);
 
 static int set_worker_hooks();
 static void main_loop();
@@ -379,12 +380,16 @@ cancel_atclient:
   if (free_ping_response) {
     free(ping_response);
   }
-  if (!is_child_process) {
+  if (is_child_process) {
+    free_atclient_without_disconnect(&worker);
+  } else {
     atclient_connection_disconnect(&worker.atserver_connection);
     atclient_free(&worker);
   }
 cancel_monitor_ctx:
-  if (!is_child_process) {
+  if (is_child_process) {
+    free_atclient_without_disconnect(&monitor_ctx);
+  } else {
     atclient_connection_disconnect(&monitor_ctx.atserver_connection);
     atclient_free(&monitor_ctx);
   }
@@ -664,4 +669,20 @@ static int reconnect_monitor() {
 
   atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Reconnected the monitor connection.\n");
   return 0;
+}
+
+static void free_atclient_without_disconnect(atclient *atclient) {
+  if (atclient_is_atsign_initialized(atclient)) {
+    atclient_unset_atsign(atclient);
+  }
+  atclient_connection *conn = &atclient->atserver_connection;
+
+  if (atclient_connection_hooks_is_enabled(conn)) {
+    atclient_connection_hooks_disable(conn);
+  }
+  free(conn->host);
+
+  // commented until https://github.com/atsign-foundation/at_c/issues/555
+  // has been addressed
+  // atclient_tls_socket_free(&conn->_socket);
 }

--- a/packages/c/valgrind-test-scenarios.md
+++ b/packages/c/valgrind-test-scenarios.md
@@ -1,0 +1,61 @@
+# Valgrind Test Scenarios
+
+A list of test scenarios to run sshnpd under valgrind with.
+All of these test scenarios assume the program is shutdown with the
+graceful-shutdown-tool unless dictated otherwise.
+
+## Test Scenarios
+
+### idle
+
+Don't create any sessions. Start the program, wait for a few stats notifications
+then shutdown.
+
+### idle reconnect
+
+Same thing, don't create any sessions. Start the program, but this time, once
+monitor is started, disconnect the network, and wait for it to reconnect. The
+best way to do this is force a swap from Ethernet to WiFi or vice-versa. Then,
+after the reconnect wait for another stats notification and shutdown.
+
+### idle background thread
+
+Again, don't create any sessions. This time we want to test that the hourly
+background job doesn't have any leaks. The easiest way to do this is to
+temporarily reduce the timer from 60 minutes to 1 minute
+(global search for `60 * 60` to find this). Then do the same thing as the idle,
+but wait until you see the background job run again. Then shutdown.
+
+### sshnp session
+
+Start an sshnp session with the minimum required arguments: -f, -t, & -d.
+Using the valgrind container with `--network=host` is a fine option, if you have
+password authentication turned on, it's fine to not sign in to the ssh session.
+Close the sshnp session, then shutdown.
+
+### npt session
+
+Start an npt session with the minimum required arguments: -f, -t, -d, -l, & -p.
+Using the valgrind container with `--network=host` is a fine option.
+Close the npt session, then shutdown.
+
+### ping handler
+
+Should be tested by newer versions of sshnp and npt already. No need to test
+separately, but calling it out since it is its own notification type.
+
+### send ssh public key
+
+Same as sshnp session, but include the `-s` and `-i` flag in the sshnp command.
+It's best to address any issues with `sshnp session` before moving on to this
+test.
+
+### live sshnp session
+
+Same thing as `sshnp session` but don't close the sshnp session before shutting
+down.
+
+### live npt session
+
+Same thing as `npt session` but don't close the npt session before shutting
+down.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
closes #1716 

**- What I did**

- Updated tooling (just commands) to help analyze and address leaks
- Addressed leaked strings in handler commons, ssh request handler, npt request handler
- Refactored cleanup on child processes, but awaiting: https://github.com/Mbed-TLS/mbedtls/issues/9958
  - We don't need this though to address all leaks in the main process, which are fully handled in this PR

**- How I did it**

**- How to verify it**

See valgrind logs here: https://gist.github.com/XavierChanth/3636f55f625f14c8999b1bed43916eae
Note: A handful of these logs will show leaks, but that is when a child process from an srv session is closed, the logs indicate process number like `==PID==` on the left margin, lowest number is the main process.

**- Description for the changelog**
fix: sshnpd main process leaks
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
