### PR TITLE
build: updates for release 5.11.0

### DIFF
--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -617,7 +617,7 @@ packages:
       path: "../../../packages/dart/noports_core"
       relative: true
     source: path
-    version: "6.5.0"
+    version: "6.6.0"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/noports_core/CHANGELOG.md
+++ b/packages/dart/noports_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.6.0
+- feat: twin keys for control socket and data sockets
+- fix: enable daemons and policy service to use the same atSign
+
 # 6.5.0
 - feat: New ESCR (Encrypted Signed Challenge-Response) relay socket 
   authentication

--- a/packages/dart/noports_core/lib/src/version.dart
+++ b/packages/dart/noports_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '6.5.0';
+const packageVersion = '6.6.0';

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: noports_core
 description: Core library code for sshnoports
 homepage: https://docs.atsign.com/
 
-version: 6.5.0
+version: 6.6.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -988,7 +988,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.5.0"
+    version: "6.6.0"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.10.0';
+const packageVersion = '5.11.0';

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -617,7 +617,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.5.0"
+    version: "6.6.0"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.10.0
+version: 5.11.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
**- What I did**
build: updates for release 5.11.0

**- How I did it**
- updated versions for sshnoports and noports_core packages
- updated noports_core changelog
- ran `dart run melos bootstrap`

**- How to verify it**
