### PR TITLE
fix: Tag all releases as canary

### DIFF
--- a/.github/workflows/dockerhub_sshnpd.yml
+++ b/.github/workflows/dockerhub_sshnpd.yml
@@ -133,15 +133,13 @@ jobs:
           docker buildx imagetools create \
             -t atsigncompany/${{ matrix.name }}:${{ env.TAG2 }} \
             --append atsigncompany/${{ matrix.name }}:amd64-${{ env.TAG2 }}
-      # Promote to canary so long as this isn't a pre-release
+      # Promote to canary
       - name: Update canary tag
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          RELEASE_JSON=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ env.VERSION }}")
-          PRERELEASE=$(echo "$RELEASE_JSON" | jq -r '.prerelease')
-          if [ $PRERELEASE == 'false' ]; then
-            docker buildx imagetools create -t \
-              atsigncompany/${{ matrix.name }}:canary \
-              atsigncompany/${{ matrix.name }}:canary-${{ github.ref_name }} \
-              atsigncompany/${{ matrix.name }}:release-${{ github.ref_name }}
-          fi
+          docker buildx imagetools create -t \
+            atsigncompany/${{ matrix.name }}:canary \
+            atsigncompany/${{ matrix.name }}:release-${{ github.ref_name }}
+          docker buildx imagetools create -t \
+            atsigncompany/${{ matrix.name }}:canary-${{ github.ref_name }} \
+            atsigncompany/${{ matrix.name }}:release-${{ github.ref_name }}

--- a/.github/workflows/promote_canary.yml
+++ b/.github/workflows/promote_canary.yml
@@ -36,7 +36,11 @@ jobs:
         run: |
           docker buildx imagetools create -t \
             atsigncompany/${{ github.event.inputs.image }}:latest \
+            atsigncompany/${{ github.event.inputs.image }}:canary
+          docker buildx imagetools create -t \
             atsigncompany/${{ github.event.inputs.image }}:prod \
+            atsigncompany/${{ github.event.inputs.image }}:canary
+          docker buildx imagetools create -t \
             atsigncompany/${{ github.event.inputs.image }}:prod-wd-gha${{ github.run_number }} \
             atsigncompany/${{ github.event.inputs.image }}:canary
 
@@ -64,6 +68,10 @@ jobs:
         run: |
           docker buildx imagetools create -t \
             atsigncompany/${{ matrix.name }}:latest \
+            atsigncompany/${{ matrix.name }}:canary
+          docker buildx imagetools create -t \
             atsigncompany/${{ matrix.name }}:prod \
+            atsigncompany/${{ matrix.name }}:canary
+          docker buildx imagetools create -t \
             atsigncompany/${{ matrix.name }}:prod-${{ github.ref_name }} \
             atsigncompany/${{ matrix.name }}:canary


### PR DESCRIPTION
Pre-releases weren't being tagged as canary

**- What I did**

* Ensure all releases tagged as canary
* Only try to create one tag at a time

**- How to verify it**

Will need to wait for next release

**- Description for the changelog**

fix: Tag all releases as canary