### PR TITLE
feat: (DRAFT / SPIKE) managed policy profiles

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -3,7 +3,7 @@ name: noports
 packages:
   - packages/dart/noports_core
   - packages/dart/sshnoports
-  - packages/dart/sshnp_flutter
+  - packages/dart/npt_flutter
 
 command:
   bootstrap:

--- a/packages/dart/npt_flutter/lib/features/onboarding/util/profile_progress_listener.dart
+++ b/packages/dart/npt_flutter/lib/features/onboarding/util/profile_progress_listener.dart
@@ -4,18 +4,77 @@ import 'dart:developer';
 import 'package:at_client_mobile/at_client_mobile.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:npt_flutter/app.dart';
+import 'package:npt_flutter/constants.dart';
 import 'package:npt_flutter/features/profile_list/bloc/profile_list_bloc.dart';
+import 'package:npt_flutter/util/uuid.dart';
 
 import '../../profile_list/cubit/sync_cubit.dart';
 
 class ProfileProgressListener extends SyncProgressListener {
+  ProfileProgressListener() {
+    Stream<AtNotification> subscription = AtClientManager.getInstance()
+        .atClient
+        .notificationService
+        .subscribe(
+            regex:
+                '\\.${Uuid.profilesSubNamespace}\\.${Constants.namespace!}@');
+    subscription.listen((AtNotification n) async {
+      try {
+        final profileListBlock =
+            App.navState.currentContext!.read<ProfileListBloc>();
+
+        App.log('[INFO] Notification $n'.loggable);
+        if (n.key.contains(
+            '.${Uuid.profilesSubNamespace}.${Constants.namespace!}')) {
+          switch (n.operation) {
+            case 'update':
+              AtClientManager.getInstance().atClient.syncService.sync();
+              break;
+
+            case 'delete':
+              await AtClientManager.getInstance()
+                  .atClient
+                  .getLocalSecondary()!
+                  .keyStore!
+                  .remove('cached:${n.key}', skipCommit: true);
+              profileListBlock.add(const ProfileListLoadEvent());
+              log('ProfileProgressListener: ProfileListLoadEvent triggered to reload profiles');
+              break;
+
+            default:
+              break;
+          }
+        }
+      } catch (ignore) {
+        App.log('[ERROR] Caught $ignore while listening to notifications.'
+                ' Ignoring and continuing.'
+            .loggable);
+      }
+    });
+  }
+
   @override
   void onSyncProgressEvent(SyncProgress syncProgress) async {
     unawaited(App.navState.currentContext!.read<SyncCubit>().checkSync());
-    final profileListBlock = App.navState.currentContext!.read<ProfileListBloc>();
+    final profileListBlock =
+        App.navState.currentContext!.read<ProfileListBloc>();
+
+    bool profileSynced() {
+      for (final KeyInfo ki in syncProgress.keyInfoList ?? []) {
+        App.log('[DEBUG] sync keyInfo: $ki'.loggable);
+        if (ki.syncDirection == SyncDirection.remoteToLocal) {
+          if (ki.key.contains(
+              '.${Uuid.profilesSubNamespace}.${Constants.namespace!}')) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
 
     if (syncProgress.syncStatus == SyncStatus.success &&
-        (profileListBlock.state is ProfileListLoaded &&
+        profileListBlock.state is ProfileListLoaded &&
+        (profileSynced() ||
             (profileListBlock.state as ProfileListLoaded).profiles.isEmpty)) {
       profileListBlock.add(const ProfileListLoadEvent());
       log('ProfileProgressListener: ProfileListLoadEvent triggered to reload profiles');

--- a/packages/dart/npt_flutter/lib/features/onboarding/util/profile_progress_listener.dart
+++ b/packages/dart/npt_flutter/lib/features/onboarding/util/profile_progress_listener.dart
@@ -11,13 +11,11 @@ import 'package:npt_flutter/util/uuid.dart';
 import '../../profile_list/cubit/sync_cubit.dart';
 
 class ProfileProgressListener extends SyncProgressListener {
-  ProfileProgressListener() {
-    Stream<AtNotification> subscription = AtClientManager.getInstance()
-        .atClient
-        .notificationService
-        .subscribe(
-            regex:
-                '\\.${Uuid.profilesSubNamespace}\\.${Constants.namespace!}@');
+  ProfileProgressListener(AtClient atClient) {
+    Stream<AtNotification> subscription =
+        atClient.notificationService.subscribe(
+            regex: '\\.${Uuid.profilesSubNamespace}'
+                '\\.${Constants.namespace!}@');
     subscription.listen((AtNotification n) async {
       try {
         final profileListBlock =
@@ -28,12 +26,11 @@ class ProfileProgressListener extends SyncProgressListener {
             '.${Uuid.profilesSubNamespace}.${Constants.namespace!}')) {
           switch (n.operation) {
             case 'update':
-              AtClientManager.getInstance().atClient.syncService.sync();
+              atClient.syncService.sync();
               break;
 
             case 'delete':
-              await AtClientManager.getInstance()
-                  .atClient
+              await atClient
                   .getLocalSecondary()!
                   .keyStore!
                   .remove('cached:${n.key}', skipCommit: true);

--- a/packages/dart/npt_flutter/lib/features/onboarding/widgets/onboarding_button.dart
+++ b/packages/dart/npt_flutter/lib/features/onboarding/widgets/onboarding_button.dart
@@ -1,6 +1,7 @@
 import 'dart:developer';
 import 'dart:io';
 
+import 'package:at_client/src/service/sync_service_impl.dart';
 import 'package:at_contacts_flutter/at_contacts_flutter.dart';
 import 'package:at_onboarding_flutter/at_onboarding_flutter.dart';
 import 'package:at_onboarding_flutter/at_onboarding_services.dart';
@@ -129,6 +130,9 @@ class _OnboardingButtonState extends State<OnboardingButton> {
   }
 
   Future<void> onboard({required String atsign, required String rootDomain, bool isFromInitState = false}) async {
+    SyncServiceImpl.queueSize = 1;
+    SyncServiceImpl.syncRequestThreshold = 1;
+    SyncServiceImpl.syncRequestTriggerInSeconds = 1;
     var atSigns = await KeyChainManager.getInstance().getAtSignListFromKeychain();
     var apiKey = await Constants.appAPIKey;
     var config = AtOnboardingConfig(

--- a/packages/dart/npt_flutter/lib/features/onboarding/widgets/onboarding_button.dart
+++ b/packages/dart/npt_flutter/lib/features/onboarding/widgets/onboarding_button.dart
@@ -1,7 +1,6 @@
 import 'dart:developer';
 import 'dart:io';
 
-import 'package:at_client/src/service/sync_service_impl.dart';
 import 'package:at_contacts_flutter/at_contacts_flutter.dart';
 import 'package:at_onboarding_flutter/at_onboarding_flutter.dart';
 import 'package:at_onboarding_flutter/at_onboarding_services.dart';
@@ -25,6 +24,8 @@ import 'package:npt_flutter/routes.dart';
 import 'package:npt_flutter/util/language.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
+// ignore: implementation_imports, depend_on_referenced_packages
+import 'package:at_client/src/service/sync_service_impl.dart';
 
 final strings = AppLocalizations.of(App.navState.currentContext!)!;
 Future<AtClientPreference> loadAtClientPreference(String rootDomain) async {
@@ -163,6 +164,7 @@ class _OnboardingButtonState extends State<OnboardingButton> {
     switch (onboardingResult?.status ?? AtOnboardingResultStatus.cancel) {
       case AtOnboardingResultStatus.success:
         await initializeContactsService(rootDomain: rootDomain);
+        AtClientManager.getInstance().atClient.notificationService;
         AtClientManager.getInstance().atClient.syncService.addProgressListener(ProfileProgressListener());
         AtClientManager.getInstance().atClient.syncService.sync();
         postOnboard(onboardingResult!.atsign!, rootDomain);
@@ -276,7 +278,7 @@ class _OnboardingButtonState extends State<OnboardingButton> {
           final statusStream = util.uploadAtKeysFile(atsign);
           result = await handleFileUploadStatusStream(statusStream, atsign);
         } else {
-          final atClientPrefernce = await loadAtClientPreference(
+          final atClientPreference = await loadAtClientPreference(
             util.config.atClientPreference.rootDomain,
           );
           if (!mounted) return null;
@@ -285,7 +287,7 @@ class _OnboardingButtonState extends State<OnboardingButton> {
             routeSettings: const RouteSettings(name: 'APKAM onboarding'),
             builder: (context) => OnboardingApkamDialog(
               atsign: atsign,
-              atClientPreference: atClientPrefernce,
+              atClientPreference: atClientPreference,
             ),
           );
         }

--- a/packages/dart/npt_flutter/lib/features/onboarding/widgets/onboarding_button.dart
+++ b/packages/dart/npt_flutter/lib/features/onboarding/widgets/onboarding_button.dart
@@ -163,10 +163,10 @@ class _OnboardingButtonState extends State<OnboardingButton> {
     if (!mounted) return;
     switch (onboardingResult?.status ?? AtOnboardingResultStatus.cancel) {
       case AtOnboardingResultStatus.success:
+        AtClient atClient = AtClientManager.getInstance().atClient;
         await initializeContactsService(rootDomain: rootDomain);
-        AtClientManager.getInstance().atClient.notificationService;
-        AtClientManager.getInstance().atClient.syncService.addProgressListener(ProfileProgressListener());
-        AtClientManager.getInstance().atClient.syncService.sync();
+        atClient.syncService.addProgressListener(ProfileProgressListener(atClient));
+        atClient.syncService.sync();
         postOnboard(onboardingResult!.atsign!, rootDomain);
         final result = await saveAtsignInformation(
           AtsignInformation(

--- a/packages/dart/npt_flutter/lib/features/profile/repository/profile_repository.dart
+++ b/packages/dart/npt_flutter/lib/features/profile/repository/profile_repository.dart
@@ -8,11 +8,11 @@ import 'package:npt_flutter/util/uuid.dart';
 
 class ProfileRepository {
   final Map<String, Profile> _profileCache = {};
-  final Map<String, String?> _uuidMap = {};
+  final Map<String, String?> _profileSharedByMap = {};
 
   Future<Iterable<String>?> getProfileUuids() async {
     _profileCache.clear();
-    _uuidMap.clear();
+    _profileSharedByMap.clear();
     AtClient atClient = AtClientManager.getInstance().atClient;
 
     String namespace = Constants.namespace ?? '';
@@ -30,13 +30,13 @@ class ProfileRepository {
       if (ix >= 0) {
         final uuid = key.key.substring(0, ix);
         final sharedBy = key.sharedBy;
-        _uuidMap[uuid] = sharedBy;
+        _profileSharedByMap[uuid] = sharedBy;
       }
     }
 
-    App.log('[DEBUG] _uuidMap = $_uuidMap'.loggable);
+    App.log('[DEBUG] _uuidMap = $_profileSharedByMap'.loggable);
 
-    return _uuidMap.keys;
+    return _profileSharedByMap.keys;
   }
 
   Future<Iterable<Profile>> getProfiles(Iterable<String> uuids) {
@@ -52,7 +52,7 @@ class ProfileRepository {
     }
 
     AtClient atClient = AtClientManager.getInstance().atClient;
-    String ? sharedBy = _uuidMap[uuid] ?? atClient.getCurrentAtSign();
+    String ? sharedBy = _profileSharedByMap[uuid] ?? atClient.getCurrentAtSign();
     AtKey key = Uuid(uuid).toProfileAtKey(sharedBy: sharedBy);
     try {
       App.log('[DEBUG] loading profile $key'.loggable);
@@ -83,6 +83,7 @@ class ProfileRepository {
 
   Future<bool> deleteProfile(String uuid) async {
     _profileCache.remove(uuid);
+    _profileSharedByMap.remove(uuid);
     AtClient atClient = AtClientManager.getInstance().atClient;
     String? atSign = atClient.getCurrentAtSign();
     AtKey key = Uuid(uuid).toProfileAtKey(sharedBy: atSign);

--- a/packages/dart/npt_flutter/lib/features/profile/repository/profile_repository.dart
+++ b/packages/dart/npt_flutter/lib/features/profile/repository/profile_repository.dart
@@ -8,8 +8,11 @@ import 'package:npt_flutter/util/uuid.dart';
 
 class ProfileRepository {
   final Map<String, Profile> _profileCache = {};
+  final Map<String, String?> _uuidMap = {};
 
   Future<Iterable<String>?> getProfileUuids() async {
+    _profileCache.clear();
+    _uuidMap.clear();
     AtClient atClient = AtClientManager.getInstance().atClient;
 
     String namespace = Constants.namespace ?? '';
@@ -21,8 +24,19 @@ class ProfileRepository {
       App.log('[ERROR] getProfileUuids failed: $e'.loggable);
       keys = [];
     }
-    return keys.map((key) =>
-        key.key.substring(0, key.key.indexOf('.${Uuid.profilesSubNamespace}')));
+
+    for (final key in keys) {
+      final ix = key.key.indexOf('.${Uuid.profilesSubNamespace}');
+      if (ix >= 0) {
+        final uuid = key.key.substring(0, ix);
+        final sharedBy = key.sharedBy;
+        _uuidMap[uuid] = sharedBy;
+      }
+    }
+
+    App.log('[DEBUG] _uuidMap = $_uuidMap'.loggable);
+
+    return _uuidMap.keys;
   }
 
   Future<Iterable<Profile>> getProfiles(Iterable<String> uuids) {
@@ -38,9 +52,10 @@ class ProfileRepository {
     }
 
     AtClient atClient = AtClientManager.getInstance().atClient;
-    String? atSign = atClient.getCurrentAtSign();
-    AtKey key = Uuid(uuid).toProfileAtKey(sharedBy: atSign);
+    String ? sharedBy = _uuidMap[uuid] ?? atClient.getCurrentAtSign();
+    AtKey key = Uuid(uuid).toProfileAtKey(sharedBy: sharedBy);
     try {
+      App.log('[DEBUG] loading profile $key'.loggable);
       var value = await atClient.get(key);
       var profile = Profile.fromJson(jsonDecode(value.value));
       _profileCache[uuid] = profile;

--- a/packages/dart/npt_flutter/linux/flutter/generated_plugin_registrant.cc
+++ b/packages/dart/npt_flutter/linux/flutter/generated_plugin_registrant.cc
@@ -8,7 +8,6 @@
 
 #include <at_file_saver/file_saver_plugin.h>
 #include <biometric_storage/biometric_storage_plugin.h>
-#include <file_selector_linux/file_selector_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
 #include <tray_manager/tray_manager_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
@@ -21,9 +20,6 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) biometric_storage_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "BiometricStoragePlugin");
   biometric_storage_plugin_register_with_registrar(biometric_storage_registrar);
-  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
-  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
   g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
   screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);

--- a/packages/dart/npt_flutter/linux/flutter/generated_plugins.cmake
+++ b/packages/dart/npt_flutter/linux/flutter/generated_plugins.cmake
@@ -5,7 +5,6 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   at_file_saver
   biometric_storage
-  file_selector_linux
   screen_retriever_linux
   tray_manager
   url_launcher_linux

--- a/packages/dart/npt_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/dart/npt_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,7 +8,7 @@ import Foundation
 import at_file_saver
 import biometric_storage
 import device_info_plus
-import file_selector_macos
+import file_picker
 import package_info_plus
 import path_provider_foundation
 import screen_retriever_macos
@@ -23,7 +23,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSaverPlugin.register(with: registry.registrar(forPlugin: "FileSaverPlugin"))
   BiometricStorageMacOSPlugin.register(with: registry.registrar(forPlugin: "BiometricStorageMacOSPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
-  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
+  FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
@@ -31,6 +31,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   TrayManagerPlugin.register(with: registry.registrar(forPlugin: "TrayManagerPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
-  FLTWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "FLTWebViewFlutterPlugin"))
+  WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/packages/dart/npt_flutter/macos/Podfile.lock
+++ b/packages/dart/npt_flutter/macos/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
     - FlutterMacOS
   - device_info_plus (0.0.1):
     - FlutterMacOS
-  - file_selector_macos (0.0.1):
+  - file_picker (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
   - package_info_plus (0.0.1):
@@ -34,7 +34,7 @@ DEPENDENCIES:
   - at_file_saver (from `Flutter/ephemeral/.symlinks/plugins/at_file_saver/macos`)
   - biometric_storage (from `Flutter/ephemeral/.symlinks/plugins/biometric_storage/macos`)
   - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
-  - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
+  - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
@@ -53,8 +53,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/biometric_storage/macos
   device_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos
-  file_selector_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
+  file_picker:
+    :path: Flutter/ephemeral/.symlinks/plugins/file_picker/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
   package_info_plus:
@@ -80,7 +80,7 @@ SPEC CHECKSUMS:
   at_file_saver: 598610e2f4579e4193faa1187fd4f87ffbfc3a0f
   biometric_storage: 9de0cb4e591e52329ca0da7df42e964db6c526cf
   device_info_plus: a56e6e74dbbd2bb92f2da12c64ddd4f67a749041
-  file_selector_macos: 6280b52b459ae6c590af5d78fc35c7267a3c4b31
+  file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   package_info_plus: f0052d280d17aa382b932f399edf32507174e870
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
@@ -89,7 +89,7 @@ SPEC CHECKSUMS:
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   tray_manager: a104b5c81b578d83f3c3d0f40a997c8b10810166
   url_launcher_macos: 0fba8ddabfc33ce0a9afe7c5fef5aab3d8d2d673
-  webview_flutter_wkwebview: 44d4dee7d7056d5ad185d25b38404436d56c547c
+  webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2
   window_manager: 1d01fa7ac65a6e6f83b965471b1a7fdd3f06166c
 
 PODFILE CHECKSUM: 236401fc2c932af29a9fcf0e97baeeb2d750d367

--- a/packages/dart/npt_flutter/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/dart/npt_flutter/macos/Runner.xcodeproj/project.pbxproj
@@ -542,7 +542,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -572,10 +572,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = "1.1.6+8";
-				DEVELOPMENT_TEAM = Z2L888C4VZ;
+				DEVELOPMENT_TEAM = 5XUSS6C2DF;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Noports Desktop";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
@@ -626,7 +626,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -682,7 +682,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -712,10 +712,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = "1.1.6+8";
-				DEVELOPMENT_TEAM = Z2L888C4VZ;
+				DEVELOPMENT_TEAM = 5XUSS6C2DF;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Noports Desktop";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
@@ -740,10 +740,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = "1.1.6+8";
-				DEVELOPMENT_TEAM = Z2L888C4VZ;
+				DEVELOPMENT_TEAM = 5XUSS6C2DF;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Noports Desktop";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";

--- a/packages/dart/npt_flutter/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/dart/npt_flutter/macos/Runner.xcodeproj/project.pbxproj
@@ -542,7 +542,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -572,10 +572,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = "1.1.6+8";
-				DEVELOPMENT_TEAM = 5XUSS6C2DF;
+				DEVELOPMENT_TEAM = Z2L888C4VZ;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Noports Desktop";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
@@ -626,7 +626,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -682,7 +682,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -712,10 +712,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = "1.1.6+8";
-				DEVELOPMENT_TEAM = 5XUSS6C2DF;
+				DEVELOPMENT_TEAM = Z2L888C4VZ;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Noports Desktop";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
@@ -740,10 +740,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = "1.1.6+8";
-				DEVELOPMENT_TEAM = 5XUSS6C2DF;
+				DEVELOPMENT_TEAM = Z2L888C4VZ;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Noports Desktop";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";

--- a/packages/dart/npt_flutter/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/dart/npt_flutter/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -59,6 +59,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -5,15 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "88399e291da5f7e889359681a8f64b18c5123e03576b01f32a6a276611e511c3"
+      sha256: dc27559385e905ad30838356c5f5d574014ba39872d732111cd07ac0beff4c57
       url: "https://pub.dev"
     source: hosted
-    version: "78.0.0"
-  _macros:
-    dependency: transitive
-    description: dart
-    source: sdk
-    version: "0.3.3"
+    version: "80.0.0"
   adaptive_theme:
     dependency: "direct main"
     description:
@@ -26,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "62899ef43d0b962b056ed2ebac6b47ec76ffd003d5f7c4e4dc870afe63188e33"
+      sha256: "192d1c5b944e7e53b24b5586db760db934b177d4147c42fbca8c8c5f1eb8d11e"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.3.0"
   archive:
     dependency: transitive
     description:
@@ -51,18 +46,18 @@ packages:
     dependency: transitive
     description:
       name: asn1lib
-      sha256: "4bae5ae63e6d6dd17c4aac8086f3dec26c0236f6a0f03416c6c19d830c367cf5"
+      sha256: "1c296cd268f486cabcc3930e9b93a8133169305f18d722916e675959a88f6d2c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.8"
+    version: "1.5.9"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   at_auth:
     dependency: "direct main"
     description:
@@ -75,10 +70,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_backupkey_flutter
-      sha256: "674d5ebf8443e0848c86cd14e25c326e33d7fef54a2a9732c4328a138f6c4fa5"
+      sha256: "8d3ab03e29a7cdeac3e661b2ade4aced4570ac753b159157eed5f5c859f0c4fd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.16"
+    version: "4.0.17"
   at_base2e15:
     dependency: transitive
     description:
@@ -95,6 +90,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  at_cli_commons:
+    dependency: "direct main"
+    description:
+      name: at_cli_commons
+      sha256: "1683ec641d307cdcbbdae95b1296338c42c976261588fb3204b39db0ab493018"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   at_client:
     dependency: transitive
     description:
@@ -124,10 +127,10 @@ packages:
     dependency: transitive
     description:
       name: at_commons
-      sha256: "6e0a53c26726e05727a2cfbb6d0062fb67205225fbe061315bfe0f187128e5bd"
+      sha256: "3380ff0e066c43f0efd008568664d9fce0817ebc69d8fa216b3abe7a3eeb6127"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.2"
+    version: "5.2.0"
   at_contact:
     dependency: "direct main"
     description:
@@ -168,6 +171,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.49"
+  at_onboarding_cli:
+    dependency: transitive
+    description:
+      name: at_onboarding_cli
+      sha256: "67d6def85ae2ac57511e40558cabf81b984fe08e2098a303fe5fbc749fe85a27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.8.2"
   at_onboarding_flutter:
     dependency: "direct main"
     description:
@@ -245,10 +256,10 @@ packages:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   build:
     dependency: transitive
     description:
@@ -269,26 +280,26 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "294a2edaf4814a378725bfe6358210196f5ea37af89ecd81bfa32960113d4948"
+      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.3"
+    version: "4.0.4"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "99d3980049739a985cf9b21f30881f46db3ebc62c5b8d5e60e27440876b1ba1e"
+      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
+    version: "2.4.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "74691599a5bc750dc96a6b4bfd48f7d9d66453eab04c7f4063134800d6a5c573"
+      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.14"
+    version: "2.4.15"
   build_runner_core:
     dependency: transitive
     description:
@@ -309,26 +320,26 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "28a712df2576b63c6c005c465989a348604960c0958d28be5303ba9baa841ac2"
+      sha256: "8b158ab94ec6913e480dc3f752418348b5ae099eb75868b5f4775f0572999c61"
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.3"
+    version: "8.9.4"
   chalkdart:
     dependency: transitive
     description:
       name: chalkdart
-      sha256: "0b7ec5c6a6bafd1445500632c00c573722bd7736e491675d4ac3fe560bbd9cfe"
+      sha256: "08c910ee341fcdd1e46f20ddce59b13c1d85f5d97f2fd2f12014c46ede670e40"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.3.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   charcode:
     dependency: transitive
     description:
@@ -357,10 +368,10 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   code_builder:
     dependency: transitive
     description:
@@ -373,10 +384,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   console:
     dependency: transitive
     description:
@@ -526,18 +537,18 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   file:
     dependency: transitive
     description:
@@ -550,74 +561,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: c904b4ab56d53385563c7c39d8e9fa9af086f91495dfc48717ad84a42c3cf204
+      sha256: ab13ae8ef5580a411c458d6207b6774a6c237d77ac37011b13994879f68a8810
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.7"
-  file_selector:
-    dependency: transitive
-    description:
-      name: file_selector
-      sha256: "5019692b593455127794d5718304ff1ae15447dea286cdda9f0db2a796a1b828"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.3"
-  file_selector_android:
-    dependency: transitive
-    description:
-      name: file_selector_android
-      sha256: "98ac58e878b05ea2fdb204e7f4fc4978d90406c9881874f901428e01d3b18fbc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.1+12"
-  file_selector_ios:
-    dependency: transitive
-    description:
-      name: file_selector_ios
-      sha256: "94b98ad950b8d40d96fee8fa88640c2e4bd8afcdd4817993bd04e20310f45420"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.3+1"
-  file_selector_linux:
-    dependency: transitive
-    description:
-      name: file_selector_linux
-      sha256: "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.3+2"
-  file_selector_macos:
-    dependency: transitive
-    description:
-      name: file_selector_macos
-      sha256: "271ab9986df0c135d45c3cdb6bd0faa5db6f4976d3e4b437cf7d0f258d941bfc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.4+2"
-  file_selector_platform_interface:
-    dependency: transitive
-    description:
-      name: file_selector_platform_interface
-      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.6.2"
-  file_selector_web:
-    dependency: transitive
-    description:
-      name: file_selector_web
-      sha256: c4c0ea4224d97a60a7067eca0c8fd419e708ff830e0c83b11a48faf566cec3e7
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.4+2"
-  file_selector_windows:
-    dependency: transitive
-    description:
-      name: file_selector_windows
-      sha256: "8f5d2f6590d51ecd9179ba39c64f722edc15226cc93dcc8698466ad36a4a85a4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.3+3"
+    version: "8.3.7"
   fixnum:
     dependency: transitive
     description:
@@ -659,10 +606,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_launcher_icons
-      sha256: "31cd0885738e87c72d6f055564d37fabcdacee743b396b78c7636c169cac64f5"
+      sha256: bfa04787c85d80ecb3f8777bde5fc10c3de809240c48fa061a2c2bf15ea5211c
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.2"
+    version: "0.14.3"
   flutter_lints:
     dependency: "direct overridden"
     description:
@@ -680,10 +627,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "615a505aef59b151b46bbeef55b36ce2b6ed299d160c51d84281946f0aa0ce0e"
+      sha256: "1f74d9bd071bd8ab661faf38f6c57028a953b182703cac4b60821b9b2af583e9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.24"
+    version: "2.0.25"
   flutter_slidable:
     dependency: transitive
     description:
@@ -696,10 +643,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: "54900a1a1243f3c4a5506d853a2b5c2dbc38d5f27e52a52618a8054401431123"
+      sha256: c200fd79c918a40c5cd50ea0877fa13f81bdaf6f0a5d3dbcc2a13e3285d6aa1b
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.16"
+    version: "2.0.17"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -730,10 +677,10 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   graphs:
     dependency: transitive
     description:
@@ -754,10 +701,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.3.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -826,26 +773,26 @@ packages:
     dependency: "direct main"
     description:
       name: json_serializable
-      sha256: "8f52361c07497a7f2c16c13aac159f9be6fb12b1d67719eac98a21d9a205d571"
+      sha256: "81f04dee10969f89f604e1249382d46b97a1ccad53872875369622b5bfc9e58a"
       url: "https://pub.dev"
     source: hosted
-    version: "6.9.2"
+    version: "6.9.4"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -870,22 +817,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
-  macros:
-    dependency: transitive
-    description:
-      name: macros
-      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -977,26 +916,26 @@ packages:
     dependency: transitive
     description:
       name: package_info_plus
-      sha256: "70c421fe9d9cc1a9a7f3b05ae56befd469fe4f8daa3b484823141a55442d858d"
+      sha256: "7976bfe4c583170d6cdc7077e3237560b364149fcd268b5f53d95a991963b191"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.2"
+    version: "8.3.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: a5ef9986efc7bf772f2696183a3992615baa76c1ffb1189318dd8803778fb05b
+      sha256: "6c935fb612dff8e3cc9632c2b301720c77450a126114126ffaafe28d2e87956c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.2.0"
   path:
     dependency: "direct main"
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_parsing:
     dependency: transitive
     description:
@@ -1057,26 +996,26 @@ packages:
     dependency: transitive
     description:
       name: permission_handler
-      sha256: "18bf33f7fefbd812f37e72091a15575e72d5318854877e0e4035a24ac1113ecb"
+      sha256: "59adad729136f01ea9e35a48f5d1395e25cba6cea552249ddbe9cf950f5d7849"
       url: "https://pub.dev"
     source: hosted
-    version: "11.3.1"
+    version: "11.4.0"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: "71bbecfee799e65aff7c744761a57e817e73b738fedf62ab7afd5593da21f9f1"
+      sha256: d3971dcdd76182a0c198c096b5db2f0884b0d4196723d21a866fc4cdea057ebc
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.13"
+    version: "12.1.0"
   permission_handler_apple:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: e6f6d73b12438ef13e648c4ae56bd106ec60d17e90a59c4545db6781229082a0
+      sha256: f84a188e79a35c687c132a0a0556c254747a08561e99ab933f12f6ca71ef3c98
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.5"
+    version: "9.4.6"
   permission_handler_html:
     dependency: transitive
     description:
@@ -1089,10 +1028,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
-      sha256: e9c8eadee926c4532d0305dff94b85bf961f16759c3af791486613152af4b4f9
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.3"
+    version: "4.3.0"
   permission_handler_windows:
     dependency: transitive
     description:
@@ -1105,10 +1044,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
+      sha256: "07c8f0b1913bcde1ff0d26e57ace2f3012ccbf2b204e070290dad3bb22797646"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "6.1.0"
   phosphor_flutter:
     dependency: "direct main"
     description:
@@ -1257,10 +1196,10 @@ packages:
     dependency: transitive
     description:
       name: share_plus
-      sha256: "6327c3f233729374d0abaafd61f6846115b2a481b4feddd8534211dc10659400"
+      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.3"
+    version: "10.1.4"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -1273,18 +1212,18 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences
-      sha256: a752ce92ea7540fc35a0d19722816e04d0e72828a4200e83a98cf1a1eb524c9a
+      sha256: "846849e3e9b68f3ef4b60c60cf4b3e02e9321bc7f4d8c4692cf87ffa82fc8a3a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.5"
+    version: "2.5.2"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "02a7d8a9ef346c9af715811b01fbd8e27845ad2c41148eefd31321471b41863d"
+      sha256: a768fc8ede5f0c8e6150476e14f38e2417c0864ca36bb4582be8e21925a03c22
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.6"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -1313,10 +1252,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: d2ca4132d3946fec2184261726b355836a82c33d7d5b67af32692aff18a4684e
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   shared_preferences_windows:
     dependency: transitive
     description:
@@ -1337,10 +1276,10 @@ packages:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.0"
   shortid:
     dependency: transitive
     description:
@@ -1390,26 +1329,26 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:
@@ -1422,26 +1361,26 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.4"
   timing:
     dependency: transitive
     description:
@@ -1470,10 +1409,10 @@ packages:
     dependency: transitive
     description:
       name: tutorial_coach_mark
-      sha256: df450c88d4c812bc221afd3ff948da3dc0f44c0b4fa5dbc046d6d86f2cfc9e71
+      sha256: "2c77c0b00bbe7d5b8a6d31cb9e03d44bf77dfe7ba6514cc2b546886d024a9945"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.12"
+    version: "1.2.13"
   typed_data:
     dependency: transitive
     description:
@@ -1534,18 +1473,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "772638d3b34c779ede05ba3d38af34657a05ac55b06279ea6edd409e323dca8e"
+      sha256: "3ba963161bd0fe395917ba881d320b9c4f6dd3c4a233da62ab18a5025c85f1e9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.4.0"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "44cf3aabcedde30f2dba119a9dea3b0f2672fbe6fa96e85536251d678216b3c4"
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.4"
   uuid:
     dependency: "direct main"
     description:
@@ -1558,10 +1497,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: "27d5fefe86fb9aace4a9f8375b56b3c292b64d8c04510df230f849850d912cb7"
+      sha256: "44cc7104ff32563122a929e4620cf3efd584194eec6d1d913eb5ba593dbcf6de"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.15"
+    version: "1.1.18"
   vector_graphics_codec:
     dependency: transitive
     description:
@@ -1606,10 +1545,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.0"
+    version: "14.3.1"
   watcher:
     dependency: transitive
     description:
@@ -1622,10 +1561,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   web_socket:
     dependency: transitive
     description:
@@ -1638,10 +1577,10 @@ packages:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "9f187088ed104edd8662ca07af4b124465893caf063ba29758f97af57e61da8f"
+      sha256: "0b8e2457400d8a859b7b2030786835a28a8e80836ef64402abef392ff4f1d0e5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   webview_flutter:
     dependency: transitive
     description:
@@ -1654,10 +1593,10 @@ packages:
     dependency: transitive
     description:
       name: webview_flutter_android
-      sha256: "3d535126f7244871542b2f0b0fcf94629c9a14883250461f9abe1a6644c1c379"
+      sha256: "512c26ccc5b8a571fd5d13ec994b7509f142ff6faf85835e243dde3538fdc713"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "4.3.2"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
@@ -1670,18 +1609,18 @@ packages:
     dependency: transitive
     description:
       name: webview_flutter_wkwebview
-      sha256: b7e92f129482460951d96ef9a46b49db34bd2e1621685de26e9eaafd9674e7eb
+      sha256: d183aa3d0fbc1f4d0715ce06c5a44cad636598c3340ae8d359fbc61b4016fb60
       url: "https://pub.dev"
     source: hosted
-    version: "3.16.3"
+    version: "3.18.3"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: "154360849a56b7b67331c21f09a386562d88903f90a1099c5987afc1912e1f29"
+      sha256: b89e6e24d1454e149ab20fbb225af58660f0c0bf4475544650700d8e2da54aef
       url: "https://pub.dev"
     source: hosted
-    version: "5.10.0"
+    version: "5.11.0"
   win32_registry:
     dependency: transitive
     description:
@@ -1726,10 +1665,10 @@ packages:
     dependency: "direct main"
     description:
       name: yaml_writer
-      sha256: "2ae2cd5f5a612a930ef2b1b40df540c819ab85e301f26dfaf0b6201b857db825"
+      sha256: "69651cd7238411179ac32079937d4aa9a2970150d6b2ae2c6fe6de09402a5dc5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   zxing2:
     dependency: transitive
     description:
@@ -1739,5 +1678,5 @@ packages:
     source: hosted
     version: "0.2.3"
 sdks:
-  dart: ">=3.6.0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.27.0"

--- a/packages/dart/npt_flutter/pubspec.yaml
+++ b/packages/dart/npt_flutter/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
       url: https://github.com/atsign-foundation/at_client_sdk.git
       path: packages/at_client_mobile
       ref: 8e8b68d2f00db0aeca266685be1e9c0b103ad301
+  at_cli_commons: ^1.3.0
   at_contact: ^3.0.8
   at_contacts_flutter: ^4.0.15
   at_onboarding_flutter:

--- a/packages/dart/npt_flutter/windows/flutter/generated_plugin_registrant.cc
+++ b/packages/dart/npt_flutter/windows/flutter/generated_plugin_registrant.cc
@@ -7,7 +7,6 @@
 #include "generated_plugin_registrant.h"
 
 #include <at_file_saver/file_saver_plugin.h>
-#include <file_selector_windows/file_selector_windows.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
@@ -18,8 +17,6 @@
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FileSaverPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSaverPlugin"));
-  FileSelectorWindowsRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("FileSelectorWindows"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(

--- a/packages/dart/npt_flutter/windows/flutter/generated_plugins.cmake
+++ b/packages/dart/npt_flutter/windows/flutter/generated_plugins.cmake
@@ -4,7 +4,6 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   at_file_saver
-  file_selector_windows
   permission_handler_windows
   screen_retriever_windows
   share_plus

--- a/packages/dart/sshnoports/bin/npp_push.dart
+++ b/packages/dart/sshnoports/bin/npp_push.dart
@@ -1,0 +1,54 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:at_client/at_client.dart';
+import 'package:uuid/uuid.dart' as u;
+import 'package:sshnoports/src/profile.dart';
+
+import 'package:at_cli_commons/at_cli_commons.dart' as cli;
+
+main(List<String> args) async {
+  String myAtsign = '@baboonblue18';
+  String userAtsign = '@garycasey';
+  cli.CLIBase cliBase = cli.CLIBase(
+      atSign: myAtsign,
+      homeDir: cli.getHomeDirectory(),
+      nameSpace: 'noports',
+      rootDomain: 'root.atsign.org',
+      verbose: true,
+      syncDisabled: true);
+
+  await cliBase.init();
+
+  Profile profile = Profile(
+    u.Uuid().v4(),
+    displayName: args[0],
+    sshnpdAtsign: '@asparagussquare',
+    deviceName: 'some_device',
+    relayAtsign: '@stream',
+    remotePort: 8080,
+    localPort: 0,
+  );
+
+  var profileKey = AtKey.fromString('$userAtsign'
+      ':'
+      '${profile.uuid}.profiles.noports'
+      '$myAtsign');
+  profileKey.metadata.ttr = -1; // cache indefinitely
+  profileKey.metadata.ttl = 30000;
+
+  print(profileKey);
+  print(jsonEncode(profile.toJson()));
+
+  print ('$myAtsign is CREATING $profileKey');
+  await cliBase.atClient.put(profileKey, jsonEncode(profile.toJson()),
+      putRequestOptions: PutRequestOptions()..useRemoteAtServer = true);
+
+  print('\nWaiting for 20 seconds');
+  await Future.delayed(Duration(seconds: 25));
+
+  print ('$myAtsign is DELETING $profileKey');
+  await cliBase.atClient.delete(profileKey,
+      deleteRequestOptions: DeleteRequestOptions()..useRemoteAtServer = true);
+
+  exit(0);
+}

--- a/packages/dart/sshnoports/bin/npp_push.dart
+++ b/packages/dart/sshnoports/bin/npp_push.dart
@@ -34,7 +34,7 @@ main(List<String> args) async {
       '${profile.uuid}.profiles.noports'
       '$myAtsign');
   profileKey.metadata.ttr = -1; // cache indefinitely
-  profileKey.metadata.ttl = 30000;
+  profileKey.metadata.ttl = 60 * 60 * 1000; // 1 hour
 
   print(profileKey);
   print(jsonEncode(profile.toJson()));
@@ -44,7 +44,7 @@ main(List<String> args) async {
       putRequestOptions: PutRequestOptions()..useRemoteAtServer = true);
 
   print('\nWaiting for 20 seconds');
-  await Future.delayed(Duration(seconds: 25));
+  await Future.delayed(Duration(seconds: 20));
 
   print ('$myAtsign is DELETING $profileKey');
   await cliBase.atClient.delete(profileKey,

--- a/packages/dart/sshnoports/lib/src/profile.dart
+++ b/packages/dart/sshnoports/lib/src/profile.dart
@@ -1,0 +1,37 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'profile.g.dart';
+
+@JsonSerializable()
+final class Profile {
+  final String uuid;
+  final String displayName;
+  final String? relayAtsign;
+  final String sshnpdAtsign;
+  final String deviceName;
+  final String remoteHost;
+  final int remotePort;
+  final int localPort;
+
+  const Profile(
+    this.uuid, {
+    required this.displayName,
+    this.relayAtsign,
+    required this.sshnpdAtsign,
+    required this.deviceName,
+    this.remoteHost = 'localhost',
+    required this.remotePort,
+    required this.localPort,
+  });
+
+  Map<String, dynamic> toJson() => _$ProfileToJson(this);
+
+  factory Profile.fromJson(Map<String, dynamic> json) =>
+      _$ProfileFromJson(json);
+
+  @override
+  String toString() {
+    return 'Profile(displayName: $displayName, sshnpd: $sshnpdAtsign, '
+        'deviceName: $deviceName, relayAtsign: $relayAtsign, uuid: $uuid)';
+  }
+}

--- a/packages/dart/sshnoports/lib/src/profile.g.dart
+++ b/packages/dart/sshnoports/lib/src/profile.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'profile.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Profile _$ProfileFromJson(Map<String, dynamic> json) => Profile(
+  json['uuid'] as String? ?? '',
+  displayName: json['displayName'] as String,
+  relayAtsign: json['relayAtsign'] as String?,
+  sshnpdAtsign: json['sshnpdAtsign'] as String,
+  deviceName: json['deviceName'] as String,
+  remoteHost: json['remoteHost'] as String? ?? 'localhost',
+  remotePort: (json['remotePort'] as num).toInt(),
+  localPort: (json['localPort'] as num).toInt(),
+);
+
+Map<String, dynamic> _$ProfileToJson(Profile instance) => <String, dynamic>{
+  'displayName': instance.displayName,
+  'relayAtsign': instance.relayAtsign,
+  'sshnpdAtsign': instance.sshnpdAtsign,
+  'deviceName': instance.deviceName,
+  'remoteHost': instance.remoteHost,
+  'remotePort': instance.remotePort,
+  'localPort': instance.localPort,
+};

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -5,23 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "88399e291da5f7e889359681a8f64b18c5123e03576b01f32a6a276611e511c3"
+      sha256: dc27559385e905ad30838356c5f5d574014ba39872d732111cd07ac0beff4c57
       url: "https://pub.dev"
     source: hosted
-    version: "78.0.0"
-  _macros:
-    dependency: transitive
-    description: dart
-    source: sdk
-    version: "0.3.3"
+    version: "80.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "62899ef43d0b962b056ed2ebac6b47ec76ffd003d5f7c4e4dc870afe63188e33"
+      sha256: "192d1c5b944e7e53b24b5586db760db934b177d4147c42fbca8c8c5f1eb8d11e"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.3.0"
   archive:
     dependency: transitive
     description:
@@ -43,18 +38,18 @@ packages:
     dependency: transitive
     description:
       name: asn1lib
-      sha256: "4bae5ae63e6d6dd17c4aac8086f3dec26c0236f6a0f03416c6c19d830c367cf5"
+      sha256: "1c296cd268f486cabcc3930e9b93a8133169305f18d722916e675959a88f6d2c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.8"
+    version: "1.5.9"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   at_auth:
     dependency: transitive
     description:
@@ -99,10 +94,10 @@ packages:
     dependency: transitive
     description:
       name: at_commons
-      sha256: "6e0a53c26726e05727a2cfbb6d0062fb67205225fbe061315bfe0f187128e5bd"
+      sha256: "3380ff0e066c43f0efd008568664d9fce0817ebc69d8fa216b3abe7a3eeb6127"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.2"
+    version: "5.2.0"
   at_demo_data:
     dependency: transitive
     description:
@@ -195,10 +190,10 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "294a2edaf4814a378725bfe6358210196f5ea37af89ecd81bfa32960113d4948"
+      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.3"
+    version: "4.0.4"
   build_resolvers:
     dependency: transitive
     description:
@@ -243,10 +238,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "28a712df2576b63c6c005c465989a348604960c0958d28be5303ba9baa841ac2"
+      sha256: "8b158ab94ec6913e480dc3f752418348b5ae099eb75868b5f4775f0572999c61"
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.3"
+    version: "8.9.4"
   chalkdart:
     dependency: "direct main"
     description:
@@ -404,10 +399,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   file:
     dependency: transitive
     description:
@@ -436,10 +431,10 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   graphs:
     dependency: transitive
     description:
@@ -460,10 +455,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.3.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -536,14 +531,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
-  macros:
-    dependency: transitive
-    description:
-      name: macros
-      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
@@ -731,10 +718,10 @@ packages:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.0"
   socket_connector:
     dependency: "direct main"
     description:
@@ -883,10 +870,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   web_socket:
     dependency: transitive
     description:
@@ -899,10 +886,10 @@ packages:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "9f187088ed104edd8662ca07af4b124465893caf063ba29758f97af57e61da8f"
+      sha256: "0b8e2457400d8a859b7b2030786835a28a8e80836ef64402abef392ff4f1d0e5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -936,4 +923,4 @@ packages:
     source: hosted
     version: "0.2.3"
 sdks:
-  dart: ">=3.6.0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"


### PR DESCRIPTION
Closes #1777 

Currently end-users have to fully manage all of their profiles. We want to enable policy owners / administrators to have their policy management atSign “push” profiles to their end-users so that those profiles are visible and available for use (or removed, and unavailable for use) in near-real-time.

This PR currently only contains an initial spike. It illustrates the basic functionality but has the following limitations:
(1) It would permit 'spam' - i.e. any atSign could push profiles to any user
(2) It does not allow the end-user to remove or update these managed profiles as they wish, while still allowing for profiles to be deleted via the policy management atSign sending a deleteProfile event

Ongoing design discussion is [here](https://docs.google.com/document/d/1ttiI9me_K1t3f6leNtxzvWUjPFEaHolWfWTHU0Nb2S8/edit?tab=t.0)

**- What I did**
- Modified the app so it dynamically updates its profiles list as another atSign shares / un-shares a profile
- Created a very basic programme (`npp_push`) with hard-coded values to share and then un-share a profile

**- How I did it**
- See commits, and comments on the `Files Changed` tab

**- How to verify it**
- Run the desktop app from this branch
- Modify `packages/sshnoports/bin/npp_push.dart` changing atSigns etc, then execute `dart bin/npp_push.dart <profile name>`