### PR TITLE
ci: Add COMPONENT_NAME of csshnpd to SBOM

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -215,6 +215,7 @@ jobs:
           TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
           COMPONENT_ID: 'Y6pppn8rC4'
           LOCK_FILE: './packages/c/conan.lock'
+          COMPONENT_NAME: 'csshnpd'
           COMPONENT_VERSION: ${{github.ref_name}}
           OUTPUT_FILE: 'tarballs/csshnpd-${{github.ref_name}}-sbom.cdx.json'
           AUGMENT: true


### PR DESCRIPTION
The SBOM component name is presently defaulting to `/github/workspace/packages/c/conan.lock` as that's the file being passed into Trivy by sbomify

**- What I did**

Added a COMPONENT_NAME

**- How I did it**

Following suggestion from @vpetersson

**- How to verify it**

Re-release c1.0.15

**- Description for the changelog**

ci: Add COMPONENT_NAME of csshnpd to SBOM
