### PR TITLE
feat: changes for sending a heartbeat over the npt control socket

### DIFF
--- a/packages/c/srv/src/srv.c
+++ b/packages/c/srv/src/srv.c
@@ -89,7 +89,7 @@ int run_srv_daemon_side_multi(srv_params_t *params) {
     }
   }
 
-  // Open a control socket of type B (non local host and port)
+  // Open a control channel of type B (non local host and port)
   // This socket will decrypt the messages comming from the other side
   // which provide the information to create new sockets
   side_t control_side;
@@ -187,7 +187,7 @@ int run_srv_daemon_side_multi(srv_params_t *params) {
           goto exit;
         }
         atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG,
-                     "run_srv_daemon_side_multi\n Control socket received %s request - \n creating new socketToSocket "
+                     "run_srv_daemon_side_multi\n control channel received %s request - \n creating new socketToSocket "
                      "connection\n",
                      messagetype);
 
@@ -237,7 +237,7 @@ int run_srv_daemon_side_multi(srv_params_t *params) {
         pthread_detach(sts_thread);
 
       } else {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Unknown request to control socket: %s\n", requests[i]);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Unknown request to control channel: %s\n", requests[i]);
       }
     }
     // Clean buffer for next iteration and free previous requests

--- a/packages/dart/noports_core/lib/src/common/default_args.dart
+++ b/packages/dart/noports_core/lib/src/common/default_args.dart
@@ -37,6 +37,15 @@ class DefaultArgs {
   /// How long srv should stay running if SocketConnector has no connections
   static const int srvTimeoutInSeconds = 30;
   static const Duration srvTimeout = Duration(seconds: srvTimeoutInSeconds);
+
+  /// How frequently to send heartbeats over the control socket.
+  ///
+  /// Heartbeats are an attempt to persuade over-zealous network
+  /// intermediaries that the control socket shouldn't be closed due to lack
+  /// of activity.
+  static const int controlSocketHeartbeatIntervalMins = 30;
+  static const Duration controlSocketHeartbeatInterval =
+      Duration(minutes: controlSocketHeartbeatIntervalMins);
 }
 
 class DefaultSshnpArgs {

--- a/packages/dart/noports_core/lib/src/common/default_args.dart
+++ b/packages/dart/noports_core/lib/src/common/default_args.dart
@@ -38,14 +38,14 @@ class DefaultArgs {
   static const int srvTimeoutInSeconds = 30;
   static const Duration srvTimeout = Duration(seconds: srvTimeoutInSeconds);
 
-  /// How frequently to send heartbeats over the control socket.
+  /// How frequently to send heartbeats over the control channel.
   ///
   /// Heartbeats are an attempt to persuade over-zealous network
-  /// intermediaries that the control socket shouldn't be closed due to lack
+  /// intermediaries that the control channel shouldn't be closed due to lack
   /// of activity.
-  static const int controlSocketHeartbeatIntervalMins = 30;
-  static const Duration controlSocketHeartbeatInterval =
-      Duration(minutes: controlSocketHeartbeatIntervalMins);
+  static const int controlChannelHeartbeatIntervalMins = 30;
+  static const Duration controlChannelHeartbeatInterval =
+      Duration(minutes: controlChannelHeartbeatIntervalMins);
 }
 
 class DefaultSshnpArgs {

--- a/packages/dart/noports_core/lib/src/common/features.dart
+++ b/packages/dart/noports_core/lib/src/common/features.dart
@@ -22,6 +22,10 @@ enum DaemonFeature {
   /// Understands and respects the 'timeout' value in an npt session request
   /// See also [NptParams.timeout]
   adjustableTimeout,
+
+  /// Can handle heartbeat messages being sent over the control channel.
+  /// See also [NptParams.controlChannelHeartbeat]
+  controlChannelHeartbeats,
 }
 
 extension FeatureDescription on DaemonFeature {
@@ -37,6 +41,8 @@ extension FeatureDescription on DaemonFeature {
         return 'support requests for specific device ports';
       case DaemonFeature.adjustableTimeout:
         return 'support the \'timeout\' value in npt session requests';
+      case DaemonFeature.controlChannelHeartbeats:
+        return 'handle heartbeat messages being send over the control channel';
     }
   }
 }

--- a/packages/dart/noports_core/lib/src/common/features.dart
+++ b/packages/dart/noports_core/lib/src/common/features.dart
@@ -6,28 +6,28 @@ import 'package:version/version.dart';
 enum DaemonFeature {
   /// daemon will accept ssh public keys sent by clients (i.e. daemon has been
   /// started with the `--sshpublickey` or `-s` flag)
-  acceptsPublicKeys("1.0.0"),
+  acceptsPublicKeys('1.0.0'),
 
   /// authenticate when connecting to the Socket Rendezvous (sr)
-  srAuth("1.1.0"),
+  srAuth('1.1.0'),
 
   /// End-to-end encrypt traffic sent via the SocketRendezvous (sr)
-  srE2ee("1.1.0"),
+  srE2ee('1.1.0'),
 
   /// Understands requests from clients for specific ports. Note that this
   /// does not mean that a daemon will **allow** a connection to that port,
   /// just that the daemon will understand the request. For example, a client
   /// could request to connect to port 80, and the daemon could allow it, but
   /// not allow connections to any other ports.
-  supportsPortChoice("1.2.0"),
+  supportsPortChoice('1.2.0'),
 
   /// Understands and respects the 'timeout' value in an npt session request
   /// See also [NptParams.timeout]
-  adjustableTimeout("1.3.0"),
+  adjustableTimeout('1.3.0'),
 
   /// Can handle heartbeat messages being sent over the control channel.
   /// See also [NptParams.controlChannelHeartbeat]
-  controlChannelHeartbeats("1.4.0"),
+  controlChannelHeartbeats('1.4.0'),
   ;
 
   /// The version of the NoPorts control protocol which introduced this feature.

--- a/packages/dart/noports_core/lib/src/common/features.dart
+++ b/packages/dart/noports_core/lib/src/common/features.dart
@@ -1,31 +1,58 @@
+import 'package:version/version.dart';
+
 /// Features which can be supported by the NoPorts Daemon
 /// Do not change the names of existing features as this will cause
 /// breaking changes across versions
 enum DaemonFeature {
   /// daemon will accept ssh public keys sent by clients (i.e. daemon has been
   /// started with the `--sshpublickey` or `-s` flag)
-  acceptsPublicKeys,
+  acceptsPublicKeys("1.0.0"),
 
   /// authenticate when connecting to the Socket Rendezvous (sr)
-  srAuth,
+  srAuth("1.1.0"),
 
   /// End-to-end encrypt traffic sent via the SocketRendezvous (sr)
-  srE2ee,
+  srE2ee("1.1.0"),
 
   /// Understands requests from clients for specific ports. Note that this
   /// does not mean that a daemon will **allow** a connection to that port,
   /// just that the daemon will understand the request. For example, a client
   /// could request to connect to port 80, and the daemon could allow it, but
   /// not allow connections to any other ports.
-  supportsPortChoice,
+  supportsPortChoice("1.2.0"),
 
   /// Understands and respects the 'timeout' value in an npt session request
   /// See also [NptParams.timeout]
-  adjustableTimeout,
+  adjustableTimeout("1.3.0"),
 
   /// Can handle heartbeat messages being sent over the control channel.
   /// See also [NptParams.controlChannelHeartbeat]
-  controlChannelHeartbeats,
+  controlChannelHeartbeats("1.4.0"),
+  ;
+
+  /// The version of the NoPorts control protocol which introduced this feature.
+  Version get since => Version.parse(_since);
+  final String _since;
+
+  const DaemonFeature(this._since);
+
+  /// The latest version amongst all of the features supported.
+  static Version? _latestVersion;
+
+  static Version get latestVersion {
+    if (_latestVersion != null) {
+      return _latestVersion!;
+    }
+
+    Version v = Version.parse('0.0.0');
+    for (final f in DaemonFeature.values) {
+      if (f.since > v) {
+        v = f.since;
+      }
+    }
+    _latestVersion = v;
+    return v;
+  }
 }
 
 extension FeatureDescription on DaemonFeature {
@@ -45,4 +72,8 @@ extension FeatureDescription on DaemonFeature {
         return 'handle heartbeat messages being send over the control channel';
     }
   }
+}
+
+void main() {
+  print(DaemonFeature.latestVersion);
 }

--- a/packages/dart/noports_core/lib/src/common/features.dart
+++ b/packages/dart/noports_core/lib/src/common/features.dart
@@ -73,7 +73,3 @@ extension FeatureDescription on DaemonFeature {
     }
   }
 }
