### PR TITLE
fix: Take up at_c with fix for switch fallthrough

### DIFF
--- a/packages/c/CMakeLists.txt
+++ b/packages/c/CMakeLists.txt
@@ -11,7 +11,7 @@ set(ATSDK_MBEDTLS_PATH ${NOPORTS_MBEDTLS_PATH})
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(noports VERSION 1.0.6 LANGUAGES C)
+project(noports VERSION 1.0.7 LANGUAGES C)
 
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/CPackSetup.cmake")
 

--- a/packages/c/cmake/CPackSetup.cmake
+++ b/packages/c/cmake/CPackSetup.cmake
@@ -1,7 +1,7 @@
 # package info
 set(CPACK_PACKAGE_NAME noports)
 set(CPACK_PACKAGE_DESCRIPTION "noports source tarballs")
-set(CPACK_PACKAGE_VERSION 1.0.6)
+set(CPACK_PACKAGE_VERSION 1.0.7)
 set(CPACK_PACKAGE_VENDOR_NAME atsign-foundation)
 
 # cmake configuration

--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -12,7 +12,7 @@ if(NOT atsdk_FOUND)
     FetchContent_Declare(
       atsdk
       GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-      GIT_TAG cf38e9fcacf74b49ffc9fe92678b4af6f6cba817
+      GIT_TAG a77d003b52deb2a7bbb1f947d042fcf8f27c0458
     )
   endif()
   FetchContent_MakeAvailable(atsdk)

--- a/packages/c/graceful-shutdown-tool/CMakeLists.txt
+++ b/packages/c/graceful-shutdown-tool/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(graceful-shutdown-tool VERSION 1.0.6 LANGUAGES C)
+project(graceful-shutdown-tool VERSION 1.0.7 LANGUAGES C)
 
 include(FetchContent)
 include(GNUInstallDirs)

--- a/packages/c/srv/CMakeLists.txt
+++ b/packages/c/srv/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
 
-project(srv VERSION 1.0.6 LANGUAGES C)
+project(srv VERSION 1.0.7 LANGUAGES C)
 
 # 1. Variables - you are free to edit anything in this step
 

--- a/packages/c/sshnpd/CHANGELOG.md
+++ b/packages/c/sshnpd/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.7
+
+- fix: switch statement fallthrough warning
+
 ## 1.0.6
 
 - fix: more build warnings for openwrt upstream

--- a/packages/c/sshnpd/CMakeLists.txt
+++ b/packages/c/sshnpd/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(sshnpd VERSION 1.0.6 LANGUAGES C)
+project(sshnpd VERSION 1.0.7 LANGUAGES C)
 
 # 1. Variables - you are free to edit anything in this step
 


### PR DESCRIPTION
https://github.com/atsign-foundation/noports/issues/1866#issuecomment-2876530634

**- What I did**

* Uptake latest at_c with fix for switch statement fallthrough
* Bumped version to 1.0.7

**- How I did it**

Based on #1911

**- How to verify it**

Releace c1.0.7 and rebuild in OpenWrt

**- Description for the changelog**

fix: Take up at_c with fix for switch fallthrough
