### PR TITLE
fix: make sure ~/.ssh is owned by the user

### DIFF
--- a/packages/dart/sshnoports/bundles/shell/install.sh
+++ b/packages/dart/sshnoports/bundles/shell/install.sh
@@ -113,6 +113,9 @@ usage() {
 
 setup_authorized_keys() {
   mkdir -p "$user_ssh_dir"
+  if is_root; then
+    chown $user:$user "$user_ssh_dir" 2>/dev/null || chown $user "$user_ssh_dir" 2>/dev/null
+  fi
   touch "$user_ssh_dir/authorized_keys"
   chown $user:$user "$user_ssh_dir/authorized_keys" 2>/dev/null || chown $user "$user_ssh_dir/authorized_keys" 2>/dev/null
   chmod 644 "$user_ssh_dir/authorized_keys"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Ensure we `chown $user:$user ~/.ssh`

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: make sure ~/.ssh is owned by the user
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
