### PR TITLE
test: (Not for merging) test noports against the at_client 3.5.2 release candidate

### DIFF
--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -94,19 +94,20 @@ packages:
   at_client:
     dependency: "direct main"
     description:
-      name: at_client
-      sha256: "71d54d9a05ef1e14054ebd55f74f8192dbcd7abd7d14dee063201542681dad8f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.5.0"
+      path: "packages/at_client"
+      ref: more-namespace-hassles
+      resolved-ref: "065c8612e7d905e793ffccbac8ce690ca27f1599"
+      url: "https://github.com/atsign-foundation/at_client_sdk"
+    source: git
+    version: "3.5.2"
   at_commons:
     dependency: transitive
     description:
       name: at_commons
-      sha256: "2b86d4e8b80fddcbec87be20270ec8c9dfb11aab25c29cfd1b082b328c39f92a"
+      sha256: "9e7568b90efd8643ad34a3536211757d66596cb65477cfc9f2accf4ac7b0b399"
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.0"
+    version: "5.4.1"
   at_demo_data:
     dependency: transitive
     description:

--- a/apps/admin/admin_api/pubspec.yaml
+++ b/apps/admin/admin_api/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 # Add regular dependencies here.
 dependencies:
   alfred: 1.1.2+1
-  at_client: 3.5.0
+  at_client: 3.5.1
   json_annotation: 4.9.0
   at_cli_commons: 2.1.0
   args: 2.6.0
@@ -19,6 +19,11 @@ dependencies:
     path: ../../../packages/dart/noports_core
 
 dependency_overrides:
+  at_client:
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk
+      ref: more-namespace-hassles
+      path: packages/at_client
   args:
     git:
       ref: gkc/show-aliases-in-usage

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -93,11 +93,12 @@ packages:
   at_client:
     dependency: "direct main"
     description:
-      name: at_client
-      sha256: "71d54d9a05ef1e14054ebd55f74f8192dbcd7abd7d14dee063201542681dad8f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.5.0"
+      path: "packages/at_client"
+      ref: more-namespace-hassles
+      resolved-ref: "065c8612e7d905e793ffccbac8ce690ca27f1599"
+      url: "https://github.com/atsign-foundation/at_client_sdk"
+    source: git
+    version: "3.5.2"
   at_commons:
     dependency: "direct main"
     description:

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   at_onboarding_cli: 1.11.0
   at_commons: ^5.4.1
   at_cli_commons: 2.1.0
-  at_client: 3.5.0
+  at_client: 3.5.1
   args: 2.6.0
   socket_connector: 2.3.3
   dartssh2: 2.11.0
@@ -23,6 +23,11 @@ dependencies:
   yaml: 3.1.3
 
 dependency_overrides:
+  at_client:
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk
+      ref: more-namespace-hassles
+      path: packages/at_client
   dartssh2:
     git:
       url: https://github.com/atsign-foundation/dartssh2


### PR DESCRIPTION
**- What I did**
- test: test noports against the at_client 3.5.2 release candidate

**- How I did it**
- updated pubspecs, ran `dart run melos bootstrap`

**- How to verify it**
Tests pass

