### PR TITLE
chore: Bump versions for c1.0.13 release

### DIFF
--- a/packages/c/CMakeLists.txt
+++ b/packages/c/CMakeLists.txt
@@ -14,7 +14,7 @@ set(ATSDK_USE_SHARED_LIBS ${NOPORTS_USE_SHARED_LIBS})
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(noports VERSION 1.0.12 LANGUAGES C)
+project(noports VERSION 1.0.13 LANGUAGES C)
 
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/CPackSetup.cmake")
 

--- a/packages/c/cmake/CPackSetup.cmake
+++ b/packages/c/cmake/CPackSetup.cmake
@@ -1,7 +1,7 @@
 # package info
 set(CPACK_PACKAGE_NAME noports)
 set(CPACK_PACKAGE_DESCRIPTION "noports source tarballs")
-set(CPACK_PACKAGE_VERSION 1.0.12)
+set(CPACK_PACKAGE_VERSION 1.0.13)
 set(CPACK_PACKAGE_VENDOR_NAME atsign-foundation)
 
 # cmake configuration

--- a/packages/c/graceful-shutdown-tool/CMakeLists.txt
+++ b/packages/c/graceful-shutdown-tool/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(graceful-shutdown-tool VERSION 1.0.12 LANGUAGES C)
+project(graceful-shutdown-tool VERSION 1.0.13 LANGUAGES C)
 
 include(FetchContent)
 include(GNUInstallDirs)

--- a/packages/c/srv/CMakeLists.txt
+++ b/packages/c/srv/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
 
-project(srv VERSION 1.0.12 LANGUAGES C)
+project(srv VERSION 1.0.13 LANGUAGES C)
 
 # 1. Variables - you are free to edit anything in this step
 

--- a/packages/c/sshnpd/CHANGELOG.md
+++ b/packages/c/sshnpd/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.13
+
+- feat: csshnpd root-domain implementation
+
 ## 1.0.12
 
 - fix: convert device name to lower case to comply with Dart

--- a/packages/c/sshnpd/CMakeLists.txt
+++ b/packages/c/sshnpd/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(sshnpd VERSION 1.0.12 LANGUAGES C)
+project(sshnpd VERSION 1.0.13 LANGUAGES C)
 
 # 1. Variables - you are free to edit anything in this step
 

--- a/packages/c/sshnpd/include/sshnpd/version.h
+++ b/packages/c/sshnpd/include/sshnpd/version.h
@@ -1,4 +1,4 @@
 #ifndef SSHNPD_VERSION_H
 #define SSHNPD_VERSION_H
-#define SSHNPD_VERSION "1.0.12"
+#define SSHNPD_VERSION "1.0.13"
 #endif

--- a/tests/e2e_all/scripts/main.sh
+++ b/tests/e2e_all/scripts/main.sh
@@ -48,7 +48,7 @@ atDirectoryPort=64
 testsToRun="all"
 
 # defaultDaemonVersions="c:current"
-defaultDaemonVersions="d:current c:current c:1.0.12 d:5.5.0 d:5.9.4"
+defaultDaemonVersions="d:current c:current c:1.0.13 d:5.5.0 d:5.9.4"
 defaultClientVersions="d:current d:5.5.0 d:5.9.4"
 
 daemonVersions=$defaultDaemonVersions

--- a/tests/e2e_all/scripts/main.sh
+++ b/tests/e2e_all/scripts/main.sh
@@ -48,7 +48,7 @@ atDirectoryPort=64
 testsToRun="all"
 
 # defaultDaemonVersions="c:current"
-defaultDaemonVersions="d:current c:current c:1.0.13 d:5.5.0 d:5.9.4"
+defaultDaemonVersions="d:current c:current c:1.0.12 d:5.5.0 d:5.9.4"
 defaultClientVersions="d:current d:5.5.0 d:5.9.4"
 
 daemonVersions=$defaultDaemonVersions


### PR DESCRIPTION
Bump versions so we can release #2020 in c1.0.13

**- Description for the changelog**

chore: Bump versions for c1.0.13 release
