### PR TITLE
build(deps): Bump pubspec.lock to use alfred fork

### DIFF
--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -12,10 +12,11 @@ packages:
   alfred:
     dependency: "direct main"
     description:
-      name: alfred
-      sha256: cecd070b75d10eacce2c2148f7ffd489bf85faea4b12cfa608a3428febdaf6ca
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: cc-directory-4-windows
+      resolved-ref: "8ecf0437cb91d591d5b1e1547e662438d5f65351"
+      url: "https://github.com/atsign-foundation/alfred"
+    source: git
     version: "1.1.2+1"
   analyzer:
     dependency: transitive

--- a/apps/admin/admin_api/pubspec.yaml
+++ b/apps/admin/admin_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: admin_api
 description: A sample command-line application.
-version: 1.0.0
+version: 1.0.1
 publish_to: none
 # repository: https://github.com/my_org/my_repo
 
@@ -9,10 +9,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  alfred:
-    git:
-      ref: cc-directory-4-windows
-      url: https://github.com/atsign-foundation/alfred.git
+  alfred: 1.1.2+1
   at_client: 3.4.2
   json_annotation: 4.9.0
   at_cli_commons: 2.1.0
@@ -26,6 +23,10 @@ dependency_overrides:
     git:
       ref: gkc/show-aliases-in-usage
       url: https://github.com/gkc/args
+  alfred:
+    git:
+      ref: cc-directory-4-windows
+      url: https://github.com/atsign-foundation/alfred
 
 dev_dependencies:
   lints: ^5.1.1


### PR DESCRIPTION
Progresses #1916, though there's work to be done on testing

**- What I did**

* Moved alfred fork to a dependency override (in common with gkc/args fork)
* Recreated pubspec.lock

**- How to verify it**

I'll attempt to release v5.9.4 again

**- Description for the changelog**

build(deps): Bump pubspec.lock to use alfred fork
