### PR TITLE
feat: add `--help` flag to the sshnpd binary

### DIFF
--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
@@ -324,6 +324,11 @@ class SshnpdParams {
       hide: true,
     );
 
+    parser.addFlag(
+      'help',
+      help: 'Show usage',
+    );
+
     return parser;
   }
 }

--- a/packages/dart/sshnoports/bin/sshnpd.dart
+++ b/packages/dart/sshnoports/bin/sshnpd.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'package:args/args.dart';
 import 'package:at_cli_commons/at_cli_commons.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:noports_core/sshnp_foundation.dart';
@@ -12,6 +13,13 @@ void main(List<String> args) async {
   AtSignLogger.root_level = 'SEVERE';
   AtSignLogger.defaultLoggingHandler = AtSignLogger.stdErrLoggingHandler;
   late final Sshnpd sshnpd;
+
+  ArgResults r = SshnpdParams.parser.parse(args);
+  if (r.wasParsed('help')) {
+    printVersion();
+    stderr.writeln(SshnpdParams.parser.usage);
+    exit(0);
+  }
 
   try {
     sshnpd = await Sshnpd.fromCommandLineArgs(


### PR DESCRIPTION
Fixes #1545 

**- What I did**
feat: add 'help' flag to SshnpdParams and modify bin/sshnpd.dart to parse args, check if 'help' was parsed, and print usage and exit cleanly if so.

**- How I did it**

**- How to verify it**
Manually tested by building and executing `sshnpd --help` which has the desired output. If `--help` is not supplied behaviour is as it was previously.
