### PR TITLE
ci: Workflow to promote canary to prod/latest

### DIFF
--- a/.github/workflows/promote_canary.yml
+++ b/.github/workflows/promote_canary.yml
@@ -1,0 +1,69 @@
+name: Promote Canary
+
+on:
+  push:
+    tags:
+      - 'r*.*.*' 
+  workflow_dispatch:
+    inputs:
+      image:
+        type: choice
+        description: Select image to promote
+        options:
+          - sshnpd
+          - activate_sshnpd
+          - sshnp_sshnpd
+          - npt_sshnpd
+          - sshnpd-slim
+          - srvd
+
+permissions: # added using https://github.com/step-security/secure-workflows
+  contents: read
+
+jobs:
+  single:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+      - name: Login to Docker Hub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Promote canary to latest
+        run: |
+          docker buildx imagetools create -t \
+            atsigncompany/${{ github.event.inputs.image }}:latest \
+            atsigncompany/${{ github.event.inputs.image }}:prod \
+            atsigncompany/${{ github.event.inputs.image }}:prod-wd-gha${{ github.run_number }} \
+            atsigncompany/${{ github.event.inputs.image }}:canary
+
+  multi:
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include:
+          - name: sshnpd
+          - name: activate_sshnpd
+          - name: sshnp_sshnpd
+          - name: npt_sshnpd
+          - name: sshnpd-slim
+          - name: srvd
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+      - name: Login to Docker Hub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Promote canary to latest
+        run: |
+          docker buildx imagetools create -t \
+            atsigncompany/${{ matrix.name }}:latest \
+            atsigncompany/${{ matrix.name }}:prod \
+            atsigncompany/${{ matrix.name }}:prod-${{ github.ref_name }} \
+            atsigncompany/${{ matrix.name }}:canary


### PR DESCRIPTION
Closes #1912

**- What I did**

Added workflow to promote canary images to prod/latest

**- How I did it**

Jobs to do single image based on workflow dispatch or all based on publishing of an 'r' tag

**- How to verify it**

We will need to first do a release to create canary tags, then do a promotion

**- Description for the changelog**

ci: Workflow to promote canary to prod/latest
