### PR TITLE
chore: Bump version in CMake files

### DIFF
--- a/packages/c/cmake/CPackSetup.cmake
+++ b/packages/c/cmake/CPackSetup.cmake
@@ -1,7 +1,7 @@
 # package info
 set(CPACK_PACKAGE_NAME noports)
 set(CPACK_PACKAGE_DESCRIPTION "noports source tarballs")
-set(CPACK_PACKAGE_VERSION 1.0.4)
+set(CPACK_PACKAGE_VERSION 1.0.5)
 set(CPACK_PACKAGE_VENDOR_NAME atsign-foundation)
 
 # cmake configuration

--- a/packages/c/graceful-shutdown-tool/CMakeLists.txt
+++ b/packages/c/graceful-shutdown-tool/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(graceful-shutdown-tool VERSION 1.0.4 LANGUAGES C)
+project(graceful-shutdown-tool VERSION 1.0.5 LANGUAGES C)
 
 include(FetchContent)
 include(GNUInstallDirs)

--- a/packages/c/srv/CMakeLists.txt
+++ b/packages/c/srv/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
 
-project(srv VERSION 1.0.4 LANGUAGES C)
+project(srv VERSION 1.0.5 LANGUAGES C)
 
 # 1. Variables - you are free to edit anything in this step
 


### PR DESCRIPTION
c1.0.5 release didn't build correctly as the source tarball was name c1.0.4

**- What I did**

Bumped version in CMake files

**- How to verify it**

Re-release c1.0.5

**- Description for the changelog**

chore: Bump version in CMake files