### PR TITLE
fix: use cpack for c_release source tarballs

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -159,10 +159,11 @@ jobs:
         working-directory: ./packages/c
         run: |
           cmake --workflow --preset package-source
+          mv build/release-static/noports-source.tar.gz ../../tarball/csshnpd-${{ github.ref_name }}.tar.gz
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: csshnpd-src-${{github.ref_name}}-${{github.run_number}}-${{github.run_attempt}}
-          path: ./packages/c/build/release-static/noports-source.tar.gz
+          path: ./tarball/csshnpd-${{ github.ref_name }}.tar.gz
 
   github-release:
     if: startsWith(github.ref, 'refs/tags/c')

--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -159,11 +159,10 @@ jobs:
         working-directory: ./packages/c
         run: |
           cmake --workflow --preset package-source
-          mv build/release-static/noports-source.tar.gz ../../tarball/csshnpd-${{ github.ref_name }}.tar.gz
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: csshnpd-src-${{github.ref_name}}-${{github.run_number}}-${{github.run_attempt}}
-          path: ./tarball/csshnpd-${{ github.ref_name }}.tar.gz
+          path: ./packages/c/build/release-static/noports-source.tar.gz
 
   github-release:
     if: startsWith(github.ref, 'refs/tags/c')

--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -79,13 +79,11 @@ jobs:
           mv build/at_activate .
       - if: ${{ matrix.os == 'macOS-13' || matrix.os == 'macos-14'}}
         name: Zip the build
