### PR TITLE
chore: Consistent use of debian:stable-{DATE}-slim

### DIFF
--- a/tests/e2e_all/dockerfiles/Dockerfile.base.runtime
+++ b/tests/e2e_all/dockerfiles/Dockerfile.base.runtime
@@ -1,5 +1,5 @@
 # Dockerfile.base-runtime
-FROM debian:stable-slim@sha256:377ddc2a20fe8632a49b69dcfff10fccbd5b4f0b8c2d593420a6a5e03070dfa1
+FROM debian:stable-20250721-slim@sha256:377ddc2a20fe8632a49b69dcfff10fccbd5b4f0b8c2d593420a6a5e03070dfa1
 
 ENV USER=atsign
 ENV HOMEDIR=/${USER}

--- a/tests/e2e_all/dockerfiles/Dockerfile.dart.release
+++ b/tests/e2e_all/dockerfiles/Dockerfile.dart.release
@@ -1,4 +1,4 @@
-FROM debian:stable-slim@sha256:377ddc2a20fe8632a49b69dcfff10fccbd5b4f0b8c2d593420a6a5e03070dfa1 AS buildimage
+FROM debian:stable-20250721-slim@sha256:377ddc2a20fe8632a49b69dcfff10fccbd5b4f0b8c2d593420a6a5e03070dfa1 AS buildimage
 
 ENV URL="https://api.github.com/repos/atsign-foundation/noports/releases/latest"
 ENV URLP="https://github.com/atsign-foundation/noports/releases/download"


### PR DESCRIPTION
Some of our Dockerfiles use a Debian image label with a date in it, whilst others use one without, even though they point to the same image (as referenced by the SHA).

To keep things consistent they should all have a date (so it's obvious when the image was last refreshed).

**- What I did**

Added date to image label.

**- How I did it**

Copy/paste from other Dockerfile in this repo

**- Description for the changelog**

chore: Consistent use of debian:stable-{DATE}-slim
