### PR TITLE
fix: openwrt upstream 2

### DIFF
--- a/packages/c/CMakeLists.txt
+++ b/packages/c/CMakeLists.txt
@@ -11,7 +11,7 @@ set(ATSDK_MBEDTLS_PATH ${NOPORTS_MBEDTLS_PATH})
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(noports VERSION 1.0.5 LANGUAGES C)
+project(noports VERSION 1.0.6 LANGUAGES C)
 
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/CPackSetup.cmake")
 

--- a/packages/c/cmake/CPackSetup.cmake
+++ b/packages/c/cmake/CPackSetup.cmake
@@ -1,7 +1,7 @@
 # package info
 set(CPACK_PACKAGE_NAME noports)
 set(CPACK_PACKAGE_DESCRIPTION "noports source tarballs")
-set(CPACK_PACKAGE_VERSION 1.0.5)
+set(CPACK_PACKAGE_VERSION 1.0.6)
 set(CPACK_PACKAGE_VENDOR_NAME atsign-foundation)
 
 # cmake configuration

--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -12,7 +12,7 @@ if(NOT atsdk_FOUND)
     FetchContent_Declare(
       atsdk
       GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-      GIT_TAG e2f0c3e245e465f1d9c7be2f716eabe36ddc75d7
+      GIT_TAG cf38e9fcacf74b49ffc9fe92678b4af6f6cba817
     )
   endif()
   FetchContent_MakeAvailable(atsdk)

--- a/packages/c/graceful-shutdown-tool/CMakeLists.txt
+++ b/packages/c/graceful-shutdown-tool/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(graceful-shutdown-tool VERSION 1.0.5 LANGUAGES C)
+project(graceful-shutdown-tool VERSION 1.0.6 LANGUAGES C)
 
 include(FetchContent)
 include(GNUInstallDirs)

--- a/packages/c/srv/CMakeLists.txt
+++ b/packages/c/srv/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
 
-project(srv VERSION 1.0.5 LANGUAGES C)
+project(srv VERSION 1.0.6 LANGUAGES C)
 
 # 1. Variables - you are free to edit anything in this step
 

--- a/packages/c/sshnpd/CHANGELOG.md
+++ b/packages/c/sshnpd/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.6
+
+- fix: more build warnings for openwrt upstream
+
 ## 1.0.5
 
 - chore: stricter compile options to match openwrt upstream

--- a/packages/c/sshnpd/CMakeLists.txt
+++ b/packages/c/sshnpd/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(sshnpd VERSION 1.0.5 LANGUAGES C)
+project(sshnpd VERSION 1.0.6 LANGUAGES C)
 
 # 1. Variables - you are free to edit anything in this step
 

--- a/packages/c/sshnpd/README.md
+++ b/packages/c/sshnpd/README.md
@@ -25,7 +25,7 @@ With `gcc` (disables warnings found in mbedtls' tests):
 
 ```bash
 cd packages/c/sshnpd
-cmake -B build -S . -DBUILD_SHARED_LIBS=off -DCMAKE_C_COMPILER=gcc -DCMAKE_C_FLAGS="-Wno-calloc-transposed-args -Wno-error -pthread -lrt"
+cmake -B build -S . -DBUILD_SHARED_LIBS=off -DCMAKE_C_COMPILER=gcc -DCMAKE_C_FLAGS="-Wno-error -pthread -lrt"
 cmake --build build
 ```
 

--- a/packages/c/sshnpd/include/sshnpd/daemon.h
+++ b/packages/c/sshnpd/include/sshnpd/daemon.h
@@ -11,18 +11,10 @@ extern "C" {
 #include <signal.h>
 
 // Global state of the main daemon process
-
-static struct {
+extern struct _notification_key_map {
   char *str;
   enum notification_key key;
-} notification_key_map[] = {
-    {"", NK_NONE},
-    {"sshpublickey", NK_SSHPUBLICKEY},
-    {"ping", NK_PING},
-    {"ssh_request", NK_SSH_REQUEST},
-    {"npt_request", NK_NPT_REQUEST},
-    {"graceful_shutdown", NK_GRACEFUL_SHUTDOWN},
-};
+} notification_key_map[];
 
 extern atclient worker;
 extern atclient monitor_ctx;

--- a/packages/c/sshnpd/src/daemon.c
+++ b/packages/c/sshnpd/src/daemon.c
@@ -35,6 +35,15 @@
 
 #define LOGGER_TAG "sshnpd - loop"
 
+struct _notification_key_map notification_key_map[] = {
+    {"", NK_NONE},
+    {"sshpublickey", NK_SSHPUBLICKEY},
+    {"ping", NK_PING},
+    {"ssh_request", NK_SSH_REQUEST},
+    {"npt_request", NK_NPT_REQUEST},
+    {"graceful_shutdown", NK_GRACEFUL_SHUTDOWN},
+};
+
 atclient worker;
 atclient monitor_ctx;
 char *ping_response;

--- a/packages/c/sshnpd/tools/debug_build.sh
+++ b/packages/c/sshnpd/tools/debug_build.sh
@@ -5,6 +5,6 @@ SCRIPT_DIRECTORY="$(dirname "$FULL_PATH_TO_SCRIPT")"
 cd "$SCRIPT_DIRECTORY"
 cd ..
 
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-calloc-transposed-args -Wno-error -pthread -lrt"
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread -lrt"
 
 cmake --build build


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- bump atsdk to https://github.com/atsign-foundation/at_c/pull/586
- silence a static map in a header being unused (in some files) by making it an extern variable... which will hopefully suppress it since it is no longer marked static in the header (and thus the files it is unused in)

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: openwrt upstream 2
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
