### PR TITLE
build(deps): Bump at_c ref to b542e8

### DIFF
--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -3,7 +3,7 @@ if(NOT atsdk_FOUND)
   FetchContent_Declare(
     atsdk
     GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-    GIT_TAG 21139ae13a48c4b13c09d948a7212b60740312a2
+    GIT_TAG b542e87d0d90f387b326555f65527752e229e821
   )
   FetchContent_MakeAvailable(atsdk)
   install(


### PR DESCRIPTION
Take up changes in at_c from https://github.com/atsign-foundation/at_c/pull/571 and https://github.com/atsign-foundation/at_c/pull/572

**- What I did**

Bumped git ref

**- How to verify it**

I'll do a 1.0.3 release and test builds for OpenWrt

**- Description for the changelog**

build(deps): Bump at_c ref to b542e8
