### PR TITLE
chore: Ensure addgroup command is available

### DIFF
--- a/packages/dart/sshnoports/tools/Dockerfile
+++ b/packages/dart/sshnoports/tools/Dockerfile
@@ -28,7 +28,7 @@ COPY --from=buildimage /app/packages/dart/sshnoports/bundles/core/docker/.startu
 RUN \
   set -eux ; \
   apt-get update ; \
-  apt-get install -y openssh-server sudo iputils-ping iproute2 ncat telnet net-tools nmap iperf3 traceroute vim ; \
+  apt-get install -y adduser openssh-server sudo iputils-ping iproute2 ncat telnet net-tools nmap iperf3 traceroute vim ; \
   addgroup --gid ${GROUP_ID} ${USER} ; \
   useradd --system --uid ${USER_ID} --gid ${GROUP_ID} --shell /bin/bash --home ${HOMEDIR} ${USER} ; \
   mkdir -p ${HOMEDIR}/.atsign/keys ; \

--- a/packages/dart/sshnoports/tools/Dockerfile.activate
+++ b/packages/dart/sshnoports/tools/Dockerfile.activate
@@ -28,7 +28,7 @@ WORKDIR ${HOMEDIR}
 RUN \
   set -eux ; \
   apt-get update ; \
-  apt-get install -y sudo ; \
+  apt-get install -y adduser sudo ; \
   addgroup --gid ${GROUP_ID} ${USER} ; \
   useradd --system --uid ${USER_ID} --gid ${GROUP_ID} --shell /bin/bash --home ${HOMEDIR} ${USER} ; \
   mkdir -p ${HOMEDIR}/.atsign/keys ; \

--- a/packages/dart/sshnoports/tools/Dockerfile.npt
+++ b/packages/dart/sshnoports/tools/Dockerfile.npt
@@ -28,7 +28,7 @@ WORKDIR ${HOMEDIR}
 RUN \
   set -eux ; \
   apt-get update ; \
-  apt-get install -y sudo ; \
+  apt-get install -y adduser sudo ; \
   addgroup --gid ${GROUP_ID} ${USER} ; \
   useradd --system --uid ${USER_ID} --gid ${GROUP_ID} --shell /bin/bash --home ${HOMEDIR} ${USER} ; \
   mkdir -p ${HOMEDIR}/.atsign/keys ; \

--- a/packages/dart/sshnoports/tools/Dockerfile.srvd
+++ b/packages/dart/sshnoports/tools/Dockerfile.srvd
@@ -29,7 +29,7 @@ WORKDIR ${HOMEDIR}
 RUN \
   set -eux ; \
   apt-get update ; \
-  apt-get install -y sudo ; \
+  apt-get install -y adduser sudo ; \
   addgroup --gid ${GROUP_ID} ${USER} ; \
   useradd --system --uid ${USER_ID} --gid ${GROUP_ID} --shell /bin/bash --home ${HOMEDIR} ${USER} ; \
   mkdir -p ${HOMEDIR}/.atsign/keys ; \

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnp
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnp
@@ -28,7 +28,7 @@ WORKDIR ${HOMEDIR}
 RUN \
   set -eux ; \
   apt-get update ; \
-  apt-get install -y sudo ; \
+  apt-get install -y adduser sudo ; \
   addgroup --gid ${GROUP_ID} ${USER} ; \
   useradd --system --uid ${USER_ID} --gid ${GROUP_ID} --shell /bin/bash --home ${HOMEDIR} ${USER} ; \
   mkdir -p ${HOMEDIR}/.atsign/keys ; \


### PR DESCRIPTION
The adduser package is no longer included in debian-slim images now that they've been bumped to Trixie, so our use of `addgroup` fails.

**- What I did**

Added `adduser` to `apt-get` lines prior to use of `addgroup`

**- How to verify it**

Images should (re)build after merge

**- Description for the changelog**

chore: Ensure addgroup command is available
