### PR TITLE
feat: added --root-domain url:portnumber leaving port 64 as default

### DIFF
--- a/packages/dart/sshnoports/lib/src/create_at_client_cli.dart
+++ b/packages/dart/sshnoports/lib/src/create_at_client_cli.dart
@@ -17,10 +17,7 @@ Future<AtClient> createAtClientCli({
   int rootPort = 64;
   if (rootDomain.contains(':')) {
     rootPort = int.parse(rootDomain.split(':')[1]);
-    print(rootPort);
-    print(rootDomain);
     rootDomain = rootDomain.split(':')[0];
-    print(rootDomain);
   }
   AtOnboardingPreference atOnboardingConfig = AtOnboardingPreference()
     ..hiveStoragePath = storagePath

--- a/packages/dart/sshnoports/lib/src/create_at_client_cli.dart
+++ b/packages/dart/sshnoports/lib/src/create_at_client_cli.dart
@@ -14,6 +14,14 @@ Future<AtClient> createAtClientCli({
 }) async {
   // Now on to the atPlatform startup
   //onboarding preference builder can be used to set onboardingService parameters
+  int rootPort = 64;
+  if (rootDomain.contains(':')) {
+    rootPort = int.parse(rootDomain.split(':')[1]);
+    print(rootPort);
+    print(rootDomain);
+    rootDomain = rootDomain.split(':')[0];
+    print(rootDomain);
+  }
   AtOnboardingPreference atOnboardingConfig = AtOnboardingPreference()
     ..hiveStoragePath = storagePath
     ..namespace = namespace
@@ -23,6 +31,7 @@ Future<AtClient> createAtClientCli({
     ..fetchOfflineNotifications = false
     ..atKeysFilePath = atKeysFilePath
     ..atProtocolEmitted = Version(2, 0, 0)
+    ..rootPort = rootPort
     ..rootDomain = rootDomain;
 
   AtOnboardingService onboardingService = AtOnboardingServiceImpl(


### PR DESCRIPTION

**- What I did**
Added the option of adding a port number (e.g. 443) to the root-domain flag

**- How I did it**
Altered the atClient generation to include a root port from the URL and leave a default of 64
**- How to verify it**
Compiled and tested by hand for both sshnp and sshnpd

**- Description for the changelog**
feat: added --root-domain url:portnumber leaving port 64 as default