### PR TITLE
fix: Have relays bind ports before locking the response mutex

### DIFF
--- a/packages/dart/noports_core/lib/src/srvd/socket_connector.dart
+++ b/packages/dart/noports_core/lib/src/srvd/socket_connector.dart
@@ -109,8 +109,23 @@ void socketConnector(ConnectorParams connectorParams) async {
   logger.info('Assigned ports [$portA, $portB]'
       ' for session ${srvdSessionParams.sessionId}');
 
+  // Make a ReceivePort so the main isolate can send messages to us
+  ReceivePort receivePort = ReceivePort(srvdSessionParams.sessionId);
+
   /// Return the assigned ports to the main isolate
-  sendPort.send((portA, portB));
+  sendPort.send(((portA, portB), receivePort.sendPort));
+
+  receivePort.listen((msg) {
+    switch (msg) {
+      case 'kill':
+        logger.shout('Received $msg from main isolate - terminating');
+        connector.close();
+        break;
+      default:
+        logger.shout('Received $msg from main isolate - ignoring');
+        break;
+    }
+  });
 
   /// Shut myself down once the socket connector closes
   logger.info('Waiting for connector to close');

--- a/packages/dart/noports_core/lib/src/srvd/srvd_impl.dart
+++ b/packages/dart/noports_core/lib/src/srvd/srvd_impl.dart
@@ -152,9 +152,11 @@ class SrvdImpl implements Srvd {
 
     logger.shout('Acquiring port pair');
     PortPair ports;
+    // ignore: unused_local_variable
     Isolate spawned;
+    SendPort sendToSpawned;
     try {
-      (ports, spawned) = await _spawnSocketConnector(
+      (ports, spawned, sendToSpawned) = await _spawnSocketConnector(
         0,
         0,
         sessionParams,
@@ -188,7 +190,7 @@ class SrvdImpl implements Srvd {
       if (err.toString().toLowerCase().contains('immutable')) {
         logger.shout('🤷‍♂️ Will not handle request from ${notification.from}'
             '; did not acquire mutex $mutexKey');
-        spawned.kill();
+        sendToSpawned.send('kill');
       } else {
         logger.shout('Will not handle; did not acquire mutex $mutexKey : $err');
       }
@@ -234,7 +236,7 @@ class SrvdImpl implements Srvd {
   /// once the socketConnector has spawned and is ready to accept connections
   /// it sends back the port numbers to the main isolate
   /// then the port numbers are returned from this function
-  Future<(PortPair, Isolate)> _spawnSocketConnector(
+  Future<(PortPair, Isolate, SendPort)> _spawnSocketConnector(
     int portA,
     int portB,
     SrvdSessionParams srvdSessionParams,
@@ -259,11 +261,13 @@ class SrvdImpl implements Srvd {
     Isolate spawned =
         await Isolate.spawn<ConnectorParams>(socketConnector, parameters);
 
+    SendPort sendPort;
     logger.info('Waiting for isolate to send its port pair info');
     PortPair ports;
     try {
-      ports =
-          await receivePort.first.timeout(Duration(milliseconds: timeoutMs));
+      (ports, sendPort) = await receivePort.first.timeout(
+        Duration(milliseconds: timeoutMs),
+      );
     } on TimeoutException catch (_) {
       throw TimeoutException('Timed out after ${timeoutMs}ms');
     }
@@ -271,7 +275,7 @@ class SrvdImpl implements Srvd {
     logger.info('Received ports $ports in main isolate'
         ' for session ${srvdSessionParams.sessionId}');
 
-    return (ports, spawned);
+    return (ports, spawned, sendPort);
   }
 }
 

--- a/packages/dart/noports_core/lib/src/srvd/srvd_impl.dart
+++ b/packages/dart/noports_core/lib/src/srvd/srvd_impl.dart
@@ -37,6 +37,8 @@ class SrvdImpl implements Srvd {
   @visibleForTesting
   bool initialized = false;
 
+  static int timeoutMs = 1000;
+
   static final String subscriptionRegex = '${Srvd.namespace}@';
 
   late final SrvdUtil srvdUtil;
@@ -148,6 +150,22 @@ class SrvdImpl implements Srvd {
 
     logger.info('New session request params: $sessionParams');
 
+    logger.shout('Acquiring port pair');
+    PortPair ports;
+    Isolate spawned;
+    try {
+      (ports, spawned) = await _spawnSocketConnector(
+        0,
+        0,
+        sessionParams,
+        logTraffic,
+        verbose,
+      );
+    } catch (e) {
+      logger.shout('_spawnSocketConnector exception: $e');
+      return;
+    }
+
     var mutexKey = AtKey.fromString('${sessionParams.sessionId}'
         '.session_mutexes.${Srvd.namespace}'
         '${atClient.getCurrentAtSign()!}')
@@ -170,19 +188,13 @@ class SrvdImpl implements Srvd {
       if (err.toString().toLowerCase().contains('immutable')) {
         logger.shout('🤷‍♂️ Will not handle request from ${notification.from}'
             '; did not acquire mutex $mutexKey');
+        spawned.kill();
       } else {
         logger.shout('Will not handle; did not acquire mutex $mutexKey : $err');
       }
       return;
     }
 
-    (int, int) ports = await _spawnSocketConnector(
-      0,
-      0,
-      sessionParams,
-      logTraffic,
-      verbose,
-    );
     var (portA, portB) = ports;
     logger.shout('Starting session ${sessionParams.sessionId}'
         ' for ${sessionParams.atSignA} to ${sessionParams.atSignB}'
@@ -222,7 +234,7 @@ class SrvdImpl implements Srvd {
   /// once the socketConnector has spawned and is ready to accept connections
   /// it sends back the port numbers to the main isolate
   /// then the port numbers are returned from this function
-  Future<PortPair> _spawnSocketConnector(
+  Future<(PortPair, Isolate)> _spawnSocketConnector(
     int portA,
     int portB,
     SrvdSessionParams srvdSessionParams,
@@ -241,17 +253,25 @@ class SrvdImpl implements Srvd {
       verbose,
     );
 
-    logger
-        .info("Spawning socket connector isolate with parameters $parameters");
+    logger.info("Spawning socket connector isolate"
+        " with parameters $parameters");
 
-    unawaited(Isolate.spawn<ConnectorParams>(socketConnector, parameters));
+    Isolate spawned =
+        await Isolate.spawn<ConnectorParams>(socketConnector, parameters);
 
-    PortPair ports = await receivePort.first;
+    logger.info('Waiting for isolate to send its port pair info');
+    PortPair ports;
+    try {
+      ports =
+          await receivePort.first.timeout(Duration(milliseconds: timeoutMs));
+    } on TimeoutException catch (_) {
+      throw TimeoutException('Timed out after ${timeoutMs}ms');
+    }
 
     logger.info('Received ports $ports in main isolate'
         ' for session ${srvdSessionParams.sessionId}');
 
-    return ports;
+    return (ports, spawned);
   }
 }
 


### PR DESCRIPTION
**- What I did**
fix: Have the relays acquire their ports before attempting to lock the respond-to-client mutex

**- How I did it**
See commits

**- How to verify it**
See #1821 