-
-void main() {
-  print(DaemonFeature.latestVersion);
-}

--- a/packages/dart/noports_core/lib/src/common/types.dart
+++ b/packages/dart/noports_core/lib/src/common/types.dart
@@ -12,6 +12,7 @@ typedef SrvGenerator<T> = Srv<T> Function(
   bool multi,
   bool detached,
   Duration timeout,
+  Duration heartbeat,
 });
 
 enum SupportedSshClient {

--- a/packages/dart/noports_core/lib/src/common/types.dart
+++ b/packages/dart/noports_core/lib/src/common/types.dart
@@ -12,7 +12,7 @@ typedef SrvGenerator<T> = Srv<T> Function(
   bool multi,
   bool detached,
   Duration timeout,
-  Duration heartbeat,
+  Duration? controlChannelHeartbeat,
 });
 
 enum SupportedSshClient {

--- a/packages/dart/noports_core/lib/src/npt/npt.dart
+++ b/packages/dart/noports_core/lib/src/npt/npt.dart
@@ -315,6 +315,7 @@ class _NptImpl extends NptBase
         multi: true,
         detached: true,
         timeout: params.timeout,
+        heartbeat: params.heartbeat,
       );
       _completer.complete();
     }
@@ -338,6 +339,7 @@ class _NptImpl extends NptBase
       multi: true,
       detached: false,
       timeout: params.timeout,
