### PR TITLE
fix: convert device name to lowercase

### DIFF
--- a/packages/c/CMakeLists.txt
+++ b/packages/c/CMakeLists.txt
@@ -14,7 +14,7 @@ set(ATSDK_USE_SHARED_LIBS ${NOPORTS_USE_SHARED_LIBS})
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(noports VERSION 1.0.11 LANGUAGES C)
+project(noports VERSION 1.0.12 LANGUAGES C)
 
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/CPackSetup.cmake")
 

--- a/packages/c/cmake/CPackSetup.cmake
+++ b/packages/c/cmake/CPackSetup.cmake
@@ -1,7 +1,7 @@
 # package info
 set(CPACK_PACKAGE_NAME noports)
 set(CPACK_PACKAGE_DESCRIPTION "noports source tarballs")
-set(CPACK_PACKAGE_VERSION 1.0.11)
+set(CPACK_PACKAGE_VERSION 1.0.12)
 set(CPACK_PACKAGE_VENDOR_NAME atsign-foundation)
 
 # cmake configuration

--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -12,7 +12,7 @@ if(NOT atsdk_FOUND)
     FetchContent_Declare(
       atsdk
       GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-      GIT_TAG e62f9b41b7b7cd5b554c129d3ab38ad4f8d8aa80
+      GIT_TAG 129baf255544c69a9ebd9544a22e74d080a19598
     )
   endif()
   FetchContent_MakeAvailable(atsdk)

--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -12,7 +12,7 @@ if(NOT atsdk_FOUND)
     FetchContent_Declare(
       atsdk
       GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-      GIT_TAG 129baf255544c69a9ebd9544a22e74d080a19598
+      GIT_TAG b134eaa3e1092a41f107d3abcb12d8bd6eca7b17
     )
   endif()
   FetchContent_MakeAvailable(atsdk)

--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -12,7 +12,7 @@ if(NOT atsdk_FOUND)
     FetchContent_Declare(
       atsdk
       GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-      GIT_TAG b134eaa3e1092a41f107d3abcb12d8bd6eca7b17
+      GIT_TAG d6898eb2885acb7968be631b39d91994c6a15953
     )
   endif()
   FetchContent_MakeAvailable(atsdk)

--- a/packages/c/graceful-shutdown-tool/CMakeLists.txt
+++ b/packages/c/graceful-shutdown-tool/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(graceful-shutdown-tool VERSION 1.0.11 LANGUAGES C)
+project(graceful-shutdown-tool VERSION 1.0.12 LANGUAGES C)
 
 include(FetchContent)
 include(GNUInstallDirs)

--- a/packages/c/srv/CMakeLists.txt
+++ b/packages/c/srv/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
 
-project(srv VERSION 1.0.11 LANGUAGES C)
+project(srv VERSION 1.0.12 LANGUAGES C)
 
 # 1. Variables - you are free to edit anything in this step
 

--- a/packages/c/sshnpd/CHANGELOG.md
+++ b/packages/c/sshnpd/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.12
+
+- fix: convert device name to lower case to comply with Dart
+- build(deps): Bump at_c to support cjson patch
+
 ## 1.0.11
 
 - build(deps): Bump to at_c 0.4.3 to get mbedtls 3.6.3.1

--- a/packages/c/sshnpd/CMakeLists.txt
+++ b/packages/c/sshnpd/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(sshnpd VERSION 1.0.11 LANGUAGES C)
+project(sshnpd VERSION 1.0.12 LANGUAGES C)
 
 # 1. Variables - you are free to edit anything in this step
 

--- a/packages/c/sshnpd/include/sshnpd/version.h
+++ b/packages/c/sshnpd/include/sshnpd/version.h
@@ -1,4 +1,4 @@
 #ifndef SSHNPD_VERSION_H
 #define SSHNPD_VERSION_H
-#define SSHNPD_VERSION "1.0.11"
+#define SSHNPD_VERSION "1.0.12"
 #endif

--- a/packages/c/sshnpd/src/params.c
+++ b/packages/c/sshnpd/src/params.c
@@ -179,5 +179,11 @@ int parse_sshnpd_params(sshnpd_params *params, int argc, const char **argv) {
   }
 
   // Repeat for permit-open
+  // Convert devicename to lower case
+  for (char *c = params->device; c[0] != '\0'; c++) {
+    if (*c >= 'A' && *c <= 'Z') {
+      *c += ('a' - 'A');
+    }
+  }
   return 0;
 }

