### PR TITLE
fix: CMake search paths for cross compile

### DIFF
--- a/packages/c/CMakeLists.txt
+++ b/packages/c/CMakeLists.txt
@@ -14,7 +14,7 @@ set(ATSDK_USE_SHARED_LIBS ${NOPORTS_USE_SHARED_LIBS})
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(noports VERSION 1.0.9 LANGUAGES C)
+project(noports VERSION 1.0.10 LANGUAGES C)
 
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/CPackSetup.cmake")
 

--- a/packages/c/cmake/CPackSetup.cmake
+++ b/packages/c/cmake/CPackSetup.cmake
@@ -1,7 +1,7 @@
 # package info
 set(CPACK_PACKAGE_NAME noports)
 set(CPACK_PACKAGE_DESCRIPTION "noports source tarballs")
-set(CPACK_PACKAGE_VERSION 1.0.9)
+set(CPACK_PACKAGE_VERSION 1.0.10)
 set(CPACK_PACKAGE_VENDOR_NAME atsign-foundation)
 
 # cmake configuration

--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -12,7 +12,7 @@ if(NOT atsdk_FOUND)
     FetchContent_Declare(
       atsdk
       GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-      GIT_TAG 31b514ce1973d4cf2001b43a9e4481721826d641
+      GIT_TAG d9e9349a3a8bf220241bd706f76351a01cdbf11d
     )
   endif()
   FetchContent_MakeAvailable(atsdk)

--- a/packages/c/graceful-shutdown-tool/CMakeLists.txt
+++ b/packages/c/graceful-shutdown-tool/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(graceful-shutdown-tool VERSION 1.0.9 LANGUAGES C)
+project(graceful-shutdown-tool VERSION 1.0.10 LANGUAGES C)
 
 include(FetchContent)
 include(GNUInstallDirs)

--- a/packages/c/srv/CMakeLists.txt
+++ b/packages/c/srv/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
 
-project(srv VERSION 1.0.9 LANGUAGES C)
+project(srv VERSION 1.0.10 LANGUAGES C)
 
 # 1. Variables - you are free to edit anything in this step
 
@@ -79,12 +79,6 @@ if(NOPORTS_USE_SHARED_LIBS)
     NAMES libmbedtls.so
     PATHS /usr/lib /usr/lib64 /usr/local/lib NO_CACHE
     REQUIRED
-    NO_DEFAULT_PATH
-    NO_PACKAGE_ROOT_PATH
-    NO_CMAKE_PATH
-    NO_CMAKE_ENVIRONMENT_PATH
-    NO_CMAKE_SYSTEM_PATH
-    NO_CMAKE_INSTALL_PREFIX
   )
   list(APPEND link_libs ${mbedtls_lib_path})
 else()

--- a/packages/c/sshnpd/CHANGELOG.md
+++ b/packages/c/sshnpd/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.10
+
+- fix: CMake search paths for cross compile
+
 ## 1.0.9
 
 - feat: add support for linking against shared third party dependencies

--- a/packages/c/sshnpd/CMakeLists.txt
+++ b/packages/c/sshnpd/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(sshnpd VERSION 1.0.9 LANGUAGES C)
+project(sshnpd VERSION 1.0.10 LANGUAGES C)
 
 # 1. Variables - you are free to edit anything in this step
 
@@ -117,12 +117,6 @@ if(NOPORTS_USE_SHARED_LIBS)
     NAMES libcjson.so
     PATHS /usr/lib /usr/lib64 /usr/local/lib NO_CACHE
     REQUIRED
-    NO_DEFAULT_PATH
-    NO_PACKAGE_ROOT_PATH
-    NO_CMAKE_PATH
-    NO_CMAKE_ENVIRONMENT_PATH
-    NO_CMAKE_SYSTEM_PATH
-    NO_CMAKE_INSTALL_PREFIX
   )
   list(APPEND link_libs ${cjson_lib_path})
 else()

--- a/packages/c/sshnpd/include/sshnpd/version.h
+++ b/packages/c/sshnpd/include/sshnpd/version.h
@@ -1,4 +1,4 @@
 #ifndef SSHNPD_VERSION_H
 #define SSHNPD_VERSION_H
-#define SSHNPD_VERSION "1.0.9"
+#define SSHNPD_VERSION "1.0.10"
 #endif


### PR DESCRIPTION
Building with shared libraries in a cross compiler environment was failing due to flags.

**- What I did**

* Removed flags
* Bumped version to c1.0.10

**- How to verify it**

I've build a source package against this branch and then built an OpenWrt package from it.

**- Description for the changelog**

fix: CMake search paths for cross compile
