### PR TITLE
build: upgrade at_commons dependency to 5.6.1; more osv scanning

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -36,6 +36,22 @@ jobs:
       - name: dart test
         working-directory: apps/admin/admin_api
         run: dart test
+  sshnoports-unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1.7.1
+        with:
+          sdk: stable
+      - name: dart pub get enforce lockfile
+        working-directory: packages/dart/sshnoports
+        run: dart pub get --enforce-lockfile
+      - name: dart analyze
+        working-directory: packages/dart/sshnoports
+        run: dart analyze
+      - name: dart test
+        working-directory: packages/dart/sshnoports
+        run: dart test
   noports_core-unit_tests:
     runs-on: ubuntu-latest
     strategy:
@@ -56,6 +72,14 @@ jobs:
       - name: dart test
         working-directory: packages/dart/noports_core
         run: dart test
+  osv-scanner:
+    needs: [np_admin-unit-tests, sshnoports-unit-tests, noports_core-unit_tests]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dart-channel: [stable,beta]
+    steps:
       # Runs osv-scanner to find any vulnerable Dart dependencies
       # It needs to look at pubspec.lock files, which is why it's
       # placed here, as the `dart pub get` above will create them
@@ -63,6 +87,6 @@ jobs:
         uses: google/osv-scanner-action/osv-scanner-action@456ceb78310755116e0a3738121351006286b797 # v2.2.1
         with:
           scan-args: |-
+            --lockfile=./apps/admin/admin_api/pubspec.lock
             --lockfile=./packages/dart/sshnoports/pubspec.lock
-            --lockfile=./packages/dart/sshnp_flutter/pubspec.lock
             --lockfile=./packages/dart/noports_core/pubspec.lock

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -36,6 +36,15 @@ jobs:
       - name: dart test
         working-directory: apps/admin/admin_api
         run: dart test
+      # Runs osv-scanner to find any vulnerable Dart dependencies
+      # It needs to look at pubspec.lock files, which is why it's
+      # placed here, as the `dart pub get` above will create them
+      - name: Run osv-scanner
+        uses: google/osv-scanner-action/osv-scanner-action@456ceb78310755116e0a3738121351006286b797 # v2.2.1
+        with:
+          scan-args: |-
+            --lockfile=./apps/admin/admin_api/pubspec.lock
+
   sshnoports-unit-tests:
     runs-on: ubuntu-latest
     steps:
@@ -52,6 +61,15 @@ jobs:
       - name: dart test
         working-directory: packages/dart/sshnoports
         run: dart test
+      # Runs osv-scanner to find any vulnerable Dart dependencies
+      # It needs to look at pubspec.lock files, which is why it's
+      # placed here, as the `dart pub get` above will create them
+      - name: Run osv-scanner
+        uses: google/osv-scanner-action/osv-scanner-action@456ceb78310755116e0a3738121351006286b797 # v2.2.1
+        with:
+          scan-args: |-
+            --lockfile=./packages/dart/sshnoports/pubspec.lock
+
   noports_core-unit_tests:
     runs-on: ubuntu-latest
     strategy:
@@ -72,14 +90,6 @@ jobs:
       - name: dart test
         working-directory: packages/dart/noports_core
         run: dart test
-  osv-scanner:
-    needs: [np_admin-unit-tests, sshnoports-unit-tests, noports_core-unit_tests]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        dart-channel: [stable,beta]
-    steps:
       # Runs osv-scanner to find any vulnerable Dart dependencies
       # It needs to look at pubspec.lock files, which is why it's
       # placed here, as the `dart pub get` above will create them
@@ -87,6 +97,4 @@ jobs:
         uses: google/osv-scanner-action/osv-scanner-action@456ceb78310755116e0a3738121351006286b797 # v2.2.1
         with:
           scan-args: |-
-            --lockfile=./apps/admin/admin_api/pubspec.lock
-            --lockfile=./packages/dart/sshnoports/pubspec.lock
             --lockfile=./packages/dart/noports_core/pubspec.lock

--- a/apps/admin/admin_api/bin/np_admin.dart
+++ b/apps/admin/admin_api/bin/np_admin.dart
@@ -100,7 +100,7 @@ void main(List<String> args) async {
     print('Will serve webapp from ${dir.absolute}');
     app.get('/*', (req, res) => dir);
   }
-  await expose.policy(app, '/api/policy', api);
+  expose.policy(app, '/api/policy', api);
 
   // Track connected clients
   var users = <WebSocket>[];

--- a/apps/admin/admin_api/lib/src/expose_apis.dart
+++ b/apps/admin/admin_api/lib/src/expose_apis.dart
@@ -5,7 +5,7 @@ import 'package:alfred/alfred.dart';
 import 'package:at_client/at_client.dart';
 import 'package:noports_core/admin.dart';
 
