### PR TITLE
docs: Add sbomify badge

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -314,7 +314,7 @@ jobs:
           TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
           COMPONENT_ID: '-93khk8pUi'
           LOCK_FILE: './packages/dart/sshnoports/pubspec.lock'
-          SBOM_VERSION: ${{github.ref_name}}
+          COMPONENT_VERSION: ${{github.ref_name}}
           OUTPUT_FILE: 'tarballs/noports_dart-${{github.ref_name}}-sbom.cdx.json'
           AUGMENT: true
           ENRICH: true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/noports/badge)](https://securityscorecards.dev/viewer/?uri=github.com/atsign-foundation/noports&sort_by=check-score&sort_direction=desc)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8102/badge)](https://www.bestpractices.dev/projects/8102)
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
+[![sbomified](https://sbomify.com/assets/images/logo/badge.svg)](https://app.sbomify.com/component/-93khk8pUi)
 
 # noports
 


### PR DESCRIPTION
We've been creating an SBOM for some time, but it's only visible in the releases.

**- What I did**

Added an sbomify badge to README
Also updated workflow to use newer naming convention

**- How I did it**

Based on at_server

**- How to verify it**

View in rich diff

**- Description for the changelog**

docs: Add sbomify badge
