### PR TITLE
chore: Ensure addgroup is in place for Trixie based Dart images

### DIFF
--- a/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
@@ -33,12 +33,12 @@ RUN \
   dart compile exe bin/sshnpd.dart -o ${BINARYDIR}/sshnpd ; \
   dart compile exe bin/srv.dart -o ${BINARYDIR}/srv ; \
   # create atsign account
+  apt-get update && apt-get install -y adduser autoconf curl gcc make ; \
   addgroup --gid $GROUP_ID atsign ; \
   useradd --system --uid $USER_ID --gid $GROUP_ID --shell /bin/bash \
   --home $HOMEDIR atsign ; \
   chown -R atsign:atsign $HOMEDIR ; \
   # build static openssh binaries
-  apt update && apt install -y curl gcc make autoconf ; \
   cd ${WORKDIR}/${OPENSSH} ; \
   ARCH=${TARGETARCH} ./static-openssh.sh ; \
   cp build/openssh-portable*/ssh-keygen ${BINARYDIR}/ ; \ 


### PR DESCRIPTION
The Dart image is present based on Debian 12 (Bookworm), but is about to shift to Debian 13 (Trixie). Trixie no longer carries the adduser package by default (hence #2085), meaning that our `addgroup` command will fail.

**- What I did**

Ensured that `adduser` package is installed before we attempt `addgroup`

**- How I did it**

* Moved line that installs packages up to before `addgroup`
* Switched from `apt` to `apt-get` (stable interface for headless install so preferred for Dockerfiles)
* Added `adduser` to package list
* Re-ordered packages alphabetically

**- How to verify it**

Will only matter post release of Trixie based Dart images (expected in coming days along with 3.9.0 Stable SDK).

**- Description for the changelog**

chore: Ensure addgroup is in place for Trixie based Dart images