+      heartbeat: params.heartbeat,
     );
 
     unawaited(sc.done.then((_) {

--- a/packages/dart/noports_core/lib/src/npt/npt.dart
+++ b/packages/dart/noports_core/lib/src/npt/npt.dart
@@ -113,6 +113,8 @@ abstract class NptBase implements Npt {
 
   final logger = AtSignLogger(' Npt ');
 
+  bool sendControlHeartbeats = false;
+
   NptBase({
     required this.params,
     required this.atClient,
@@ -194,6 +196,7 @@ class _NptImpl extends NptBase
       DaemonFeature.srAuth,
       DaemonFeature.srE2ee,
       DaemonFeature.supportsPortChoice,
+      DaemonFeature.controlChannelHeartbeats,
     ];
     if (!(params.timeout == DefaultArgs.srvTimeout)) {
       requiredFeatures.add(DaemonFeature.adjustableTimeout);
@@ -215,7 +218,18 @@ class _NptImpl extends NptBase
     sendProgress('Received daemon feature check response');
 
     await Future.delayed(Duration(milliseconds: 1));
-    for (final (DaemonFeature _, bool supported, String reason) in features) {
+    for (final (DaemonFeature feature, bool supported, String reason)
+        in features) {
+      if (feature == DaemonFeature.controlChannelHeartbeats) {
+        if (supported) {
+          sendProgress('Will send control channel heartbeats');
+          sendControlHeartbeats = true;
+        } else {
+          sendProgress('Will not send control channel heartbeats');
+          sendControlHeartbeats = false;
+        }
+        continue;
+      }
       if (!supported) {
         if (reason.contains('timed out')) {
           throw TimeoutException('Ping to NoPorts daemon timed out');
@@ -315,7 +329,8 @@ class _NptImpl extends NptBase
         multi: true,
         detached: true,
         timeout: params.timeout,
-        heartbeat: params.heartbeat,
+        controlChannelHeartbeat:
+            sendControlHeartbeats ? params.controlChannelHeartbeat : null,
       );
       _completer.complete();
     }
@@ -339,7 +354,8 @@ class _NptImpl extends NptBase
       multi: true,
       detached: false,
       timeout: params.timeout,
-      heartbeat: params.heartbeat,
+      controlChannelHeartbeat:
+          sendControlHeartbeats ? params.controlChannelHeartbeat : null,
     );
 
     unawaited(sc.done.then((_) {

--- a/packages/dart/noports_core/lib/src/srv/srv.dart
+++ b/packages/dart/noports_core/lib/src/srv/srv.dart
@@ -43,6 +43,13 @@ abstract class Srv<T> {
   /// How long to keep the SocketConnector open if there have been no connections
   abstract final Duration timeout;
 
+  /// How frequently to send heartbeats over the control socket.
+  ///
+  /// Heartbeats are an attempt to persuade over-zealous network
+  /// intermediaries that the control socket shouldn't be closed due to lack
+  /// of activity.
+  abstract final Duration heartbeat;
+
   Future<T> run();
 
   // Can't use factory functions since Srv contains a generic type
@@ -58,6 +65,7 @@ abstract class Srv<T> {
     bool multi = false,
     bool detached = false,
     Duration timeout = DefaultArgs.srvTimeout,
+    Duration heartbeat = DefaultArgs.controlSocketHeartbeatInterval,
   }) {
     return SrvImplExec(
       streamingHost,
@@ -70,6 +78,7 @@ abstract class Srv<T> {
       sessionIVString: sessionIVString,
       multi: multi,
       timeout: timeout,
+      heartbeat: heartbeat,
     );
   }
 
@@ -85,6 +94,7 @@ abstract class Srv<T> {
     bool multi = false,
     bool detached = false,
     Duration timeout = DefaultArgs.srvTimeout,
+    Duration heartbeat = DefaultArgs.controlSocketHeartbeatInterval,
   }) {
     return SrvImplDart(
       streamingHost,
@@ -98,6 +108,7 @@ abstract class Srv<T> {
       multi: multi,
       detached: detached,
       timeout: timeout,
+      heartbeat: heartbeat,
     );
   }
 
@@ -113,6 +124,7 @@ abstract class Srv<T> {
     bool multi = false,
     bool detached = false,
     Duration timeout = DefaultArgs.srvTimeout,
+    Duration heartbeat = DefaultArgs.controlSocketHeartbeatInterval,
   }) {
     return SrvImplInline(
       streamingHost,
@@ -122,6 +134,7 @@ abstract class Srv<T> {
       sessionIVString: sessionIVString,
       multi: multi,
       timeout: timeout,
+      heartbeat: heartbeat,
     );
   }
 

--- a/packages/dart/noports_core/lib/src/srv/srv.dart
+++ b/packages/dart/noports_core/lib/src/srv/srv.dart
@@ -43,12 +43,12 @@ abstract class Srv<T> {
   /// How long to keep the SocketConnector open if there have been no connections
   abstract final Duration timeout;
 
-  /// How frequently to send heartbeats over the control socket.
+  /// How frequently to send heartbeats over the control channel.
   ///
   /// Heartbeats are an attempt to persuade over-zealous network
-  /// intermediaries that the control socket shouldn't be closed due to lack
+  /// intermediaries that the control channel shouldn't be closed due to lack
   /// of activity.
-  abstract final Duration heartbeat;
+  abstract final Duration? controlChannelHeartbeat;
 
   Future<T> run();
 
@@ -65,7 +65,7 @@ abstract class Srv<T> {
     bool multi = false,
     bool detached = false,
     Duration timeout = DefaultArgs.srvTimeout,
-    Duration heartbeat = DefaultArgs.controlSocketHeartbeatInterval,
+    Duration? controlChannelHeartbeat,
   }) {
     return SrvImplExec(
       streamingHost,
@@ -78,7 +78,7 @@ abstract class Srv<T> {
       sessionIVString: sessionIVString,
       multi: multi,
       timeout: timeout,
-      heartbeat: heartbeat,
+      controlChannelHeartbeat: controlChannelHeartbeat,
     );
   }
 
@@ -94,7 +94,7 @@ abstract class Srv<T> {
     bool multi = false,
     bool detached = false,
     Duration timeout = DefaultArgs.srvTimeout,
-    Duration heartbeat = DefaultArgs.controlSocketHeartbeatInterval,
+    Duration? controlChannelHeartbeat,
   }) {
     return SrvImplDart(
       streamingHost,
@@ -108,7 +108,7 @@ abstract class Srv<T> {
       multi: multi,
       detached: detached,
       timeout: timeout,
-      heartbeat: heartbeat,
+      controlChannelHeartbeat: controlChannelHeartbeat,
     );
   }
 
@@ -124,7 +124,7 @@ abstract class Srv<T> {
     bool multi = false,
     bool detached = false,
     Duration timeout = DefaultArgs.srvTimeout,
-    Duration heartbeat = DefaultArgs.controlSocketHeartbeatInterval,
+    Duration? controlChannelHeartbeat,
   }) {
     return SrvImplInline(
       streamingHost,
@@ -134,7 +134,7 @@ abstract class Srv<T> {
       sessionIVString: sessionIVString,
       multi: multi,
       timeout: timeout,
-      heartbeat: heartbeat,
+      controlChannelHeartbeat: controlChannelHeartbeat,
     );
   }
 

--- a/packages/dart/noports_core/lib/src/srv/srv_impl.dart
+++ b/packages/dart/noports_core/lib/src/srv/srv_impl.dart
@@ -13,6 +13,9 @@ import 'package:mutex/mutex.dart';
 import 'package:noports_core/srv.dart';
 import 'package:noports_core/sshnp.dart';
 import 'package:socket_connector/socket_connector.dart';
+import 'package:at_commons/at_commons.dart' as at_commons;
+
+const newLineCodeUnit = 10;
 
 @visibleForTesting
 class SrvImplExec implements Srv<Process> {
@@ -48,6 +51,9 @@ class SrvImplExec implements Srv<Process> {
   @override
   final Duration timeout;
 
+  @override
+  final Duration heartbeat;
+
   SrvImplExec(
     this.streamingHost,
     this.streamingPort, {
@@ -59,6 +65,7 @@ class SrvImplExec implements Srv<Process> {
     this.sessionIVString,
     required this.multi,
     required this.timeout,
+    required this.heartbeat,
   }) {
     if (localPort == null) {
       throw ArgumentError('localPort must be non-null');
@@ -92,6 +99,8 @@ class SrvImplExec implements Srv<Process> {
       localHost ?? 'localhost',
       '--timeout',
       timeout.inSeconds.toString(),
+      '--heartbeat',
+      heartbeat.inSeconds.toString(),
     ];
     if (multi) {
       rvArgs.add('--multi');
@@ -193,6 +202,9 @@ class SrvImplInline implements Srv<SSHSocket> {
   @override
   final Duration timeout;
 
+  @override
+  final Duration heartbeat;
+
   SrvImplInline(
     this.streamingHost,
     this.streamingPort, {
@@ -201,6 +213,7 @@ class SrvImplInline implements Srv<SSHSocket> {
     this.sessionIVString,
     this.multi = false,
     required this.timeout,
+    required this.heartbeat,
   }) {
     if ((sessionAESKeyString == null && sessionIVString != null) ||
         (sessionAESKeyString != null && sessionIVString == null)) {
@@ -347,6 +360,9 @@ class SrvImplDart implements Srv<SocketConnector> {
   @override
   final Duration timeout;
 
+  @override
+  final Duration heartbeat;
+
   final AtSignLogger logger = AtSignLogger(' SrvImplDart ');
 
   SrvImplDart(
@@ -361,6 +377,7 @@ class SrvImplDart implements Srv<SocketConnector> {
     this.multi = false,
     required this.detached,
     required this.timeout,
+    required this.heartbeat,
   }) {
     logger.info('New SrvImplDart - localPort $localPort');
     if ((sessionAESKeyString == null && sessionIVString != null) ||
@@ -564,8 +581,9 @@ class SrvImplDart implements Srv<SocketConnector> {
       timeout: timeout,
       beforeJoining: (Side sideA, Side sideB) {
         logger.info('_runClientSideMulti Sending connect request');
-        sessionControlSocket
-            .add(Uint8List.fromList('connect:no:encrypt\n'.codeUnits));
+        sessionControlSocket.add(
+          Uint8List.fromList('connect:no:encrypt\n'.codeUnits),
+        );
         // Authenticate the sideB socket (to the rvd)
         if (rvdAuthString != null) {
           logger
@@ -606,6 +624,25 @@ class SrvImplDart implements Srv<SocketConnector> {
       socketConnector?.close();
     });
 
+    bool heartbeatInProgress = false;
+    int heartbeatCounter = 1;
+    Timer.periodic(heartbeat, (timer) async {
+      if (heartbeatInProgress) {
+        logger.warning('Control socket heartbeat already in progress');
+        return;
+      }
+      try {
+        heartbeatInProgress = true;
+        logger.info('Sending heartbeat $heartbeatCounter on control socket');
+        controlSink.add(
+          Uint8List.fromList('heartbeat:$heartbeatCounter\n'.codeUnits),
+        );
+        heartbeatCounter++;
+      } finally {
+        heartbeatInProgress = false;
+      }
+    });
+
     logger.info('_runClientSideMulti calling SocketConnector.serverToSocket');
     socketConnector = await SocketConnector.serverToSocket(
       portA: localPort,
@@ -615,7 +652,7 @@ class SrvImplDart implements Srv<SocketConnector> {
       logger: ioSinkForLogger(logger),
       multi: multi,
       timeout: timeout,
-      beforeJoining: (Side sideA, Side sideB) {
+      beforeJoining: (Side sideA, Side sideB) async {
         logger.info('_runClientSideMulti Sending connect request');
 
         String socketAESKey =
@@ -669,8 +706,8 @@ class SrvImplDart implements Srv<SocketConnector> {
         await sideBSocket.flush();
       }
     } catch (e) {
-      logger.shout(
-          'Failed to connect to relay ($relayAddress:$streamingPort) with error : $e');
+      logger.shout('Failed to connect to relay ($relayAddress:$streamingPort)'
+          ' with error : $e');
       return;
     }
 
@@ -685,8 +722,8 @@ class SrvImplDart implements Srv<SocketConnector> {
       sideASocket = await Socket.connect(localAddress, localPort);
       sideA = Side(sideASocket, true, transformer: encrypter);
     } catch (e) {
-      logger.shout(
-          'Failed to connect locally ($localAddress:$localPort) with error : $e');
+      logger.shout('Failed to connect locally ($localAddress:$localPort)'
+          ' with error : $e');
       logger.shout('Closing sideB (relay) socket connection');
       sideBSocket.destroy();
 
@@ -706,29 +743,39 @@ class SrvImplDart implements Srv<SocketConnector> {
     logger.info('socket_connector: started');
   }
 
-  Future<void> _handleControlRequest(
+  Future<void> _handleControlMessage(
     SocketConnector sc,
     InternetAddress relayAddress,
-    String request,
+    String message,
   ) async {
-    request = request.trim();
-    List<String> args = request.split(":");
+    message = message.trim();
+    List<String> args = message.split(":");
     DataTransformer? encrypter;
     DataTransformer? decrypter;
     switch (args.first) {
       case 'connect':
-        if (request != 'connect:no:encrypt') {
-          if (args.length != 3) {
-            logger.severe('Unknown request to control socket: [$request]');
+        if (message == 'connect:no:encrypt') {
+          // unencrypted session
+          encrypter = null;
+          decrypter = null;
+        } else {
+          // Encrypted session, we expect params
+          if (args.length < 3) {
+            logger.severe('Malformed control message: [$message]');
             return;
           }
           decrypter = createDecrypter(args[1], args[2]);
           encrypter = createEncrypter(args[1], args[2]);
         }
+
         await _handleMultiConnectRequest(
             sc, relayAddress, encrypter, decrypter);
+        break;
+      case 'heartbeat':
+        logger.info('Received control message: $message');
+        break;
       default:
-        logger.severe('Unknown request to control socket: [$request]');
+        logger.shout('Received unknown control message: [$message]');
         return;
     }
   }
@@ -773,21 +820,19 @@ class SrvImplDart implements Srv<SocketConnector> {
     return sc;
   }
 
+  /// Start the control stream listener on the control socket itself
+  /// since there is no encryption / decryption
   void _daemonSidePlainSocket(Socket sessionControlSocket, SocketConnector sc,
       InternetAddress relayAddress) {
-    Mutex controlStreamMutex = Mutex();
-    sessionControlSocket.listen((event) async {
-      await _sessionControlSocketListener(
-          controlStreamMutex, event, sc, relayAddress);
-    }, onError: (e) {
-      logger.severe('controlSocket error: $e');
-      sc.close();
-    }, onDone: () {
-      logger.info('controlSocket done');
-      sc.close();
-    });
+    _startDaemonControlSocketListener(
+      sessionControlSocket,
+      sessionControlSocket,
+      sc,
+      relayAddress,
+    );
   }
 
+  /// Set up encrypter & decrypter and then start the control stream listener
   void _daemonSideEncryptedSocket(Socket sessionControlSocket,
       SocketConnector sc, InternetAddress relayAddress) {
     DataTransformer controlEncrypter =
@@ -801,11 +846,86 @@ class SrvImplDart implements Srv<SocketConnector> {
     StreamController<Uint8List> controlSink = StreamController<Uint8List>();
     controlEncrypter(controlSink.stream).listen(sessionControlSocket.add);
 
+    _startDaemonControlSocketListener(
+      controlStream,
+      controlSink,
+      sc,
+      relayAddress,
+    );
+  }
+
+  void _startDaemonControlSocketListener(
+    Stream<List<int>> sessionControlStream,
+    StreamSink<List<int>> sessionControlSink,
+    SocketConnector sc,
+    InternetAddress relayAddress,
+  ) {
+    logger.info('Starting control socket listener');
+    at_commons.ByteBuffer rcvBuffer = at_commons.ByteBuffer(capacity: 4096);
     Mutex controlStreamMutex = Mutex();
-    controlStream.listen((event) async {
-      logger.info('Received event on control socket.');
-      await _sessionControlSocketListener(
-          controlStreamMutex, event, sc, relayAddress);
+    sessionControlStream.listen((data) async {
+      try {
+        await controlStreamMutex.acquire();
+        for (int element = 0; element < data.length; element++) {
+          // If it's a '\n' then complete data has been received, so process it
+          if (data[element] == newLineCodeUnit) {
+            String controlMsg = '';
+            try {
+              controlMsg = utf8.decode(rcvBuffer.getData().toList()).trim();
+              try {
+                if (controlMsg.isEmpty) {
+                  logger.info('Empty control message (Uint8List) received');
+                  return;
+                }
+                await _handleControlMessage(sc, relayAddress, controlMsg);
+              } catch (e, st) {
+                logger.shout(
+                    'Caught (will rethrow) error: $e\nStack Trace:\n$st');
+                rethrow;
+              }
+            } catch (e) {
+              logger.severe('$e while handling control message: $controlMsg');
+            } finally {
+              rcvBuffer.clear();
+            }
+          } else {
+            rcvBuffer.addByte(data[element]);
+            // Backwards compatibility for clients prior to 5.6.1
+            // IF we're at the LAST byte in the received data
+            // AND the rcvBuffer length is currently *precisely* an exact
+            // multiple of the length of
+            //   'connect:$socketAESKey:$socketIV'
+            //       7   1     44      1   24
+            // i.e. an exact multiple of 77
+            // THEN we should also go ahead and process the request (or requests)
+            int oldMagic = 7 + 1 + 44 + 1 + 24;
+            if (element == data.length - 1) {
+              if (rcvBuffer.length() % oldMagic == 0) {
+                logger.shout('Backwards compatibility handler will process'
+                    ' ${rcvBuffer.length() / oldMagic} messages');
+                try {
+                  List<int> toProcess = rcvBuffer.getData().toList();
+                  while (toProcess.isNotEmpty) {
+                    String controlMsg =
+                        utf8.decode(toProcess.sublist(0, oldMagic)).trim();
+                    toProcess = toProcess.sublist(oldMagic);
+                    try {
+                      await _handleControlMessage(sc, relayAddress, controlMsg);
+                    } catch (e) {
+                      logger.severe(
+                          '$e while handling control message: $controlMsg');
+                    }
+                  }
+                } finally {
+                  rcvBuffer.clear();
+                }
+              }
+            }
+          }
+        }
+      } finally {
+        controlStreamMutex.release();
+      }
     }, onError: (e) {
       logger.severe('controlSocket error: $e');
       sc.close();
@@ -813,45 +933,6 @@ class SrvImplDart implements Srv<SocketConnector> {
       logger.info('controlSocket done');
       sc.close();
     });
-  }
-
-  Future<void> _sessionControlSocketListener(Mutex controlStreamMutex,
-      List<int> event, SocketConnector sc, InternetAddress relayAddress) async {
-    try {
-      await controlStreamMutex.acquire();
-      if (event.isEmpty) {
-        logger.info('Empty control message (Uint8List) received');
-        return;
-      }
-      String eventStr = String.fromCharCodes(event).trim();
-      if (eventStr.isEmpty) {
-        logger.info('Empty control message (String) received');
-        return;
-      }
-      // TODO The code below (splitting by `connect:`) resolves a
-      // particular issue for the moment, but the overall approach
-      // to handling control messages needs to be redone, e.g. :
-      // Ideally - send the control request, and a newline
-      //   => as of this commit, this is the case
-      // Receive - wait for newline, handle the request, repeat
-      //   => older npt clients don't send `\n` so we will need to add some
-      //      magic to handle both (a) older clients which don't send `\n`
-      //      as well as (b) newer ones which do. Cleanest is to add a
-      //      flag to the npt request from the client stating that it sends
-      //      `\n` . If so then we handle that cleanly; if not then we use
-      //      this approach (split by `connect:`)
-      List<String> requests = eventStr.split('connect:');
-      for (String request in requests) {
-        if (request.isNotEmpty) {
-          await _handleControlRequest(sc, relayAddress, 'connect:$request');
-        }
-      }
-    } catch (e, st) {
-      logger.shout('Caught (will rethrow) error: $e\nStack Trace:\n$st');
-      rethrow;
-    } finally {
-      controlStreamMutex.release();
-    }
   }
 
   Future<InternetAddress> resolveRequestedLocalHost() async {

--- a/packages/dart/noports_core/lib/src/srv/srv_impl.dart
+++ b/packages/dart/noports_core/lib/src/srv/srv_impl.dart
@@ -52,7 +52,7 @@ class SrvImplExec implements Srv<Process> {
   final Duration timeout;
 
   @override
-  final Duration heartbeat;
+  final Duration? controlChannelHeartbeat;
 
   SrvImplExec(
     this.streamingHost,
@@ -65,7 +65,7 @@ class SrvImplExec implements Srv<Process> {
     this.sessionIVString,
     required this.multi,
     required this.timeout,
-    required this.heartbeat,
+    this.controlChannelHeartbeat,
   }) {
     if (localPort == null) {
       throw ArgumentError('localPort must be non-null');
@@ -99,9 +99,11 @@ class SrvImplExec implements Srv<Process> {
       localHost ?? 'localhost',
       '--timeout',
       timeout.inSeconds.toString(),
-      '--heartbeat',
-      heartbeat.inSeconds.toString(),
     ];
+    if (controlChannelHeartbeat != null) {
+      rvArgs.addAll(
+          ['--heartbeat', controlChannelHeartbeat!.inSeconds.toString()]);
+    }
     if (multi) {
       rvArgs.add('--multi');
     }
@@ -203,7 +205,7 @@ class SrvImplInline implements Srv<SSHSocket> {
   final Duration timeout;
 
   @override
-  final Duration heartbeat;
+  final Duration? controlChannelHeartbeat;
 
   SrvImplInline(
     this.streamingHost,
@@ -213,7 +215,7 @@ class SrvImplInline implements Srv<SSHSocket> {
     this.sessionIVString,
     this.multi = false,
     required this.timeout,
-    required this.heartbeat,
+    required this.controlChannelHeartbeat,
   }) {
     if ((sessionAESKeyString == null && sessionIVString != null) ||
         (sessionAESKeyString != null && sessionIVString == null)) {
@@ -361,7 +363,7 @@ class SrvImplDart implements Srv<SocketConnector> {
   final Duration timeout;
 
   @override
-  final Duration heartbeat;
+  final Duration? controlChannelHeartbeat;
 
   final AtSignLogger logger = AtSignLogger(' SrvImplDart ');
 
@@ -377,7 +379,7 @@ class SrvImplDart implements Srv<SocketConnector> {
     this.multi = false,
     required this.detached,
     required this.timeout,
-    required this.heartbeat,
+    this.controlChannelHeartbeat,
   }) {
     logger.info('New SrvImplDart - localPort $localPort');
     if ((sessionAESKeyString == null && sessionIVString != null) ||
@@ -526,10 +528,10 @@ class SrvImplDart implements Srv<SocketConnector> {
     Socket sessionControlSocket = await Socket.connect(
         streamingHost, streamingPort,
         timeout: Duration(seconds: 10));
-    // Authenticate the control socket
+    // Authenticate the control channel
     if (rvdAuthString != null) {
       logger.info('_runClientSideMulti authenticating'
-          ' control socket connection to rvd');
+          ' control channel connection to rvd');
       sessionControlSocket.writeln(rvdAuthString);
     }
 
@@ -546,7 +548,7 @@ class SrvImplDart implements Srv<SocketConnector> {
     }
 
     logger.info('_runClientSideMulti serverToSocket is ready');
-    // upon socketConnector.done, destroy the control socket, and complete
+    // upon socketConnector.done, destroy the control channel, and complete
     unawaited(socketConnector.done.whenComplete(() {
       logger.info('_runClientSideMulti sc.done');
       sessionControlSocket.destroy();
@@ -563,7 +565,7 @@ class SrvImplDart implements Srv<SocketConnector> {
     sessionControlSocket.listen((event) {
       String response = String.fromCharCodes(event).trim();
       logger.info('_runClientSideMulti'
-          ' Received control socket response: [$response]');
+          ' Received control channel response: [$response]');
     }, onError: (e) {
       logger.severe('_runClientSideMulti controlSocket error: $e');
       socketConnector?.close();
@@ -615,7 +617,7 @@ class SrvImplDart implements Srv<SocketConnector> {
     controlStream.listen((event) {
       String response = String.fromCharCodes(event).trim();
       logger.info('_runClientSideMulti'
-          ' Received control socket response: [$response]');
+          ' Received control channel response: [$response]');
     }, onError: (e) {
       logger.severe('_runClientSideMulti controlSocket error: $e');
       socketConnector?.close();
@@ -624,24 +626,26 @@ class SrvImplDart implements Srv<SocketConnector> {
       socketConnector?.close();
     });
 
-    bool heartbeatInProgress = false;
-    int heartbeatCounter = 1;
-    Timer.periodic(heartbeat, (timer) async {
-      if (heartbeatInProgress) {
-        logger.warning('Control socket heartbeat already in progress');
-        return;
-      }
-      try {
-        heartbeatInProgress = true;
-        logger.info('Sending heartbeat $heartbeatCounter on control socket');
-        controlSink.add(
-          Uint8List.fromList('heartbeat:$heartbeatCounter\n'.codeUnits),
-        );
-        heartbeatCounter++;
-      } finally {
-        heartbeatInProgress = false;
-      }
-    });
+    if (controlChannelHeartbeat != null) {
+      bool heartbeatInProgress = false;
+      int heartbeatCounter = 1;
+      Timer.periodic(controlChannelHeartbeat!, (timer) async {
+        if (heartbeatInProgress) {
+          logger.warning('control channel heartbeat already in progress');
+          return;
+        }
+        try {
+          heartbeatInProgress = true;
+          logger.info('Sending heartbeat $heartbeatCounter on control channel');
+          controlSink.add(
+            Uint8List.fromList('heartbeat:$heartbeatCounter\n'.codeUnits),
+          );
+          heartbeatCounter++;
+        } finally {
+          heartbeatInProgress = false;
+        }
+      });
+    }
 
     logger.info('_runClientSideMulti calling SocketConnector.serverToSocket');
     socketConnector = await SocketConnector.serverToSocket(
@@ -681,7 +685,7 @@ class SrvImplDart implements Srv<SocketConnector> {
     DataTransformer? decrypter,
   ) async {
     logger.info('_runDaemonSideMulti'
-        ' Control socket received connect request - '
+        ' control channel received connect request - '
         ' creating new socketToSocket connection');
 
     InternetAddress localAddress = await resolveRequestedLocalHost();
@@ -790,15 +794,15 @@ class SrvImplDart implements Srv<SocketConnector> {
       logger: ioSinkForLogger(logger),
     );
 
-    // - create control socket and listen for requests
+    // - create control channel and listen for requests
     // - for each request, create a socketToSocket connection
     Socket sessionControlSocket = await Socket.connect(
         streamingHost, streamingPort,
         timeout: Duration(seconds: 10));
-    // Authenticate the control socket
+    // Authenticate the control channel
     if (rvdAuthString != null) {
       logger.info('_runDaemonSideMulti authenticating'
-          ' control socket connection to rvd');
+          ' control channel connection to rvd');
       sessionControlSocket.writeln(rvdAuthString);
     }
 
@@ -812,7 +816,7 @@ class SrvImplDart implements Srv<SocketConnector> {
       _daemonSidePlainSocket(sessionControlSocket, sc, relayAddress);
     }
 
-    // upon socketConnector.done, destroy the control socket, and complete
+    // upon socketConnector.done, destroy the control channel, and complete
     unawaited(sc.done.whenComplete(() {
       sessionControlSocket.destroy();
     }));
@@ -820,7 +824,7 @@ class SrvImplDart implements Srv<SocketConnector> {
     return sc;
   }
 
-  /// Start the control stream listener on the control socket itself
+  /// Start the control stream listener on the control channel itself
   /// since there is no encryption / decryption
   void _daemonSidePlainSocket(Socket sessionControlSocket, SocketConnector sc,
       InternetAddress relayAddress) {
@@ -860,7 +864,7 @@ class SrvImplDart implements Srv<SocketConnector> {
     SocketConnector sc,
     InternetAddress relayAddress,
   ) {
-    logger.info('Starting control socket listener');
+    logger.info('Starting control channel listener');
     at_commons.ByteBuffer rcvBuffer = at_commons.ByteBuffer(capacity: 4096);
     Mutex controlStreamMutex = Mutex();
     sessionControlStream.listen((data) async {

--- a/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
@@ -137,6 +137,9 @@ class NptParams extends ClientParamsBase
   /// How long to keep the local port open if there have been no connections
   final Duration timeout;
 
+  /// Interval between heartbeats on the control socket.
+  final Duration heartbeat;
+
   NptParams({
     required super.clientAtSign,
     required super.sshnpdAtSign,
@@ -154,6 +157,7 @@ class NptParams extends ClientParamsBase
     required this.inline,
     super.daemonPingTimeout,
     required this.timeout,
+    this.heartbeat = DefaultArgs.controlSocketHeartbeatInterval,
   }) {
     try {
       AtUtils.fixAtSign(clientAtSign);

--- a/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
@@ -137,8 +137,8 @@ class NptParams extends ClientParamsBase
   /// How long to keep the local port open if there have been no connections
   final Duration timeout;
 
-  /// Interval between heartbeats on the control socket.
-  final Duration heartbeat;
+  /// Interval between heartbeats on the control channel.
+  final Duration? controlChannelHeartbeat;
 
   NptParams({
     required super.clientAtSign,
@@ -157,7 +157,7 @@ class NptParams extends ClientParamsBase
     required this.inline,
     super.daemonPingTimeout,
     required this.timeout,
-    this.heartbeat = DefaultArgs.controlSocketHeartbeatInterval,
+    this.controlChannelHeartbeat,
   }) {
     try {
       AtUtils.fixAtSign(clientAtSign);

--- a/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/srvd_channel.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/srvd_channel.dart
@@ -99,7 +99,7 @@ abstract class SrvdChannel<T> with AsyncInitialization, AtClientBindings {
     bool multi = false,
     bool detached = false,
     Duration timeout = DefaultArgs.srvTimeout,
-    Duration heartbeat = DefaultArgs.controlSocketHeartbeatInterval,
+    Duration? controlChannelHeartbeat,
   }) async {
     await callInitialization();
 
@@ -125,7 +125,7 @@ abstract class SrvdChannel<T> with AsyncInitialization, AtClientBindings {
       multi: multi,
       detached: detached,
       timeout: timeout,
-      heartbeat: heartbeat,
+      controlChannelHeartbeat: controlChannelHeartbeat,
     );
     return srv.run();
   }

--- a/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/srvd_channel.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/srvd_channel.dart
@@ -99,6 +99,7 @@ abstract class SrvdChannel<T> with AsyncInitialization, AtClientBindings {
     bool multi = false,
     bool detached = false,
     Duration timeout = DefaultArgs.srvTimeout,
+    Duration heartbeat = DefaultArgs.controlSocketHeartbeatInterval,
   }) async {
     await callInitialization();
 
@@ -124,6 +125,7 @@ abstract class SrvdChannel<T> with AsyncInitialization, AtClientBindings {
       multi: multi,
       detached: detached,
       timeout: timeout,
+      heartbeat: heartbeat,
     );
     return srv.run();
   }

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -143,7 +143,7 @@ class SshnpdImpl with AtClientBindings implements Sshnpd {
         DaemonFeature.controlChannelHeartbeats.name: true,
       },
       'allowedServices': permitOpen,
-      'npCpV': DaemonFeature.latestVersion,
+      'npCpVersion': DaemonFeature.latestVersion.toString(),
     };
   }
 

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -140,6 +140,7 @@ class SshnpdImpl with AtClientBindings implements Sshnpd {
         DaemonFeature.acceptsPublicKeys.name: addSshPublicKeys,
         DaemonFeature.supportsPortChoice.name: true,
         DaemonFeature.adjustableTimeout.name: true,
+        DaemonFeature.controlChannelHeartbeats.name: true,
       },
       'allowedServices': permitOpen,
     };

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -143,6 +143,7 @@ class SshnpdImpl with AtClientBindings implements Sshnpd {
         DaemonFeature.controlChannelHeartbeats.name: true,
       },
       'allowedServices': permitOpen,
+      'npCpV': DaemonFeature.latestVersion,
     };
   }
 

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   uuid: ^3.0.7
   mutex: ^3.1.0
   json_annotation: ^4.9.0
+  version: ^3.0.2
 
 dependency_overrides:
   dartssh2:

--- a/packages/dart/noports_core/test/sshnp/util/srvd_channel/srvd_channel_mocks.dart
+++ b/packages/dart/noports_core/test/sshnp/util/srvd_channel/srvd_channel_mocks.dart
@@ -17,6 +17,7 @@ abstract class SrvGeneratorCaller<T> {
     bool multi = false,
     bool detached = false,
     Duration timeout = DefaultArgs.srvTimeout,
+    Duration heartbeat = DefaultArgs.controlSocketHeartbeatInterval,
   });
 }
 

--- a/packages/dart/noports_core/test/sshnp/util/srvd_channel/srvd_channel_mocks.dart
+++ b/packages/dart/noports_core/test/sshnp/util/srvd_channel/srvd_channel_mocks.dart
@@ -17,7 +17,7 @@ abstract class SrvGeneratorCaller<T> {
     bool multi = false,
     bool detached = false,
     Duration timeout = DefaultArgs.srvTimeout,
-    Duration heartbeat = DefaultArgs.controlSocketHeartbeatInterval,
+    Duration? controlChannelHeartbeat,
   });
 }
 

--- a/packages/dart/sshnoports/bin/npt.dart
+++ b/packages/dart/sshnoports/bin/npt.dart
@@ -201,6 +201,20 @@ void main(List<String> args) async {
             ' it has started its session.',
       );
 
+      parser.addOption(
+        'heartbeat',
+        abbr: 'H',
+        mandatory: false,
+        defaultsTo: '${DefaultArgs.controlSocketHeartbeatIntervalMins}m',
+        help: 'How frequently to send heartbeats on the connection\'s'
+            ' control socket. Heartbeats are an attempt to persuade zealous'
+            ' network intermediaries that the control socket shouldn\'t be'
+            ' closed due to lack of activity.'
+            ' Argument must be supplied in human readable'
+            ' form e.g. as follows: "30s" or "1h" or "1h,14m,30s"'
+            ' or "7d".',
+      );
+
       parser.addFlag(
         'encrypt-rvd-traffic',
         aliases: ['et'],
@@ -324,6 +338,7 @@ void main(List<String> args) async {
             ' setting timeout to $keepAliveDefaultTimeoutHours hours');
         timeoutArg = '${keepAliveDefaultTimeoutHours}h';
       }
+
       NptParams params = NptParams(
         clientAtSign: clientAtSign,
         sshnpdAtSign: daemonAtSign,
@@ -339,6 +354,7 @@ void main(List<String> args) async {
             Duration(seconds: int.parse(parsedArgs['daemon-ping-timeout'])),
         encryptRvdTraffic: parsedArgs['encrypt-rvd-traffic'],
         timeout: parseDuration(timeoutArg),
+        heartbeat: parseDuration(parsedArgs['heartbeat']),
       );
 
       while (true) {

--- a/packages/dart/sshnoports/bin/npt.dart
+++ b/packages/dart/sshnoports/bin/npt.dart
@@ -205,11 +205,12 @@ void main(List<String> args) async {
         'heartbeat',
         abbr: 'H',
         mandatory: false,
-        defaultsTo: '${DefaultArgs.controlSocketHeartbeatIntervalMins}m',
+        defaultsTo: '${DefaultArgs.controlChannelHeartbeatIntervalMins}m',
         help: 'How frequently to send heartbeats on the connection\'s'
-            ' control socket. Heartbeats are an attempt to persuade zealous'
-            ' network intermediaries that the control socket shouldn\'t be'
-            ' closed due to lack of activity.'
+            ' control channel. Heartbeats are an attempt to persuade zealous'
+            ' network intermediaries that the control channel shouldn\'t be'
+            ' closed due to lack of activity. Heartbeats will not be sent'
+            ' to older daemons which do not support them.'
             ' Argument must be supplied in human readable'
             ' form e.g. as follows: "30s" or "1h" or "1h,14m,30s"'
             ' or "7d".',
@@ -354,7 +355,7 @@ void main(List<String> args) async {
             Duration(seconds: int.parse(parsedArgs['daemon-ping-timeout'])),
         encryptRvdTraffic: parsedArgs['encrypt-rvd-traffic'],
         timeout: parseDuration(timeoutArg),
-        heartbeat: parseDuration(parsedArgs['heartbeat']),
+        controlChannelHeartbeat: parseDuration(parsedArgs['heartbeat']),
       );
 
       while (true) {

--- a/packages/dart/sshnoports/bin/srv.dart
+++ b/packages/dart/sshnoports/bin/srv.dart
@@ -59,6 +59,10 @@ Future<void> main(List<String> args) async {
             ' On the client side this is the local port which the srv will bind'
             ' to so that client-side programs can create sockets to it.')
     ..addOption('timeout',
+        defaultsTo: '1800',
+        help: 'How frequently to send heartbeats on the connection\'s'
+            ' control socket. Defaults to 30 minutes (1800 seconds)')
+    ..addOption('timeout',
         defaultsTo: '60',
         help: 'How long to keep the SocketConnector open'
             ' if there have been no connections')
@@ -100,6 +104,8 @@ Future<void> main(List<String> args) async {
       final bool rvE2ee = parsed['rv-e2ee'];
       final bool multi = parsed['multi'];
       final Duration timeout = Duration(seconds: int.parse(parsed['timeout']));
+      final Duration heartbeat =
+          Duration(seconds: int.parse(parsed['heartbeat']));
 
       String? rvdAuthString = rvAuth ? Platform.environment['RV_AUTH'] : null;
       String? sessionAESKeyString =
@@ -132,6 +138,7 @@ Future<void> main(List<String> args) async {
         detached: true,
         // by definition - this is the srv binary
         timeout: timeout,
+        heartbeat: heartbeat,
       ).run();
     } on ArgumentError catch (e) {
       printVersion();

--- a/packages/dart/sshnoports/bin/srv.dart
+++ b/packages/dart/sshnoports/bin/srv.dart
@@ -58,7 +58,7 @@ Future<void> main(List<String> args) async {
         help: 'On the daemon side, this is the local port to connect to.'
             ' On the client side this is the local port which the srv will bind'
             ' to so that client-side programs can create sockets to it.')
-    ..addOption('timeout',
+    ..addOption('heartbeat',
         defaultsTo: '1800',
         help: 'How frequently to send heartbeats on the connection\'s'
             ' control socket. Defaults to 30 minutes (1800 seconds)')

--- a/packages/dart/sshnoports/bin/srv.dart
+++ b/packages/dart/sshnoports/bin/srv.dart
@@ -61,7 +61,7 @@ Future<void> main(List<String> args) async {
     ..addOption('heartbeat',
         defaultsTo: '1800',
         help: 'How frequently to send heartbeats on the connection\'s'
-            ' control socket. Defaults to 30 minutes (1800 seconds)')
+            ' control channel. Defaults to 30 minutes (1800 seconds)')
     ..addOption('timeout',
         defaultsTo: '60',
         help: 'How long to keep the SocketConnector open'
@@ -138,7 +138,7 @@ Future<void> main(List<String> args) async {
         detached: true,
         // by definition - this is the srv binary
         timeout: timeout,
-        heartbeat: heartbeat,
+        controlChannelHeartbeat: heartbeat,
       ).run();
     } on ArgumentError catch (e) {
       printVersion();

--- a/tests/e2e_all/scripts/main.sh
+++ b/tests/e2e_all/scripts/main.sh
@@ -49,7 +49,7 @@ atDirectoryPort=64
 testsToRun="all"
 
 # defaultDaemonVersions="c:current"
-defaultDaemonVersions="d:5.5.0 d:5.8.7 d:current"
+defaultDaemonVersions="d:5.5.0 d:5.8.7 d:current c:current"
 defaultClientVersions="d:5.5.0 d:5.8.7 d:current"
 
 daemonVersions=$defaultDaemonVersions

--- a/tests/e2e_all/scripts/main.sh
+++ b/tests/e2e_all/scripts/main.sh
@@ -48,8 +48,8 @@ atDirectoryHost=root.atsign.org
 atDirectoryPort=64
 testsToRun="all"
 
-# defaultDaemonVersions="c:current"
-defaultDaemonVersions="d:5.5.0 d:5.8.7 d:current c:current"
+# defaultDaemonVersions="d:5.5.0 d:5.8.7 d:current c:current"
+defaultDaemonVersions="d:5.5.0 d:5.8.7 d:current"
 defaultClientVersions="d:5.5.0 d:5.8.7 d:current"
 
 daemonVersions=$defaultDaemonVersions

--- a/tests/e2e_all/scripts/main.sh
+++ b/tests/e2e_all/scripts/main.sh
@@ -48,8 +48,8 @@ atDirectoryHost=root.atsign.org
 atDirectoryPort=64
 testsToRun="all"
 
-# defaultDaemonVersions="d:5.5.0 d:5.8.7 d:current c:current"
-defaultDaemonVersions="d:5.5.0 d:5.8.7 d:current"
+# defaultDaemonVersions="c:current"
+defaultDaemonVersions="d:5.5.0 d:5.8.7 d:current c:current"
 defaultClientVersions="d:5.5.0 d:5.8.7 d:current"
 
 daemonVersions=$defaultDaemonVersions

--- a/tests/e2e_all/scripts/main.sh
+++ b/tests/e2e_all/scripts/main.sh
@@ -49,7 +49,7 @@ atDirectoryPort=64
 testsToRun="all"
 
 # defaultDaemonVersions="c:current"
-defaultDaemonVersions="d:5.5.0 d:5.8.7 d:current c:current"
+defaultDaemonVersions="d:5.5.0 d:5.8.7 d:current"
 defaultClientVersions="d:5.5.0 d:5.8.7 d:current"
 
 daemonVersions=$defaultDaemonVersions


### PR DESCRIPTION
**- What I did**
- feat: changes for sending a heartbeat over the npt control socket. Heartbeats are intended to persuade zealous network intermediaries that the control socket is not in fact dead.
- fix: Also took care of some technical debt in the control socket message handling.

**- How I did it**
- See commits

**- How to verify it**
- Automated tests pass
- Manually tested for races etc by setting a heartbeat interval of 250ms for an npt session and then continually refreshing my web browser
- Manually tested with npt version 5.2.0 to verify backwards compatibility of control message handling