### PR TITLE
fix: Move checkout to before download

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -188,6 +188,12 @@ jobs:
       id-token: write # IMPORTANT: mandatory for sigstore
       attestations: write
     steps:
+      - name: Get lockfile
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          sparse-checkout: |
+            packages/c/conan.lock
+          sparse-checkout-cone-mode: false
       - name: Download all the tarballs
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
@@ -203,12 +209,6 @@ jobs:
           rm -Rf -- */
           echo "After:"
           ls -latrR *
-      - name: Get lockfile
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          sparse-checkout: |
-            packages/c/conan.lock
-          sparse-checkout-cone-mode: false
       - name: Generate SBOM
         uses: sbomify/github-action@8ea6f28cd562edee2665001cd4f17aaf7a283722 # v0.5.0
         env:


### PR DESCRIPTION
Having a checkout after a download is messing up permissions (and possibly overwriting the downloaded files).

**- What I did**

Moved checkout to before download

**- How I did it**

Based on similar workflow in at_c

**- How to verify it**

Tested by running a release (now deleted) against this branch, which created this [actions run](https://github.com/atsign-foundation/noports/actions/runs/17434400444/job/49500765678)

**- Description for the changelog**

fix: Move checkout to before download