### PR TITLE
build(deps): Use clang-19 as that's what's in latest C buildimage

### DIFF
--- a/packages/c/sshnpd/tools/Dockerfile.package
+++ b/packages/c/sshnpd/tools/Dockerfile.package
@@ -10,7 +10,7 @@ RUN set -eux; \
     arm64)   ARCH="arm64";; \
   esac; \
   cd /sshnpd/sshnpd; \
-  cmake -B build -S . -DBUILD_SHARED_LIBS=off -DCMAKE_C_COMPILER=clang-18 -DCMAKE_C_FLAGS="-Wno-error -pthread"; \
+  cmake -B build -S . -DBUILD_SHARED_LIBS=off -DCMAKE_C_COMPILER=clang-19 -DCMAKE_C_FLAGS="-Wno-error -pthread"; \
   cmake --build build; \
   mkdir /tarball; \
   cd build; \


### PR DESCRIPTION
Some builds for c1.0.15 release [failed](https://github.com/atsign-foundation/noports/actions/runs/17428790370/job/49482093637) due to the Dockerfile specifying clang-18 but the newer C buildimage having clang-19:

```log
#9 0.072 + cmake -B build -S . -DBUILD_SHARED_LIBS=off -DCMAKE_C_COMPILER=clang-18 -DCMAKE_C_FLAGS=-Wno-error -pthread
#9 0.147 -- The C compiler identification is unknown
#9 0.149 CMake Error at CMakeLists.txt:4 (project):
#9 0.149   The CMAKE_C_COMPILER:
#9 0.149 
#9 0.149     clang-18
#9 0.149 
#9 0.149   is not a full path and was not found in the PATH.
#9 0.149 
#9 0.149   Tell CMake where to find the compiler by setting either the environment
#9 0.149   variable "CC" or the CMake cache entry CMAKE_C_COMPILER to the full path to
#9 0.149   the compiler, or to the compiler name if it is in the PATH.
#9 0.149 
#9 0.149 
#9 0.151 -- Configuring incomplete, errors occurred!
```

**- What I did**

Bumped Dockerfile to use clang-19

**- How to verify it**

I'll re-release c1.0.15 once this is merged.

**- Description for the changelog**

build(deps): Use clang-19 as that's what's in latest C buildimage
