### PR TITLE
feat: e2e tests `-n` functionality

### DIFF
--- a/tests/e2e_all/scripts/common/build_docker_daemons.sh
+++ b/tests/e2e_all/scripts/common/build_docker_daemons.sh
@@ -11,7 +11,17 @@ source "$testScriptsDir/common/check_env.include.sh" || exit $?
 dockerfilesDir="$(dirname "$0")/../../dockerfiles"
 cd "$dockerfilesDir"/../../.. # go to root of the repo
 
-pullBaseRuntime() {
+isImageExists() {
+  imageName="$1" # e.g. "atsigncompany/noports_e2e_all_base_runtime:latest"
+  sudo docker image inspect "$imageName" > /dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+pullBaseRuntimeImage() {
   logInfo "Pulling base runtime image"
   imageName="atsigncompany/noports_e2e_all_base_runtime:latest"
   sudo docker pull $imageName --quiet
@@ -23,45 +33,59 @@ pullBaseRuntime() {
   return 0
 }
 
-buildBaseRuntime() {
+baseRuntimeImageName=$(getBaseRuntimeImageName)
+
+buildBaseRuntimeImage() {
   logInfo "Building Dockerfile.base.runtime"
   sudo docker build \
     -f $dockerfilesDir/Dockerfile.base.runtime \
-    -t atsigncompany/noports_e2e_all_base_runtime:latest \
+    -t $baseRuntimeImageName \
     --quiet \
     .
 }
 
-buildAllDockerDaemons() {
-  logInfo "Building all docker daemons for $daemonVersions"
-  if [ "${allowParallelization}" = "true" ]; then
-    buildDockerDaemonPids=()
-    for typeAndVersion in $daemonVersions; do
-      # typeAndVersion is a string like "d:4.0.5" or "c:current"
-      type=$(echo "$typeAndVersion" | cut -d: -f1)
-      version=$(echo "$typeAndVersion" | cut -d: -f2)
-      logInfo "Building docker daemon for type $type and version $version"
-
-      buildDockerDaemon "$type" "$version" &
-      pid=$!
-      buildDockerDaemonPids+=($pid)
-    done
-    for pid in "${buildDockerDaemonPids[@]}"; do
-      wait $pid
-    done
-  else
-    for typeAndVersion in $daemonVersions; do
-      # typeAndVersion is a string like "d:4.0.5" or "c:current"
-      type=$(echo "$typeAndVersion" | cut -d: -f1)
-      version=$(echo "$typeAndVersion" | cut -d: -f2)
-      logInfo "Building docker daemon for type $type and version $version"
-      buildDockerDaemon "$type" "$version"
-    done
-  fi
-}
-
-if ! pullBaseRuntime; then
-  logInfo "Pulling base runtime failed, building it locally"
-  buildBaseRuntime
+if [ "$(isImageExists "$baseRuntimeImageName")" = "false" ]; then
+  logInfo "Base runtime image not found, building it locally"
+  buildBaseRuntimeImage
 fi
-buildAllDockerDaemons
+
+if [ "${allowParallelization}" = "true" ]; then
+  # build in parallel
+  logInfo "Building all docker daemons for $daemonVersions in parallel"
+  buildDockerDaemonPids=()
+  for typeAndVersion in $daemonVersions; do
+    # typeAndVersion is a string like "d:4.0.5" or "c:current"
+    type=$(echo "$typeAndVersion" | cut -d: -f1)
+    version=$(echo "$typeAndVersion" | cut -d: -f2)
+
+    imageName=$(getDockerDaemonImageName "$type" "$version")
+    if [[ "$recompile" == "false" && "$(isImageExists "$imageName")" == "true" && "$version" != "current" ]]; then
+      logInfo "You set recompile = $recompile and $imageName already exists, so skipping build for $typeAndVersion"
+      continue
+    fi
+
+    logInfo "Building docker daemon for type $type and version $version"
+    buildDockerDaemon "$type" "$version" &
+    pid=$!
+    buildDockerDaemonPids+=($pid)
+  done
+  for pid in "${buildDockerDaemonPids[@]}"; do
+    wait $pid
+  done
+else
+  # build sequentially
+  logInfo "Building all docker daemons for $daemonVersions sequentially"
+  for typeAndVersion in $daemonVersions; do
+    # typeAndVersion is a string like "d:4.0.5" or "c:current"
+    type=$(echo "$typeAndVersion" | cut -d: -f1)
+    version=$(echo "$typeAndVersion" | cut -d: -f2)
+    imageName=$(getDockerDaemonImageName "$type" "$version")
+    if [ "$(isImageExists "$imageName")" = "true" && $recompile = "true"]; then
+      logInfo "You set $recompile = true (using -n) and $imageName already exists, so skipping build for $typeAndVersion"
+      continue
+    fi
+
+    logInfo "Building docker daemon for type $type and version $version"
+    buildDockerDaemon "$type" "$version"
+  done
+fi

--- a/tests/e2e_all/scripts/common/build_docker_daemons.sh
+++ b/tests/e2e_all/scripts/common/build_docker_daemons.sh
@@ -59,7 +59,7 @@ if [ "${allowParallelization}" = "true" ]; then
     version=$(echo "$typeAndVersion" | cut -d: -f2)
 
     imageName=$(getDockerDaemonImageName "$type" "$version")
-    if [[ "$recompile" == "false" && "$(isImageExists "$imageName")" == "true" && "$version" != "current" ]]; then
+    if [[ "$recompile" == "false" && "$(isImageExists "$imageName")" == "true" ]]; then
       logInfo "You set recompile = $recompile and $imageName already exists, so skipping build for $typeAndVersion"
       continue
     fi

--- a/tests/e2e_all/scripts/common/common_functions.include.sh
+++ b/tests/e2e_all/scripts/common/common_functions.include.sh
@@ -364,14 +364,14 @@ getPathToBinariesForTypeAndVersion() {
   esac
 }
 
-setup_type_and_version() {
+setUpTypeAndVersion() {
   IFS=: read -r type version <<<"$1"
   case "$type" in
     d) # dart
-      setupDartVersion "$version" || logErrorAndExit "Failed to set up binaries for dart version [$version]"
+      setUpDartVersion "$version" || logErrorAndExit "Failed to set up binaries for dart version [$version]"
       ;;
     c) # c
-      setupCVersion "$version" || logErrorAndExit "Failed to set up binaries for c version [$version]"
+      setUpCVersionersion "$version" || logErrorAndExit "Failed to set up binaries for c version [$version]"
       ;;
     *)
       logErrorAndExit "This script doesn't know where to find NoPorts daemon binary for [$typeAndVersion]"
@@ -397,7 +397,7 @@ getDartReleaseBinDirForVersion() {
   echo "$testRootDir/releases/dart.$version/sshnp"
 }
 
-setupDartVersion() {
+setUpDartVersion() {
   version="$1"
 
   if test "$version" = "current"; then
@@ -526,7 +526,7 @@ getCCompilationOutputDir() {
   echo "$testRuntimeDir/binaries/c.branch"
 }
 
-setupCVersion() {
+setUpCVersionersion() {
   version="$1"
 
   if test "$version" = "current"; then
@@ -545,7 +545,7 @@ buildCurrentCBinaries() {
   binaryOutputDir=$(getCCompilationOutputDir)
   mkdir -p "$binaryOutputDir"
 
-  if [ "$recompile" = "true" ]; then
+  if [[ "$recompile" = "true" ]]; then
     cd "$binaryOutputDir" || exit 1
     rm -f activate_cli srv sshnpd srvd sshnp npt
   fi
@@ -592,30 +592,45 @@ buildCurrentCBinaries() {
 
 ### END C ###
 
-### BEGIN start_daemons.sh FUNCTIONS ###
+### BEGIN build_docker_daemons.sh and start_daemons.sh FUNCTIONS ###
+
+getDockerDaemonImageName() {
+  type="$1" # e.g. "d" or "c"
+  version="$2" # e.g. "current" or "4.0.5"
+  if [ "$version" = "current" ]; then
+      echo "atsigncompany/noports_e2e_all_$type:current"
+  else
+      echo "atsigncompany/noports_e2e_all_$type:v$version"
+  fi
+}
+
+getBaseRuntimeImageName() {
+  echo "atsigncompany/noports_e2e_all_base_runtime:latest"
+}
 
 buildDockerDaemon() {
   local type="$1"
   local version="$2"
   
-  if [[ "$type" == "d" ]]; then
+  if [ "$type" = "d" ]; then
       language="dart"
-  elif [[ "$type" == "c" ]]; then
+  elif [ "$type" = "c" ]; then
       language="c"
   else
       logErrorAndReport "Error: Unknown type: $type"
       return 1
   fi
 
-  if [[ "$version" == "current" ]]; then
+  imageName=$(getDockerDaemonImageName "$type" "$version")
+  if [ "$version" = "current" ]; then
       dockerfile="$dockerfilesDir/Dockerfile.$language.current"
-      tag="noports-$type:current"
+      tag="$imageName"
       fBuildArg=""
       fCache="--no-cache"
   else
       # assume "$version" is a release version like "4.0.5" or "5.2.0"
       dockerfile="$dockerfilesDir/Dockerfile.$language.release"
-      tag="noports-$type:v$version"
+      tag="$imageName"
       fBuildArg="--build-arg release=v$version"
       fCache=""
   fi
@@ -637,8 +652,8 @@ buildDockerDaemon() {
   local retry_count=0
   local exitCode=1
 
-  while [[ $exitCode -ne 0 && $retry_count -lt $max_retries ]]; do
-    if [[ $retry_count -gt 0 ]]; then
+  while [ $exitCode -ne 0 ] && [ $retry_count -lt $max_retries ]; do
+    if [ $retry_count -gt 0 ]; then
       logInfo "Retrying Docker build (attempt $((retry_count+1))/$max_retries)..."
       sleep 1
     fi
@@ -648,7 +663,7 @@ buildDockerDaemon() {
     retry_count=$((retry_count+1))
   done
   
-  if [[ $exitCode -ne 0 ]]; then
+  if [ $exitCode -ne 0 ]; then
       logErrorAndReport "Error: Docker build failed with exit code $exitCode after $max_retries attempts"
       return $exitCode
   else
@@ -686,11 +701,7 @@ runDockerDaemon() {
   local daemonAt="$5"
   local daemonFlags="$6"
 
-  if [[ "$version" == "current" ]]; then
-    tag="noports-$type:current"
-  else
-    tag="noports-$type:v$version"
-  fi
+  tag=$(getDockerDaemonImageName "$type" "$version")
 
   logInfo "Starting container for: Type: $type, Version: $version, atDirectory: $atDirectoryHost Flags: $daemonFlags, Device name: $deviceName, Client atSign: $clientAt, Daemon atSign: $daemonAt"
 
@@ -707,4 +718,4 @@ runDockerDaemon() {
   eval "$dockerRunCommand"
 }
 
-### END start_daemons.sh FUNCTIONS ###
+### END build_docker_daemons.sh and start_daemons.sh FUNCTIONS ###

--- a/tests/e2e_all/scripts/common/setup_binaries.sh
+++ b/tests/e2e_all/scripts/common/setup_binaries.sh
@@ -69,7 +69,7 @@ uniqueVersions=$(for ver in $allVersions; do echo "$ver"; done | sort -u | tr "\
 if [ $allowParallelization == "true" ]; then
   pids=()
   for typeAndVersion in $uniqueVersions; do
-    setup_type_and_version $typeAndVersion &
+    setUpTypeAndVersion $typeAndVersion &
     pid=$!
     pids+=($pid)
   done
@@ -82,6 +82,6 @@ if [ $allowParallelization == "true" ]; then
   done
 else
   for typeAndVersion in $uniqueVersions; do
-    setup_type_and_version $typeAndVersion
+    setUpTypeAndVersion $typeAndVersion
   done
 fi

--- a/tests/e2e_all/scripts/common/start_daemons.sh
+++ b/tests/e2e_all/scripts/common/start_daemons.sh
@@ -7,57 +7,50 @@ fi
 source "$testScriptsDir/common/common_functions.include.sh"
 source "$testScriptsDir/common/check_env.include.sh" || exit $?
 
-runAllDockerDaemons() {
-  dockerfilesDir="$(dirname "$0")/../../dockerfiles"
-  cd "$dockerfilesDir"/../../..
-
-  logFilesToCheck=()
-  for typeAndVersion in $daemonVersions; do
-    # typeAndVersion is a string like "d:4.0.5" or "c:current"
-    type=$(echo "$typeAndVersion" | cut -d: -f1)
-    version=$(echo "$typeAndVersion" | cut -d: -f2)
-
-    if [[ $(versionIsAtLeast "$typeAndVersion" "d:5.3.0") == "true" ]]; then
-      apkamApp=$(getApkamAppName)
-      apkamDev=$(getApkamDeviceName "daemon" "$commitId")
-      # keysFile=$(getApkamKeysFile "$daemonAtSign" "$apkamApp" "$apkamDev") # OLD
-
-      # the keys file is in the docker daemon
-      # e.g. /atsign/.atsign/keys/@12alpaca.e2e_all.client_2064e58.atKeys
-      keysFile="/atsign/.atsign/keys/$daemonAtSign.$apkamApp.$apkamDev".atKeys # NEW
-      extraFlags="-k $keysFile"
-    else
-      extraFlags=""
-    fi
-
-    # Run with `-s` and `-u` flags (container 1)
-    deviceName1=$(getDeviceNameWithFlags "$commitId" "$typeAndVersion")
-    logFile1="${outputDir}/daemons/${deviceName1}.log"
-    containerName1="e2e_all-$deviceName1"
-    echo "Starting daemon version $typeAndVersion with the -u and -s flags"  >> "$logFile1"
-    runDockerDaemon "$type" "$version" "$deviceName1" "$clientAtSign" "$daemonAtSign" "$extraFlags -s -u"
-    sudo docker logs -f "$containerName1" >> "$logFile1" 2>&1 &
-
-    # Run without `-s` and `u` flags (container 2)
-    deviceName2=$(getDeviceNameNoFlags "$commitId" "$typeAndVersion")
-    logFile2="${outputDir}/daemons/${deviceName2}.log"
-    containerName2="e2e_all-$deviceName2"
-    echo "Starting daemon version $typeAndVersion with neither the -u nor -s flags" >> "$logFile2"
-    runDockerDaemon "$type" "$version" "$deviceName2" "$clientAtSign" "$daemonAtSign" "$extraFlags"
-    sudo docker logs -f "$containerName2" >> "$logFile2" 2>&1 &
-
-    logFilesToCheck+=("$logFile1")
-    logFilesToCheck+=("$logFile2")
-  done
-
-  # Wait for all daemons to start
-  for logFile in "${logFilesToCheck[@]}"; do
-    logInfo "Waiting for Docker daemon with logFile \"$logFile\" to start..."
-    waitUntilDockerDaemonStarted "$logFile" 60
-  done
-}
-
 outputDir=$(getOutputDir)
 mkdir -p "${outputDir}/daemons"
 
-runAllDockerDaemons
+dockerfilesDir="$(dirname "$0")/../../dockerfiles"
+cd "$dockerfilesDir"/../../..
+
+logFilesToCheck=()
+for typeAndVersion in $daemonVersions; do
+  # typeAndVersion is a string like "d:4.0.5" or "c:current"
+  type=$(echo "$typeAndVersion" | cut -d: -f1)
+  version=$(echo "$typeAndVersion" | cut -d: -f2)
+  if [[ $(versionIsAtLeast "$typeAndVersion" "d:5.3.0") == "true" ]]; then
+    apkamApp=$(getApkamAppName)
+    apkamDev=$(getApkamDeviceName "daemon" "$commitId")
+    # keysFile=$(getApkamKeysFile "$daemonAtSign" "$apkamApp" "$apkamDev") # OLD
+    # the keys file is in the docker daemon
+    # e.g. /atsign/.atsign/keys/@12alpaca.e2e_all.client_2064e58.atKeys
+    keysFile="/atsign/.atsign/keys/$daemonAtSign.$apkamApp.$apkamDev".atKeys # NEW
+    extraFlags="-k $keysFile"
+  else
+    extraFlags=""
+  fi
+
+  # Run with `-s` and `-u` flags (container 1)
+  deviceName1=$(getDeviceNameWithFlags "$commitId" "$typeAndVersion")
+  logFile1="${outputDir}/daemons/${deviceName1}.log"
+  containerName1="e2e_all-$deviceName1"
+  echo "Starting daemon version $typeAndVersion with the -u and -s flags"  >> "$logFile1"
+  runDockerDaemon "$type" "$version" "$deviceName1" "$clientAtSign" "$daemonAtSign" "$extraFlags -s -u"
+  sudo docker logs -f "$containerName1" >> "$logFile1" 2>&1 &
+
+  # Run without `-s` and `u` flags (container 2)
+  deviceName2=$(getDeviceNameNoFlags "$commitId" "$typeAndVersion")
+  logFile2="${outputDir}/daemons/${deviceName2}.log"
+  containerName2="e2e_all-$deviceName2"
+  echo "Starting daemon version $typeAndVersion with neither the -u nor -s flags" >> "$logFile2"
+  runDockerDaemon "$type" "$version" "$deviceName2" "$clientAtSign" "$daemonAtSign" "$extraFlags"
+  sudo docker logs -f "$containerName2" >> "$logFile2" 2>&1 &
+  logFilesToCheck+=("$logFile1")
+  logFilesToCheck+=("$logFile2")
+done
+
+# Wait for all daemons to start
+for logFile in "${logFilesToCheck[@]}"; do
+  logInfo "Waiting for Docker daemon with logFile \"$logFile\" to start..."
+  waitUntilDockerDaemonStarted "$logFile" 60
+done

--- a/tests/e2e_all/scripts/main.sh
+++ b/tests/e2e_all/scripts/main.sh
@@ -141,6 +141,7 @@ export daemonStartWait
 export allowParallelization
 timeoutDuration=30 # time out for each test
 export timeoutDuration
+export recompile
 
 shift "$((OPTIND - 1))"
 

--- a/tests/e2e_all/scripts/main.sh
+++ b/tests/e2e_all/scripts/main.sh
@@ -68,6 +68,7 @@ cd "$(dirname -- "$0")" || exit 1
 testScriptsDir=$(pwd)
 export testScriptsDir
 
+export recompile
 source "$testScriptsDir/common/common_functions.include.sh"
 
 if ! command -v timeout &>/dev/null; then
@@ -188,7 +189,6 @@ fi
 
 echo
 logInfo "Calling common/setup_binaries.sh"
-export recompile
 if [ "${allowParallelization}" = "true" ]; then
   "$testScriptsDir/common/setup_binaries.sh" &
   setupBinariesPidParallel=$!


### PR DESCRIPTION
**- What I did**
- Fixed some function name typos
- Created utility functions for docker image names
- Made `common_functions.include.sh` functions POSIX compliant
- Refactored `start_daemons.sh`
- Implemented `-n` functionality that skips building Docker daemon images if they already exist

**- How to verify it**

When I use `-n`, here are log snippets:

![image](https://github.com/user-attachments/assets/4554fc52-0249-4724-a04f-53bc76328ba5)

![image](https://github.com/user-attachments/assets/be7afd36-7e43-4ce6-8f2a-c9b0e008c895)

![image](https://github.com/user-attachments/assets/76cea00e-64bf-48c4-95f2-290a5240c215)

![image](https://github.com/user-attachments/assets/5287404a-facb-4730-9f7e-ad26592596dd)

**- Description for the changelog**
feat: e2e tests `-n` functionality
