### PR TITLE
fix: authorization screen theme update.

### DIFF
--- a/packages/dart/npt_flutter/changelog.md
+++ b/packages/dart/npt_flutter/changelog.md
@@ -6,6 +6,7 @@
 - **FEAT**: Added Version Number on the onboarding and settings screen.
 - **FIX**: Added Localization support for the authentication feature.
 - **FIX**: Backup Key is implemented correctly.
+- **FIX**: Authorization screen
 
 ## 1.0.0
 

--- a/packages/dart/npt_flutter/lib/features/authorisation/view/authorisation_view.dart
+++ b/packages/dart/npt_flutter/lib/features/authorisation/view/authorisation_view.dart
@@ -15,6 +15,12 @@ class AuthorisationView extends StatelessWidget {
         ),
         child: AuthorisationHub(
           service: context.watch<AuthorisationService>(),
+          themeData: Theme.of(context).copyWith(
+            colorScheme: Theme.of(context).colorScheme.copyWith(
+                  primary: Theme.of(context).colorScheme.primary,
+                  surface: Colors.white,
+                ),
+          ),
         ),
       ),
     );

--- a/packages/dart/npt_flutter/lib/features/authorisation/view/authorisation_view.dart
+++ b/packages/dart/npt_flutter/lib/features/authorisation/view/authorisation_view.dart
@@ -18,7 +18,6 @@ class AuthorisationView extends StatelessWidget {
           themeData: Theme.of(context).copyWith(
             colorScheme: Theme.of(context).colorScheme.copyWith(
                   primary: Theme.of(context).colorScheme.primary,
-                  surface: Colors.white,
                 ),
           ),
         ),

--- a/packages/dart/npt_flutter/lib/styles/app_theme.dart
+++ b/packages/dart/npt_flutter/lib/styles/app_theme.dart
@@ -12,6 +12,10 @@ class AppTheme {
       fontSize: Sizes.p24,
       fontWeight: FontWeight.w500,
     ),
+    headlineSmall: TextStyle(
+      fontSize: 15,
+      fontWeight: FontWeight.w500,
+    ),
     titleMedium: TextStyle(
       fontSize: Sizes.p18,
       fontWeight: FontWeight.w600,
@@ -87,6 +91,7 @@ class AppTheme {
             primary: AppColor.primaryColor,
             surface: AppColor.surfaceColor,
             onSurface: AppColor.onSurfaceColor,
+            onSurfaceVariant: AppColor.onSurfaceColor,
             surfaceTint: Colors.transparent),
         appBarTheme: const AppBarTheme(
           color: AppColor.surfaceColor,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Update the theme of the authorisation widget to be more similar to the remainder of no ports desktop. 
closes #1860 
**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
