### PR TITLE
build(deps): Update and pin dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,7 @@ updates:
     directories:
       - "/packages/c/sshnpd/tools/"
       - "/packages/dart/sshnoports/tools/"
+      - "/tests/e2e_all/dockerfiles/"
       - "/tests/end2end_tests/image/"
       - "/tools/multibuild/"
     schedule:

--- a/.github/workflows/dockerhub_e2e_all_base_runtime.yml
+++ b/.github/workflows/dockerhub_e2e_all_base_runtime.yml
@@ -2,6 +2,11 @@ name: dockerhub_e2e_all_base_runtime
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '47 6 * * 1' # At 0647 each Monday
+
+permissions: # added using https://github.com/step-security/secure-workflows
+  contents: read
 
 jobs:
   docker_push:
@@ -9,8 +14,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       - name: Login to Docker Hub
@@ -25,3 +28,4 @@ jobs:
           push: true
           tags: |
             atsigncompany/noports_e2e_all_base_runtime:latest
+            atsigncompany/noports_e2e_all_base_runtime:gha${{ github.run_number }}

--- a/tests/e2e_all/dockerfiles/Dockerfile.c.branch
+++ b/tests/e2e_all/dockerfiles/Dockerfile.c.branch
@@ -24,7 +24,7 @@ RUN set -eux ; \
     cmake --build build ; \
     mv build/srv ${OUTPUT_DIR}/srv
 
-FROM atsigncompany/noports_e2e_all_base_runtime:latest AS runtime
+FROM atsigncompany/noports_e2e_all_base_runtime:latest@sha256:b93eedf0cb5fb439d46f02519cd94faf11180117fc5c89d7983621a20756b067 AS runtime
 
 ENV USER=atsign
 ENV HOMEDIR=/${USER}

--- a/tests/e2e_all/dockerfiles/Dockerfile.c.current
+++ b/tests/e2e_all/dockerfiles/Dockerfile.c.current
@@ -25,7 +25,7 @@ RUN set -eux ; \
     mv build/srv ${OUTPUT_DIR}/srv
 
 
-FROM atsigncompany/noports_e2e_all_base_runtime:latest AS runtime
+FROM atsigncompany/noports_e2e_all_base_runtime:latest@sha256:b93eedf0cb5fb439d46f02519cd94faf11180117fc5c89d7983621a20756b067 AS runtime
 
 ENV USER=atsign
 ENV HOMEDIR=/${USER}

--- a/tests/e2e_all/dockerfiles/Dockerfile.c.release
+++ b/tests/e2e_all/dockerfiles/Dockerfile.c.release
@@ -34,7 +34,7 @@ RUN set -eux ; \
     cmake --build build ; \
     mv build/srv ${OUTPUT_DIR}/srv ;
 
-FROM atsigncompany/noports_e2e_all_base_runtime:latest AS runtime
+FROM atsigncompany/noports_e2e_all_base_runtime:latest@sha256:b93eedf0cb5fb439d46f02519cd94faf11180117fc5c89d7983621a20756b067 AS runtime
 
 ENV USER=atsign
 ENV HOMEDIR=/${USER}

--- a/tests/e2e_all/dockerfiles/Dockerfile.dart.branch
+++ b/tests/e2e_all/dockerfiles/Dockerfile.dart.branch
@@ -1,4 +1,4 @@
-FROM dart:3.7.3@sha256:sha256:1d0491432892b4f7cd216dfaf8406adef5bff216adc51a024e381023d8f22ce7 AS buildimage
+FROM dart:3.8.0@sha256:132fea97bf17a4e50202ebf282f29f0e798f269ffd2d03f5179dec066727f676 AS buildimage
 
 ENV URL=https://github.com/atsign-foundation/noports.git
 ENV REPO_DIR=/app/repo
@@ -24,7 +24,7 @@ RUN set -eux ; \
     dart compile exe ${PACKAGE_DIR}/bin/srv.dart -o ${OUTPUT_DIR}/srv ; \
     dart compile exe ${PACKAGE_DIR}/bin/srvd.dart -o ${OUTPUT_DIR}/srvd
 
-FROM atsigncompany/noports_e2e_all_base_runtime:latest AS runtime
+FROM atsigncompany/noports_e2e_all_base_runtime:latest@sha256:b93eedf0cb5fb439d46f02519cd94faf11180117fc5c89d7983621a20756b067 AS runtime
 
 ENV USER=atsign
 ENV HOMEDIR=/${USER}

--- a/tests/e2e_all/dockerfiles/Dockerfile.dart.current
+++ b/tests/e2e_all/dockerfiles/Dockerfile.dart.current
@@ -1,4 +1,4 @@
-FROM dart:3.7.3@sha256:1d0491432892b4f7cd216dfaf8406adef5bff216adc51a024e381023d8f22ce7 AS buildimage
+FROM dart:3.8.0@sha256:132fea97bf17a4e50202ebf282f29f0e798f269ffd2d03f5179dec066727f676 AS buildimage
 
 ENV REPO_DIR=/app/repo
 ENV OUTPUT_DIR=/output
@@ -18,7 +18,7 @@ RUN set -eux ; \
     dart compile exe bin/srv.dart -o ${OUTPUT_DIR}/srv ; \
     dart compile exe bin/srvd.dart -o ${OUTPUT_DIR}/srvd
 
-FROM atsigncompany/noports_e2e_all_base_runtime:latest AS runtime
+FROM atsigncompany/noports_e2e_all_base_runtime:latest@sha256:b93eedf0cb5fb439d46f02519cd94faf11180117fc5c89d7983621a20756b067 AS runtime
 
 ENV USER=atsign
 ENV HOMEDIR=/${USER}

--- a/tests/e2e_all/dockerfiles/Dockerfile.dart.release
+++ b/tests/e2e_all/dockerfiles/Dockerfile.dart.release
@@ -29,7 +29,7 @@ RUN apt-get update && \
     cd sshnp && \
     mv -f at_activate install.sh np_admin npp_atserver npp_file npt srv srvd sshnp sshnpd ${OUTPUT_DIR} || true
 
-FROM atsigncompany/noports_e2e_all_base_runtime:latest AS runtime
+FROM atsigncompany/noports_e2e_all_base_runtime:latest@sha256:b93eedf0cb5fb439d46f02519cd94faf11180117fc5c89d7983621a20756b067 AS runtime
 
 ENV USER=atsign
 ENV HOMEDIR=/${USER}


### PR DESCRIPTION
Fixes #1947 

**- What I did**

* Pin docker dependencies to SHAs
* Bumped Dart deps to 3.8.0
* Added cron job to rebuild base image
* Added new Dockerfiles to Dependabot

**- How I did it**

* https://stackoverflow.com/questions/32046334/where-can-i-find-the-sha256-code-of-a-docker-image/76272618#76272618

**- How to verify it**

* Scorecard after merge should return to 9.2

**- Description for the changelog**

build(deps): Update and pin dependencies