-        run:
-          zip tarball/${{ matrix.output-name }}.zip sshnpd at_activate
+        run: zip tarball/${{ matrix.output-name }}.zip sshnpd at_activate
       - name: Upload archives
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name:
-            ${{ matrix.output-name }}_${{ matrix.compiler
+          name: ${{ matrix.output-name }}_${{ matrix.compiler
             }}-${{  github.ref_name
             }}-${{github.run_number}}-${{github.run_attempt}}
           path: ./packages/c/sshnpd/tarball
@@ -144,8 +142,7 @@ jobs:
       - name: Upload tarballs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name:
-            ${{
+          name: ${{
             matrix.output-name  }}-${{  github.ref_name  }}-${{  github.run_number
             }}-${{  github.run_attempt  }}
           path: ./packages/c/tarballs/${{ matrix.output-name }}.tgz
@@ -159,15 +156,13 @@ jobs:
         with:
           ref: c_release-${{github.run_number}}
       - name: Create tarball
+        working-directory: ./packages/c
         run: |
-          mkdir tarball
-          cd ./packages
-          mv c csshnpd-${{ github.ref_name }}
-          tar -cvzf ../tarball/csshnpd-${{ github.ref_name }}.tar.gz csshnpd-${{ github.ref_name }}
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+          cmake --workflow --preset package-source
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: csshnpd-src-${{github.ref_name}}-${{github.run_number}}-${{github.run_attempt}}
-          path: ./tarball/csshnpd-${{ github.ref_name }}.tar.gz
+          path: ./packages/c/build/release-static/noports-source.tar.gz
 
   github-release:
     if: startsWith(github.ref, 'refs/tags/c')

--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -162,7 +162,7 @@ jobs:
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: csshnpd-src-${{github.ref_name}}-${{github.run_number}}-${{github.run_attempt}}
-          path: ./packages/c/build/release-static/noports-source.tar.gz
+          path: ./packages/c/build/release-static/csshnpd-${{ github.ref_name }}.tar.gz
 
   github-release:
     if: startsWith(github.ref, 'refs/tags/c')

--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -159,7 +159,7 @@ jobs:
         working-directory: ./packages/c
         run: |
           cmake --workflow --preset package-source
-      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: csshnpd-src-${{github.ref_name}}-${{github.run_number}}-${{github.run_attempt}}
           path: ./packages/c/build/release-static/noports-source.tar.gz

--- a/packages/c/.gitignore
+++ b/packages/c/.gitignore
@@ -5,7 +5,6 @@ compile_commands.json
 
 just.env
 
-valgrind-sshnpd-*
-*.log
+/logs/
 core
 Testing/

--- a/packages/c/CMakeLists.txt
+++ b/packages/c/CMakeLists.txt
@@ -8,7 +8,7 @@ set(ATSDK_MBEDTLS_PATH ${NOPORTS_MBEDTLS_PATH})
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(noports VERSION 1.0.3 LANGUAGES C)
+project(noports VERSION 1.0.4 LANGUAGES C)
 
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/CPackSetup.cmake")
 

--- a/packages/c/CMakeLists.txt
+++ b/packages/c/CMakeLists.txt
@@ -1,6 +1,19 @@
+option(NOPORTS_ATSDK_PATH "Local atsdk path" OFF)
+option(NOPORTS_CJSON_PATH "Local cJSON path" OFF)
+option(NOPORTS_MBEDTLS_PATH "Local mbedtls path" OFF)
+option(NOPORTS_GS_TOOL "Include graceful-shutdown-tool" OFF)
+set(ATSDK_CJSON_PATH ${NOPORTS_CJSON_PATH})
+set(ATSDK_MBEDTLS_PATH ${NOPORTS_MBEDTLS_PATH})
+
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(csshnpd VERSION 1.0.3 LANGUAGES C)
+project(noports VERSION 1.0.3 LANGUAGES C)
+
+include("${CMAKE_CURRENT_LIST_DIR}/cmake/CPackSetup.cmake")
+
 add_subdirectory(sshnpd)
-add_subdirectory(graceful-shutdown-tool)
+
+if(NOPORTS_GS_TOOL)
+  add_subdirectory(graceful-shutdown-tool)
+endif()

--- a/packages/c/CMakePresets.json
+++ b/packages/c/CMakePresets.json
@@ -79,6 +79,45 @@
         "NOPORTS_MBEDTLS_PATH": "deps/mbedtls-src",
         "NOPORTS_CJSON_PATH": "deps/cjson-src",
         "NOPORTS_ATSDK_PATH": "deps/atsdk-src"
+        "BUILD_SHARED_LIBS": "OFF",
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_C_FLAGS": "-std=c99 -Wno-error -Wextra -Werror-implicit-function-declaration -Wno-calloc-transposed-args",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/release-static/tmp-install-dir",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "OFF",
+        "ATSDK_BUILD_TESTS": "OFF",
+        "ATSDK_MEMCHECK": "OFF",
+        "ENABLE_TESTING": "OFF",
+        "ENABLE_PROGRAMS": "OFF",
+        "ENABLE_CJSON_TEST": "OFF",
+        "CJSON_OVERRIDE_BUILD_SHARED_LIBS": "ON",
+        "CJSON_BUILD_SHARED_LIBS": "OFF",
+        "BUILD_SHARED_AND_STATIC_LIBS": "OFF",
+        "ENABLE_TARGET_EXPORT": "OFF",
+        "ENABLE_CJSON_VERSION_SO": "OFF"
+      }
+    },
+    {
+      "name": "openwrt",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "NOPORTS_MBEDTLS_PATH": "deps/mbedtls-src",
+        "NOPORTS_CJSON_PATH": "deps/cjson-src",
+        "NOPORTS_ATSDK_PATH": "deps/atsdk-src"
+        "BUILD_SHARED_LIBS": "OFF",
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_C_FLAGS": "-std=c99 -Wno-error -Wextra -Werror-implicit-function-declaration -fPIC -fhonour-copts -Wno-calloc-transposed-args",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/release-static/tmp-install-dir",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "OFF",
+        "ATSDK_BUILD_TESTS": "OFF",
+        "ATSDK_MEMCHECK": "OFF",
+        "ENABLE_TESTING": "OFF",
+        "ENABLE_PROGRAMS": "OFF",
+        "ENABLE_CJSON_TEST": "OFF",
+        "CJSON_OVERRIDE_BUILD_SHARED_LIBS": "ON",
+        "CJSON_BUILD_SHARED_LIBS": "OFF",
+        "BUILD_SHARED_AND_STATIC_LIBS": "OFF",
+        "ENABLE_TARGET_EXPORT": "OFF",
+        "ENABLE_CJSON_VERSION_SO": "OFF"
       }
     }
   ],
@@ -123,6 +162,13 @@
       "name": "from-package-source",
       "steps": [
         { "type": "configure", "name": "from-package-source" },
+        { "type": "build", "name": "from-package-source" }
+      ]
+    },
+    {
+      "name": "openwrt",
+      "steps": [
+        { "type": "configure", "name": "openwrt" },
         { "type": "build", "name": "from-package-source" }
       ]
     }

--- a/packages/c/CMakePresets.json
+++ b/packages/c/CMakePresets.json
@@ -50,6 +50,81 @@
       "name": "strict-ninja",
       "inherits": ["strict"],
       "generator": "Ninja"
