### PR TITLE
build: update pubspec.lock for admin_api

### DIFF
--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -616,7 +616,7 @@ packages:
       path: "../../../packages/dart/noports_core"
       relative: true
     source: path
-    version: "6.3.0"
+    version: "6.4.0"
   openssh_ed25519:
     dependency: transitive
     description:


### PR DESCRIPTION
**- What I did**
build: update pubspec.lock for admin_api

**- How I did it**
ran dart pub get in apps/admin/admin_api to update the pubspec.lock

**- How to verify it**
multibuild passes (here's a [multibuild](https://github.com/atsign-foundation/noports/actions/runs/14727204805) for this branch)