--- a/packages/c/sshnpd/tests/test_permit_open.c
+++ b/packages/c/sshnpd/tests/test_permit_open.c
@@ -44,8 +44,6 @@ int star_star_test() {
   params.permitopen_ports = ports;
   params.permitopen_len = 1;
 
-  bool allow;
-
   params.requested_host = "localhost";
   params.requested_port = 22;
   if (!should_permitopen(&params)) {
@@ -74,7 +72,6 @@ int localhost_star_test() {
   params.permitopen_hosts = hosts;
   params.permitopen_ports = ports;
   params.permitopen_len = 1;
-  bool allow;
   params.requested_host = "localhost";
   params.requested_port = 22;
   if (!should_permitopen(&params)) {
@@ -101,8 +98,6 @@ int star_port_test() {
   params.permitopen_hosts = hosts;
   params.permitopen_ports = ports;
   params.permitopen_len = 1;
-
-  bool allow;
 
   params.requested_host = "localhost";
   params.requested_port = 22;
@@ -131,8 +126,6 @@ int localhost_port_test() {
   params.permitopen_hosts = hosts;
   params.permitopen_ports = ports;
   params.permitopen_len = 1;
-
-  bool allow;
 
   params.requested_host = "localhost";
   params.requested_port = 22;
@@ -167,8 +160,6 @@ int list_test() {
   params.permitopen_hosts = hosts;
   params.permitopen_ports = ports;
   params.permitopen_len = 2;
-
-  bool allow;
 
   params.requested_host = "localhost";
   params.requested_port = 22;

--- a/packages/c/sshnpd/tests/test_sshnpd_params.c
+++ b/packages/c/sshnpd/tests/test_sshnpd_params.c
@@ -10,6 +10,7 @@ int parse_params_test();
 int atsign_mandatory_test();
 int manager_policy_mandatory_test();
 int permit_open_parse_test();
+int device_lower_test();
 
 int main() {
   int ret = 0;
@@ -32,6 +33,10 @@ int main() {
   }
   if (permit_open_parse_test()) {
     printf("permit open parse test failed\n");
+    ret++;
+  }
+  if (device_lower_test()) {
+    printf("device_name upper to lower case test failed\n");
     ret++;
   }
 
@@ -305,5 +310,68 @@ int permit_open_parse_test() {
       permitopen_ports9[0] != 22 || strcmp(permitopen_hosts9[1], "foo.bar.com") != 0 || permitopen_ports9[1] != 3399) {
     ret = 1;
   }
+  return 0;
+}
+
+int device_lower_test() {
+  int ret = 0;
+
+  sshnpd_params *params = malloc(sizeof(sshnpd_params));
+
+  const char *device_name_literal = "MY_DEVICEA-123Z";
+  size_t device_name_literal_len = strlen(device_name_literal);
+  char *device_name = malloc(sizeof(char) * (device_name_literal_len + 1));
+  if (device_name == NULL) {
+    return 1;
+  }
+  memcpy(device_name, device_name_literal, device_name_literal_len);
+  device_name[device_name_literal_len] = 0;
+
+  char *expected_device_name = "my_devicea-123z";
+  const char *argv[] = {
+      "sshnpd",
+      "-a",
+      "@atsign",
+      "-m",
+      "@manager",
+      "-d",
+      device_name,
+      "-s",
+      "-h",
+      "-v",
+      "--ssh-algorithm",
+      "ssh-rsa",
+      "--root-domain",
+      "vip.ve.atsign.zone",
+      "--local-sshd-port",
+      "6222",
+  };
+
+  apply_default_values_to_sshnpd_params(params);
+  ret = parse_sshnpd_params(params, 16, argv);
+  if (ret != 0) {
+    free(device_name);
+    free(params);
+    return 1;
+  }
+
+  size_t expected_device_len = strlen(expected_device_name);
+  size_t actual_device_len = strlen(params->device);
+
+  if (expected_device_len != actual_device_len) {
+    free(device_name);
+    free(params);
+    return 1;
+  }
+
+  size_t diff = strncmp(params->device, expected_device_name, expected_device_len);
+  if (diff != 0) {
+    free(device_name);
+    free(params);
+    return 1;
+  }
+
+  free(device_name);
+  free(params);
   return 0;
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Fixed cjson build issue : https://github.com/atsign-foundation/at_c/pull/592
- removed unused test variable
- Added a loop which converts uppercase chars to lowercase in devicename during the parsing phase

**- How I did it**

**- How to verify it**
Added temporary printf:
```c
  // Repeat for permit-open
  // Convert devicename to lower case
  for (char *c = params->device; c[0] != '\0'; c++) {
    if (*c >= 'A' && *c <= 'Z') {
      *c += ('a' - 'A');
    }
  }

  printf("dev: '%s'\n", params->device);
  return 0;
```
command input / printf output:
```
 ./build/dev-linux-x86_64/sshnpd/sshnpd -a @xchan -m @snooker
25 -d ASDSD_123Z
permitting open:
localhost:22
localhost:3389
dev: 'asdsd_123z'
```
**- Description for the changelog**
fix: convert device name to lowercase
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
