### PR TITLE
build(deps): Bump at_client to 3.4.4

### DIFF
--- a/apps/admin/admin_api/pubspec.yaml
+++ b/apps/admin/admin_api/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 # Add regular dependencies here.
 dependencies:
   alfred: 1.1.2+1
-  at_client: 3.4.3
+  at_client: 3.4.4
   json_annotation: 4.9.0
   at_cli_commons: 2.1.0
   args: 2.6.0


### PR DESCRIPTION
#2024 bumped the pubspec.lock without bumping pubspec.yaml 🤦 

**- What I did**

Bump pubspec.yaml

**- How to verify it**

CI

**- Description for the changelog**

build(deps): Bump at_client to 3.4.4