### PR TITLE
feat: srvd: default `per-session-storage` to true

### DIFF
--- a/apps/admin/admin_api/pubspec.yaml
+++ b/apps/admin/admin_api/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
   meta: ^1.16.0
   noports_core:
     path: ../../../packages/dart/noports_core
-    version: 6.3.0
 
 dependency_overrides:
   args:

--- a/packages/dart/noports_core/CHANGELOG.md
+++ b/packages/dart/noports_core/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 6.4.0
 - feat: have srvd use ephemeral local storage for its AtClient by default
+- feat: have srvd listen for PublicKeyChanged events
 # 6.3.0
 - feat: enable multiple instances of relays for load balancing and resilience
 # 6.2.1

--- a/packages/dart/noports_core/CHANGELOG.md
+++ b/packages/dart/noports_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 6.4.0
+- feat: have srvd use ephemeral local storage for its AtClient by default
 # 6.3.0
 - feat: enable multiple instances of relays for load balancing and resilience
 # 6.2.1

--- a/packages/dart/noports_core/lib/src/srvd/srvd_params.dart
+++ b/packages/dart/noports_core/lib/src/srvd/srvd_params.dart
@@ -110,13 +110,12 @@ class SrvdParams {
     parser.addFlag(
       'per-session-storage',
       aliases: ['pss'],
-      defaultsTo: false,
-      negatable: false,
+      defaultsTo: true,
+      negatable: true,
       help: 'Use ephemeral local storage for each session.'
           ' When true, allows you to run multiple srvds concurrently on the'
-          ' same host, as the same user.'
-          ' Defaults to false, enabling you to run only a single local srvd'
-          ' concurrently.',
+          ' same host, as the same user. When false, only a single local srvd'
+          ' may run concurrently on the same host as the same user.',
     );
     parser.addFlag(
       'help',

--- a/packages/dart/noports_core/lib/src/version.dart
+++ b/packages/dart/noports_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '6.3.0';
+const packageVersion = '6.4.0';

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: noports_core
 description: Core library code for sshnoports
 homepage: https://docs.atsign.com/
 
-version: 6.3.0
+version: 6.4.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -972,7 +972,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.3.0"
+    version: "6.4.0"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.9.0';
+const packageVersion = '5.9.3';

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -617,7 +617,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.3.0"
+    version: "6.4.0"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.9.0
+version: 5.9.3
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -9,7 +9,6 @@ environment:
 dependencies:
   noports_core:
     path: "../noports_core"
-    version: 6.3.0
   at_onboarding_cli: 1.10.0
   at_cli_commons: 2.0.0
   at_client: 3.4.1


### PR DESCRIPTION
**- What I did**
feat: srvd: default the `per-session-storage` command-line arg to true. (There is no current reason to use the same storage each time, and using ephemeral storage by default provides a level of insulation from potential local-storage-related bugs in the future.)

**- How I did it**
See commits

**- How to verify it**
Tests pass
