### PR TITLE
fix: Use -p flag for mkdir

### DIFF
--- a/packages/dart/sshnoports/tools/Dockerfile
+++ b/packages/dart/sshnoports/tools/Dockerfile
@@ -37,7 +37,7 @@ RUN \
   chown -R ${USER}:${USER} ${HOMEDIR} ; \
   chmod 600 ${HOMEDIR}/.ssh/authorized_keys ; \
   usermod -aG sudo ${USER} ; \
-  mkdir /run/sshd ; \
+  mkdir -p /run/sshd ; \
   chmod 755 /${USER}/.startup.sh
 
 COPY --from=buildimage --chown=${USER}:${USER} /usr/local/at/sshnpd /usr/local/at/


### PR DESCRIPTION
Fixes #2077 

**- What I did**

Added `-p` to mkdir

**- How to verify it**

Images should build once this PR merged.

**- Description for the changelog**

fix: Use -p flag for mkdir