+    },
+    {
+      "name": "release-static",
+      "binaryDir": "${sourceDir}/build/release-static",
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS": "OFF",
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_C_FLAGS": "-std=c99 -Wno-error -Wextra -Werror-implicit-function-declaration",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/release-static/tmp-install-dir",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "OFF",
+        "ATSDK_BUILD_TESTS": "OFF",
+        "ATSDK_MEMCHECK": "OFF",
+        "ENABLE_TESTING": "OFF",
+        "ENABLE_PROGRAMS": "OFF",
+        "ENABLE_CJSON_TEST": "OFF",
+        "CJSON_OVERRIDE_BUILD_SHARED_LIBS": "ON",
+        "CJSON_BUILD_SHARED_LIBS": "OFF",
+        "BUILD_SHARED_AND_STATIC_LIBS": "OFF",
+        "ENABLE_TARGET_EXPORT": "OFF",
+        "ENABLE_CJSON_VERSION_SO": "OFF"
+      }
+    },
+    {
+      "name": "from-package-source",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "NOPORTS_MBEDTLS_PATH": "deps/mbedtls-src",
+        "NOPORTS_CJSON_PATH": "deps/cjson-src",
+        "NOPORTS_ATSDK_PATH": "deps/atsdk-src"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "release-static",
+      "configurePreset": "release-static"
+    },
+    {
+      "name": "package-source",
+      "configurePreset": "release-static",
+      "targets": ["package_source"]
+    },
+    {
+      "name": "from-package-source",
+      "configurePreset": "from-package-source"
+    }
+  ],
+  "packagePresets": [
+    {
+      "name": "release-static",
+      "configurePreset": "release-static"
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "package-static",
+      "steps": [
+        { "type": "configure", "name": "release-static" },
+        { "type": "build", "name": "release-static" },
+        { "type": "package", "name": "release-static" }
+      ]
+    },
+    {
+      "name": "package-source",
+      "steps": [
+        { "type": "configure", "name": "release-static" },
+        { "type": "build", "name": "package-source" }
+      ]
+    },
+    {
+      "name": "from-package-source",
+      "steps": [
+        { "type": "configure", "name": "from-package-source" },
+        { "type": "build", "name": "from-package-source" }
+      ]
     }
   ]
 }

--- a/packages/c/CMakePresets.json
+++ b/packages/c/CMakePresets.json
@@ -78,7 +78,7 @@
       "cacheVariables": {
         "NOPORTS_MBEDTLS_PATH": "deps/mbedtls-src",
         "NOPORTS_CJSON_PATH": "deps/cjson-src",
-        "NOPORTS_ATSDK_PATH": "deps/atsdk-src"
+        "NOPORTS_ATSDK_PATH": "deps/atsdk-src",
         "BUILD_SHARED_LIBS": "OFF",
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_C_FLAGS": "-std=c99 -Wno-error -Wextra -Werror-implicit-function-declaration -Wno-calloc-transposed-args",
@@ -102,7 +102,7 @@
       "cacheVariables": {
         "NOPORTS_MBEDTLS_PATH": "deps/mbedtls-src",
         "NOPORTS_CJSON_PATH": "deps/cjson-src",
-        "NOPORTS_ATSDK_PATH": "deps/atsdk-src"
+        "NOPORTS_ATSDK_PATH": "deps/atsdk-src",
         "BUILD_SHARED_LIBS": "OFF",
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_C_FLAGS": "-std=c99 -Wno-error -Wextra -Werror-implicit-function-declaration -fPIC -fhonour-copts -Wno-calloc-transposed-args",
@@ -134,6 +134,10 @@
     {
       "name": "from-package-source",
       "configurePreset": "from-package-source"
+    },
+    {
+      "name": "openwrt",
+      "configurePreset": "openwrt"
     }
   ],
   "packagePresets": [
@@ -169,7 +173,7 @@
       "name": "openwrt",
       "steps": [
         { "type": "configure", "name": "openwrt" },
-        { "type": "build", "name": "from-package-source" }
+        { "type": "build", "name": "openwrt" }
       ]
     }
   ]