-policy(Alfred app, String pathPrefix, PolicyService api) {
+void policy(Alfred app, String pathPrefix, PolicyService api) {
   // policy log events
   app.get('$pathPrefix/logs', (req, res) async {
     stderr.writeln('Fetching policy log events');

--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -103,10 +103,10 @@ packages:
     dependency: transitive
     description:
       name: at_commons
-      sha256: e10d351bd2b1f4dd3671f265888cc0948803a6bd215b1d89409fc50044a52ba0
+      sha256: "4c9cafd32e1520fbdde8836ee5bb09616fc5e20accbc3191dc38d3632fc99a4c"
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.0"
+    version: "5.6.1"
   at_demo_data:
     dependency: transitive
     description:

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -5,13 +5,13 @@ homepage: https://docs.atsign.com/
 version: 6.6.1
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.8.0"
 
 dependencies:
   args: ^2.4.2
   at_chops: ^2.0.1
   at_client: ^3.7.0
-  at_commons: ^5.5.0
+  at_commons: ^5.6.1
   at_cli_commons: ^2.1.0
   at_utils: ^3.0.19
   cryptography: ^2.7.0

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -110,10 +110,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_client
-      sha256: "568fd8f58ad4bc7bf0486e38fa0509ed3612d0bd91e5378aaf6e4f3dbd2455b6"
+      sha256: ab0caa6f54a3d0a325dab30dfab8b12e358d1f7ee1ca952137d3913ef6cf8c16
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.0"
+    version: "3.7.0"
   at_client_mobile:
     dependency: "direct main"
     description:
@@ -135,18 +135,18 @@ packages:
     dependency: transitive
     description:
       name: at_commons
-      sha256: "9e7568b90efd8643ad34a3536211757d66596cb65477cfc9f2accf4ac7b0b399"
+      sha256: "4c9cafd32e1520fbdde8836ee5bb09616fc5e20accbc3191dc38d3632fc99a4c"
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.1"
+    version: "5.6.1"
   at_contact:
     dependency: "direct main"
     description:
       name: at_contact
-      sha256: e67a3545f2df3f0c8e28f0360c8cb301c1677043cd4b797c8d78dc92a69f2e62
+      sha256: "4f8456fce51ec28628503cdfd63f02c6573e0cf87631b1b93126d04e80148eb5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.1.0"
   at_contacts_flutter:
     dependency: "direct main"
     description:
@@ -200,10 +200,10 @@ packages:
     dependency: transitive
     description:
       name: at_persistence_secondary_server
-      sha256: "00a964a0e7f4ca984276975f043d55d17c969feea5e6bc5ee554a72579b4b160"
+      sha256: "392efb813d9f44dbcadfc36e74699db07cf0b0b96bc4820970be708953c1daac"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.0"
   at_persistence_spec:
     dependency: transitive
     description:
@@ -216,10 +216,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_server_status
-      sha256: "2773fa7c4377802b671f6854863214aabe8ee8cd49be87226352dd14562a5d6b"
+      sha256: caffbc483f3c8d7606fa8a6767ade941e6fccf017765c3c1d436b2f2eaf2d156
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   at_sync_ui_flutter:
     dependency: transitive
     description:
@@ -1524,6 +1524,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   stack_trace:
     dependency: transitive
     description:
@@ -1704,10 +1712,10 @@ packages:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.7"
+    version: "4.5.1"
   vector_graphics:
     dependency: transitive
     description:

--- a/packages/dart/npt_flutter/pubspec.yaml
+++ b/packages/dart/npt_flutter/pubspec.yaml
@@ -77,7 +77,7 @@ dependencies:
   toml: ^0.16.0
   tray_manager: ^0.2.3
   url_launcher: ^6.3.0
-  uuid: ^3.0.7
+  uuid: ^4.0.0
   visibility_detector: ^0.4.0+2
   window_manager: ^0.4.2
   yaml: ^3.1.2

--- a/packages/dart/sshnoports/lib/src/create_at_client_cli.dart
+++ b/packages/dart/sshnoports/lib/src/create_at_client_cli.dart
@@ -1,8 +1,6 @@
 import 'package:at_client/at_client.dart';
-import 'package:at_commons/at_commons.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
 import 'package:noports_core/utils.dart';
-import 'package:version/version.dart';
 import 'package:path/path.dart' as path;
 
 Future<AtClient> createAtClientCli({
@@ -28,7 +26,6 @@ Future<AtClient> createAtClientCli({
     ..commitLogPath = path.normalize('$storagePath/commitLog')
     ..fetchOfflineNotifications = false
     ..atKeysFilePath = atKeysFilePath
-    ..atProtocolEmitted = Version(2, 0, 0)
     ..rootDomain = domain
     ..rootPort = port;
 

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -102,10 +102,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_commons
-      sha256: e10d351bd2b1f4dd3671f265888cc0948803a6bd215b1d89409fc50044a52ba0
+      sha256: "4c9cafd32e1520fbdde8836ee5bb09616fc5e20accbc3191dc38d3632fc99a4c"
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.0"
+    version: "5.6.1"
   at_demo_data:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   noports_core:
     path: "../noports_core"
   at_onboarding_cli: 1.11.0
-  at_commons: ^5.6.0
+  at_commons: ^5.6.1
   at_cli_commons: 2.1.0
   at_client: ^3.7.0
   args: 2.6.0
@@ -31,11 +31,6 @@ dependency_overrides:
     git:
       url: https://github.com/gkc/args
       ref: gkc/show-aliases-in-usage
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_client_sdk
-      ref: trunk
-      path: packages/at_commons
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/dart/sshnoports/test/empty_test.dart
+++ b/packages/dart/sshnoports/test/empty_test.dart
@@ -1,0 +1,5 @@
+import 'package:test/test.dart';
+
+void main() {
+  test('empty test initially', () {});
+}


### PR DESCRIPTION
**- What I did**
- build: remove at_commons dependency override from packages/dart/sshnoports and upgrade to 5.6.1
- build: update uuid dependency in npt_flutter
- build: update at_commons dependency in noports_core
- ci: add unit tests job for packages/dart/sshnoports
- ci: add osv scanning for apps/admin/admin_api
- chore: run dart format

**- How I did it**
See commits

**- How to verify it**
Tests pass

