### PR TITLE
feat: Add SBOM using Conan lock file

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -192,12 +192,6 @@ jobs:
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           path: tarballs/
-      ## 20240806: Need a different approach to SBOMs for C daemon
-      #    - name: Generate SBOMs
-      #      run: |
-      #        syft scan file:./packages/dart/sshnoports/pubspec.lock \
-      #          -o 'spdx-json=tarballs/dart_sshnoports_sbom.spdx.json' \
-      #          -o 'cyclonedx-json=tarballs/dart_sshnoports_sbom.cyclonedx.json'
       - name: Move packages for signing
         run: |
           cd tarballs
@@ -209,6 +203,23 @@ jobs:
           rm -Rf -- */
           echo "After:"
           ls -latrR *
+      - name: Get lockfile
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          sparse-checkout: |
+            packages/c/conan.lock
+          sparse-checkout-cone-mode: false
+      - name: Generate SBOM
+        uses: sbomify/github-action@8ea6f28cd562edee2665001cd4f17aaf7a283722 # v0.5.0
+        env:
+          TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
+          COMPONENT_ID: 'Y6pppn8rC4'
+          LOCK_FILE: './packages/c/conan.lock'
+          COMPONENT_VERSION: ${{github.ref_name}}
+          OUTPUT_FILE: 'tarballs/csshnpd-${{github.ref_name}}-sbom.cdx.json'
+          AUGMENT: true
+          ENRICH: true
+          UPLOAD: true
       - name: Generate SHA256 checksums
         working-directory: tarballs
         run: sha256sum * > checksums.txt

--- a/docs/installation/openwrt-installation-guide.md
+++ b/docs/installation/openwrt-installation-guide.md
@@ -41,10 +41,10 @@ Those command line snippets set some variables for the `RELEASE` number, `ARCH` 
 
 Packages are installed using `opkg install` for OpenWrt 24.10 and earlier releases that use `.ipk` type packages, or `apk add` for newer OpenWrt which uses `.apk` packages.
 
-For example, to install the c1.0.14 release:
+For example, to install the c1.0.15 release:
 
 ```
-RELEASE="1.0.14"
+RELEASE="1.0.15"
 ARCH=$(opkg print-architecture | grep ' 10$' | awk '{print $2}')
 PACKAGE="csshnpd_${RELEASE}-1_${ARCH}.ipk"
 wget -O ${PACKAGE} https://github.com/atsign-foundation/Atsign_OpenWRT_packages/releases/download/c${RELEASE}/${PACKAGE}

--- a/packages/c/cmake/CPackSetup.cmake
+++ b/packages/c/cmake/CPackSetup.cmake
@@ -1,7 +1,7 @@
 # package info
 set(CPACK_PACKAGE_NAME noports)
 set(CPACK_PACKAGE_DESCRIPTION "noports source tarballs")
-set(CPACK_PACKAGE_VERSION 1.0.14)
+set(CPACK_PACKAGE_VERSION 1.0.15)
 set(CPACK_PACKAGE_VENDOR_NAME atsign-foundation)
 
 # cmake configuration

--- a/packages/c/conan.lock
+++ b/packages/c/conan.lock
@@ -1,0 +1,11 @@
+{
+    "version": "0.5",
+    "requires": [
+        "mbedtls/3.6.4#b686248bee97f7bc92b88c6bc6e514a2%1752241954.6017513",
+        "cjson/1.7.18#e67d95071acf8902d892d89a858d31ab%1743006050.674",
+        "at_c/0.3.5#34b56d9094830185b0edbc3911bb9a6d%1756826801.317262"
+    ],
+    "build_requires": [],
+    "python_requires": [],
+    "config_requires": []
+}

--- a/packages/c/conanfile.py
+++ b/packages/c/conanfile.py
@@ -1,0 +1,47 @@
+# This Conanfile is presently used to create the at_c SBOM and isn't
+# used to generate CMake builds or anything else.
+
+from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
+from conan.tools.files import get
+
+
+class at_cRecipe(ConanFile):
+    name = "noports"
+    version = "1.0.15"
+    package_type = "application"
+
+    # Optional metadata
+    license = "BSD-3-Clause"
+    author = "atsign-foundation"
+    url = "https://github.com/atsign-foundation/noports"
+    description = "C implementation of NoPorts daemon"
+
+    # Binary configuration
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+
+    def source(self):
+        get(self, f"https://github.com/atsign-foundation/noports/releases/download/c{self.version}/csshnpd-c{self.version}.tar.gz",
+              strip_root=True)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def requirements(self):
+        self.requires("at_c/0.3.5")

--- a/packages/c/graceful-shutdown-tool/CMakeLists.txt
+++ b/packages/c/graceful-shutdown-tool/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(graceful-shutdown-tool VERSION 1.0.14 LANGUAGES C)
+project(graceful-shutdown-tool VERSION 1.0.15 LANGUAGES C)
 
 include(FetchContent)
 include(GNUInstallDirs)

--- a/packages/c/srv/CMakeLists.txt
+++ b/packages/c/srv/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
 
-project(srv VERSION 1.0.14 LANGUAGES C)
+project(srv VERSION 1.0.15 LANGUAGES C)
 
 # 1. Variables - you are free to edit anything in this step
 

--- a/packages/c/sshnpd/CHANGELOG.md
+++ b/packages/c/sshnpd/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.15
+
+- feat: Add SBOM using Conan lock file
+
 ## 1.0.14
 
 - build(deps): Bump at_c to use MbedTLS 3.6.4

--- a/packages/c/sshnpd/CMakeLists.txt
+++ b/packages/c/sshnpd/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(sshnpd VERSION 1.0.14 LANGUAGES C)
+project(sshnpd VERSION 1.0.15 LANGUAGES C)
 
 # 1. Variables - you are free to edit anything in this step
 

--- a/packages/c/sshnpd/include/sshnpd/version.h
+++ b/packages/c/sshnpd/include/sshnpd/version.h
@@ -1,4 +1,4 @@
 #ifndef SSHNPD_VERSION_H
 #define SSHNPD_VERSION_H
-#define SSHNPD_VERSION "1.0.14"
+#define SSHNPD_VERSION "1.0.15"
 #endif


### PR DESCRIPTION
Adds Conanfile and associated lock file that can be used by sbomify to generate sbom

**- What I did**

* Added `conanfile.py`
* Generate lock file
* Bumped version to 1.0.15 in anticipation of c1.0.15 release with an SBOM

**- How I did it**

Based on SBOM work in at_c

**- How to verify it**

c1.0.15 release will be done once merged so we have an SBOM in the release

**- Description for the changelog**

feat: Add SBOM using Conan lock file