--- a/packages/c/LICENSE
+++ b/packages/c/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2022, The Atsign Foundation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/c/cmake/CPackSetup.cmake
+++ b/packages/c/cmake/CPackSetup.cmake
@@ -1,0 +1,56 @@
+# package info
+set(CPACK_PACKAGE_NAME noports)
+set(CPACK_PACKAGE_DESCRIPTION "noports source tarballs")
+set(CPACK_PACKAGE_VERSION 1.0.3)
+set(CPACK_PACKAGE_VENDOR_NAME atsign-foundation)
+
+# cmake configuration
+set(CPACK_CMAKE_GENERATOR "Unix Makefiles")
+
+# static cpack configuration
+set(CPACK_PACKAGE_FILE_NAME noports-static)
+set(CPACK_GENERATOR ZIP TGZ)
+set(CPACK_INSTALL_CMAKE_PROJECTS ".;noports;ALL;/")
+
+# source cpack configuration
+set(CPACK_SOURCE_PACKAGE_FILE_NAME noports-source)
+set(CPACK_SOURCE_GENERATOR TGZ ZIP)
+
+set(CPACK_SOURCE_INSTALLED_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR};/")
+
+# Yes, you need 4 * '\' to escape literal '.'
+set(
+  CPACK_SOURCE_IGNORE_FILES
+  # directories
+  "/\\\\.cache/"
+  "/\\\\.git/"
+  "/\\\\.github/"
+  "/\\\\.jj/"
+  "/\\\\.vscode/"
+  "/CMakeFiles/"
+  "/docs/"
+  "/build/"
+  "/logs/"
+  "/graceful-shutdown-tool/"
+  "/valgrind-test-scenarios.md"
+  # root files
+  "/\\\\.clang-format"
+  "/\\\\.clang-tidy"
+  "/\\\\.clangd"
+  "/just.env"
+  "/just.template.env"
+  "/justfile"
+  # (Potentially) nested files
+  "\\\\.DS_Store"
+  "\\\\.gitignore"
+  "compile_commands.json"
+)
+
+set(CPACK_INSTALL_SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/CPackSourceDeps.cmake")
+configure_file(
+  "${CMAKE_SOURCE_DIR}/cmake/CPackSourceDeps.cmake"
+  "CPackSourceDeps.cmake"
+  @ONLY
+)
+
+include(CPack)

--- a/packages/c/cmake/CPackSetup.cmake
+++ b/packages/c/cmake/CPackSetup.cmake
@@ -8,12 +8,12 @@ set(CPACK_PACKAGE_VENDOR_NAME atsign-foundation)
 set(CPACK_CMAKE_GENERATOR "Unix Makefiles")
 
 # static cpack configuration
-set(CPACK_PACKAGE_FILE_NAME noports-static)
+set(CPACK_PACKAGE_FILE_NAME csshnpd-static-c${CPACK_PACKAGE_VERSION})
 set(CPACK_GENERATOR ZIP TGZ)
 set(CPACK_INSTALL_CMAKE_PROJECTS ".;noports;ALL;/")
 
 # source cpack configuration
-set(CPACK_SOURCE_PACKAGE_FILE_NAME noports-source)
+set(CPACK_SOURCE_PACKAGE_FILE_NAME csshnpd-c${CPACK_PACKAGE_VERSION})
 set(CPACK_SOURCE_GENERATOR TGZ ZIP)
 
 set(CPACK_SOURCE_INSTALLED_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR};/")

--- a/packages/c/cmake/CPackSetup.cmake
+++ b/packages/c/cmake/CPackSetup.cmake
@@ -1,7 +1,7 @@
 # package info
 set(CPACK_PACKAGE_NAME noports)
 set(CPACK_PACKAGE_DESCRIPTION "noports source tarballs")
-set(CPACK_PACKAGE_VERSION 1.0.3)
+set(CPACK_PACKAGE_VERSION 1.0.4)
 set(CPACK_PACKAGE_VENDOR_NAME atsign-foundation)
 
 # cmake configuration

--- a/packages/c/cmake/CPackSourceDeps.cmake
+++ b/packages/c/cmake/CPackSourceDeps.cmake
@@ -1,0 +1,12 @@
+file(
+  COPY "@CMAKE_BINARY_DIR@/_deps/cjson-src"
+  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/deps
+)
+file(
+  COPY "@CMAKE_BINARY_DIR@/_deps/mbedtls-src"
+  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/deps
+)
+file(
+  COPY "@CMAKE_BINARY_DIR@/_deps/atsdk-src"
+  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/deps
+)

--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -1,14 +1,22 @@
+option(NOPORTS_ATSDK_PATH "Local atsdk path" OFF)
 if(NOT atsdk_FOUND)
-  message(STATUS "atsdk not found, fetching from GitHub..")
-  FetchContent_Declare(
-    atsdk
-    GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-    GIT_TAG b542e87d0d90f387b326555f65527752e229e821
-  )
+  message(STATUS "[atsdk] fetching package...")
+  include(FetchContent)
+  if(NOPORTS_ATSDK_PATH)
+    FetchContent_Declare(
+      atsdk
+      SOURCE_DIR
+      ${CMAKE_SOURCE_DIR}/${NOPORTS_ATSDK_PATH}
+    )
+  else()
+    FetchContent_Declare(
+      atsdk
+      GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
+      GIT_TAG b542e87d0d90f387b326555f65527752e229e821
+    )
+  endif()
   FetchContent_MakeAvailable(atsdk)
   install(
     TARGETS atclient atchops atlogger atauth atcommons
   )
-else()
-  message(STATUS "atsdk already installed...")
 endif()

--- a/packages/c/graceful-shutdown-tool/CMakeLists.txt
+++ b/packages/c/graceful-shutdown-tool/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(graceful-shutdown-tool VERSION 0.4.1 LANGUAGES C)
+project(graceful-shutdown-tool VERSION 1.0.4 LANGUAGES C)
 
 include(FetchContent)
 include(GNUInstallDirs)

--- a/packages/c/justfile
+++ b/packages/c/justfile
@@ -28,6 +28,12 @@ install: build-dev
 
 # BUILD COMMANDS
 
+package-static:
+  cmake --workflow --preset package-static
+
+package-source:
+  cmake --workflow --preset package-source
+
 build-dev: configure-dev
   cmake --build {{ dev_dir }}
 
@@ -52,7 +58,7 @@ memcheck +ARGS='': build-dev
   #!/usr/bin/env bash
   file="valgrind-sshnpd-$(date +%s).log"
   # child-silient-after-fork=yes: ignore session forks, we don't care
-  valgrind --log-file="$file" \
+  valgrind --log-file="logs/$file" \
   --tool=memcheck \
   --leak-check=full \
   --show-leak-kinds=all \
@@ -94,6 +100,7 @@ configure-dev:
     -DCMAKE_BUILD_TYPE=Debug \
     -DCMAKE_C_COMPILER=$C_COMPILER \
     -DCMAKE_C_FLAGS="-std=c99 -Wno-error -DATSDK_DEBUG_MODE" \
+    -DNOPORTS_GS_TOOL=ON \
     -DSSHNPD_ENABLE_TESTING_SHUTDOWN_NOTIFICATION=ON
 
 configure-strict:

--- a/packages/c/srv/CMakeLists.txt
+++ b/packages/c/srv/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
 
-project(srv VERSION 1.0.3 LANGUAGES C)
+project(srv VERSION 1.0.4 LANGUAGES C)
 
 # 1. Variables - you are free to edit anything in this step
 

--- a/packages/c/srv/CMakeLists.txt
+++ b/packages/c/srv/CMakeLists.txt
@@ -66,6 +66,7 @@ endif()
 
 # 5. Create srv_lib library target
 
+add_compile_options("-pthread")
 add_library(${PROJECT_NAME}-lib STATIC ${SRV_SRCS})
 
 target_link_libraries(

--- a/packages/c/sshnpd/CHANGELOG.md
+++ b/packages/c/sshnpd/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.4
+
+- chore: change source packaging format
+  - If you are using 1.0.3 from GitHub releases (non-source code),
+    then there is no need to upgrade
+
 ## 1.0.3
 
 - fix: uptake segfault bug fix in atsdk

--- a/packages/c/sshnpd/CMakeLists.txt
+++ b/packages/c/sshnpd/CMakeLists.txt
@@ -98,6 +98,7 @@ endif()
 
 # 5. Create sshnpd_lib library target
 
+add_compile_options("-lrt")
 add_library(${PROJECT_NAME}-lib STATIC ${SSHNPD_SRCS})
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/packages/c/sshnpd/CMakeLists.txt
+++ b/packages/c/sshnpd/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(sshnpd VERSION 1.0.3 LANGUAGES C)
+project(sshnpd VERSION 1.0.4 LANGUAGES C)
 
 # 1. Variables - you are free to edit anything in this step
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This is copied from the work I did for packaging the atsdk, then modified as needed.
See also: https://github.com/atsign-foundation/at_c/pull/574

- Added presets to generate a source tarball
- Added preset to build from the source tarball with

```sh
cmake --workflow --preset from-package-source
```

openwrt specific flags (`-fPIC -fhonour-copts`) can use a custom workflow from the same source tar to build:
```sh
cmake --workflow --preset openwrt
```

**- How I did it**

**- How to verify it**

Tested by emptying build cache, disabled internet, then ran the workflow preset noted above.

**- Description for the changelog**
fix: use cpack for c_release source tarballs
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
