### PR TITLE
docs: Update READMEs for archiving Python daemon

### DIFF
--- a/packages/c/sshnpd/README.md
+++ b/packages/c/sshnpd/README.md
@@ -2,33 +2,7 @@
 
 ## Status
 
-The C version of sshnpd is currently in alpha, we are working hard to deliver a
-lighter weight and more widely available version of sshnpd (NoPorts device
-daemon).
-
-## Caveats
-
-Because this is still in alpha, and it is dependent on the alpha
-[C atSDK](https://github.com/atsign-foundation/at_c), this version of sshnpd is
-expected to have both known and unknown bugs as it undergoes extensive testing
-and analysis.
-
-### Known bugs
-
-There are some known memory leaks in the current alpha (0.1.0) release. We are
-actively addressing the most critical ones first, and will provide valgrind
-suppression files for non-critical ones.
-
-In this case, "non-critical memory leaks" includes finite memory leaks which
-will not grow with continued use of the software. This can include:
-
-- Memory leaks which are cleaned upon closure of a forked child process
-- Memory which should be allocated for the entire life of the main process
-
-### Likely bugs
-
-Stability around system calls is not well tested, and may not work in all
-environments. We have done our best to use portable solutions where possible.
+The C version of sshnpd is production ready.
 
 ## How to build
 

--- a/packages/python/sshnpd/README.md
+++ b/packages/python/sshnpd/README.md
@@ -4,7 +4,18 @@
 [![PyPI version](https://badge.fury.io/py/sshnpd.svg)](https://badge.fury.io/py/sshnpd)
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 
-# SSHNPD Python (beta)
+# ARCHIVED - SSHNPD Python (beta)
+
+0.4.16 will be the final release of this package, which is being archived.
+
+Pyhton was chosen to implement a NoPorts daemon that was more portable than
+the Dart version, but unfortunately the installation footprint was too large
+for many of the intended devices.
+
+With the production release of the
+[C NoPorts daemon](https://github.com/atsign-foundation/noports/tree/trunk/packages/c/sshnpd)
+we now recommend that be used for any devices where a small portable
+implementation is required.
 
 SSH No Ports provides a way to ssh to a remote linux host/device without that
 device or the client having any open ports (not even 22) on external

--- a/packages/python/sshnpd/pyproject.toml
+++ b/packages/python/sshnpd/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sshnpd"
-version = "0.4.15"
+version = "0.4.16"
 description = "Python implementation of SSH No Ports daemon"
 authors = ["Xavier Lin <xavier.lin@atsign.com >"]
 maintainers = ["Chris Swan <chris@atsign.com>"]
@@ -12,7 +12,7 @@ sshnpd = 'sshnpd:main'
 
 [tool.poetry.dependencies]
 python = "^3.10"
-atsdk = "0.2.30"
+atsdk = "0.2.33"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
We need to do a final release of the Python daemon with an archival notice before archiving the package.

**- What I did**

* Bumped to use latest SDK
* Updated READMEs

**- Description for the changelog**

docs: Update READMEs for archiving Python daemon
