### PR TITLE
build: use `npm ci` instead of `npm install` in build scripts

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -228,9 +228,6 @@ jobs:
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: '20.17.0'
-      - name: setup required npm version
-        run: |
-          npm ci npm@10.8.2
       - name: Build admin webapp
         working-directory: ./apps/admin/webapp
         run: |

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -230,7 +230,7 @@ jobs:
           node-version: '20.17.0'
       - name: setup required npm version
         run: |
-          npm ci -g npm@10.8.2
+          npm ci npm@10.8.2
       - name: Build admin webapp
         working-directory: ./apps/admin/webapp
         run: |

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -230,7 +230,7 @@ jobs:
           node-version: '20.17.0'
       - name: setup required npm version
         run: |
-          npm install -g npm@10.8.2
+          npm ci -g npm@10.8.2
       - name: Build admin webapp
         working-directory: ./apps/admin/webapp
         run: |

--- a/.github/workflows/npm_build_test.yml
+++ b/.github/workflows/npm_build_test.yml
@@ -20,6 +20,6 @@ jobs:
       - name: setup required npm version and test build
         working-directory: ./apps/admin/webapp
         run: |
-          npm ci -g npm@10.8.2
+          npm ci npm@10.8.2
           npm ci
           npm run build

--- a/.github/workflows/npm_build_test.yml
+++ b/.github/workflows/npm_build_test.yml
@@ -20,6 +20,6 @@ jobs:
       - name: setup required npm version and test build
         working-directory: ./apps/admin/webapp
         run: |
-          npm install -g npm@10.8.2
+          npm ci -g npm@10.8.2
           npm ci
           npm run build

--- a/.github/workflows/npm_build_test.yml
+++ b/.github/workflows/npm_build_test.yml
@@ -17,9 +17,8 @@ jobs:
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: '20.17.0'
-      - name: setup required npm version and test build
+      - name: test the build
         working-directory: ./apps/admin/webapp
         run: |
-          npm ci npm@10.8.2
           npm ci
           npm run build


### PR DESCRIPTION
**- What I did**
build: use `npm ci` instead of `npm install` in build scripts, so that the dependency isn't flagged as being unpinned

**- How I did it**
Modified npm_build_test.yml and multibuild.yml

**- How to verify it**
line no longer flagged as unpinned by the dependency checker
