### PR TITLE
feat: created mutex for sshnpd for load balancing/redundancy etc

### DIFF
--- a/docs/sshnpd-load-balancing.md
+++ b/docs/sshnpd-load-balancing.md
@@ -1,0 +1,73 @@
+# Session-Based Mutex for sshnpd Load Balancing
+
+## Overview
+
+This document describes the session-based mutex mechanism implemented in sshnpd to enable load balancing and redundancy across multiple sshnpd daemon instances listening on the same atSign and device name.
+
+## Problem
+
+Previously, when multiple sshnpd daemons were running on different machines but configured with the same atSign and device name, all daemons would respond to incoming connection notifications, causing confusion and connection failures.
+
+## Solution
+
+A session-based mutex mechanism similar to the one used in srvd.dart has been implemented. When a session-based request is received, only one sshnpd instance will acquire the mutex and handle the request, while others will ignore it.
+
+## How It Works
+
+### Mutex Key Generation
+For each session-based request, a mutex key is generated using the pattern:
+```
+{sessionId}.session_mutexes.{namespace}{deviceAtSign}
+```
+
+### Mutex Acquisition
+1. When sshnpd receives a session-based notification (`ssh_request`, `npt_request`, or legacy `sshd`), it attempts to create an immutable AtKey with the session ID
+2. The first sshnpd instance to successfully create the key acquires the mutex and processes the request
+3. Other instances receive an "immutable key" error and ignore the request
+4. The mutex key has a TTL of 30 seconds to prevent stale locks
+
+### Session ID Extraction
+- **ssh_request/npt_request**: Session ID is extracted from the JSON payload
+- **Legacy sshd**: Session ID is extracted from the space-separated payload (5th parameter for sshnp >=2.0.0 clients) or generated using notification ID for older clients
+
+### Supported Request Types
+- `ssh_request` - Modern SSH connection requests
+- `npt_request` - Network packet tunnel requests  
+- `sshd` - Legacy SSH connection requests
+
+### Non-Session Requests
+Requests that don't have sessions (like `ping`, `sshpublickey`, `privatekey`) are processed by all daemons without mutex, as they don't require exclusive handling.
+
+## Implementation Details
+
+### Key Methods
+- `tryAcquireSessionMutex()`: Attempts to acquire mutex for a session-based request
+- `extractSessionId()`: Extracts session ID from different notification formats
+
+### Error Handling
+- If session ID extraction fails, the request proceeds without mutex for backward compatibility
+- If mutex acquisition fails due to non-immutable errors, the request proceeds to maintain functionality
+- Only immutable key errors trigger request rejection
+
+### Logging
+- Successful mutex acquisition: `😎 Will handle {type} request from {client}; acquired mutex {key}`
+- Failed mutex acquisition: `🤷‍♂️ Will not handle {type} request from {client}; did not acquire session mutex (another sshnpd instance will handle this)`
+
+## Benefits
+
+1. **Load Balancing**: Multiple sshnpd instances can share the load automatically
+2. **Redundancy**: If one instance fails, others can take over new sessions
+3. **No Configuration Changes**: Existing clients work without modification
+4. **Backward Compatibility**: Graceful degradation for older clients or parsing errors
+
+## Testing
+
+Unit tests verify:
+- Session ID extraction from various notification formats
+- Mutex acquisition success and failure scenarios
+- Graceful handling of malformed notifications
+- Backward compatibility behavior
+
+## Usage
+
+No configuration changes are required. Simply run multiple sshnpd instances with the same atSign and device name on different machines. The mutex mechanism will automatically ensure only one instance handles each session.

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -281,8 +281,8 @@ class SshnpdImpl with AtClientBindings, ApkamSigning implements Sshnpd {
       String? resp;
       try {
         resp = await atClient.getRemoteSecondary()?.atLookUp.executeCommand(
-              'noop:0\n',
-            );
+          'noop:0\n',
+        );
       } catch (_) {}
       if (resp == null || !resp.startsWith('data:ok')) {
         if (lastHeartbeatOk) {
@@ -320,6 +320,18 @@ class SshnpdImpl with AtClientBindings, ApkamSigning implements Sshnpd {
         .toLowerCase();
 
     logger.info('Received: $notificationKey');
+
+    // For session-based requests, try to acquire mutex before processing
+    if (['ssh_request', 'npt_request', 'sshd'].contains(notificationKey)) {
+      bool mutexAcquired = await tryAcquireSessionMutex(
+        notification,
+        notificationKey,
+      );
+      if (!mutexAcquired) {
+        return; // Another sshnpd instance will handle this request
+      }
+    }
+
     switch (notificationKey) {
       case 'privatekey':
         logger.info(
@@ -413,6 +425,92 @@ class SshnpdImpl with AtClientBindings, ApkamSigning implements Sshnpd {
     );
   }
 
+  /// Attempts to acquire a session-based mutex for load balancing between multiple sshnpd instances.
+  /// Returns true if mutex was acquired (this instance should handle the request),
+  /// false if another instance already acquired the mutex (this instance should ignore the request).
+  @visibleForTesting
+  Future<bool> tryAcquireSessionMutex(
+    AtNotification notification,
+    String notificationKey,
+  ) async {
+    try {
+      // Extract session ID from the notification payload
+      String? sessionId = await extractSessionId(notification, notificationKey);
+      if (sessionId == null) {
+        logger.warning(
+          'Could not extract session ID from $notificationKey notification, proceeding without mutex',
+        );
+        return true; // Proceed without mutex for backward compatibility
+      }
+
+      // Create a mutex key using the session ID
+      var mutexKey =
+          AtKey.fromString(
+              '$sessionId'
+              '.session_mutexes.${DefaultArgs.namespace}'
+              '${atClient.getCurrentAtSign()!}',
+            )
+            ..metadata = (Metadata()
+              ..immutable =
+                  true // only one sshnpd will succeed in doing this
+              ..ttl = 30000); // expire after 30 seconds to keep datastore clean
+
+      PutRequestOptions pro = PutRequestOptions()
+        ..shouldEncrypt = false
+        ..useRemoteAtServer = true;
+
+      await atClient.put(mutexKey, 'lock', putRequestOptions: pro);
+      logger.shout(
+        '😎 Will handle $notificationKey request from ${notification.from}'
+        '; acquired mutex $mutexKey',
+      );
+      return true;
+    } catch (err) {
+      if (err.toString().toLowerCase().contains('immutable')) {
+        logger.shout(
+          '🤷‍♂️ Will not handle $notificationKey request from ${notification.from}'
+          '; did not acquire session mutex (another sshnpd instance will handle this)',
+        );
+        return false;
+      } else {
+        logger.shout('Unexpected error acquiring session mutex: $err');
+        return true; // Proceed anyway to maintain functionality
+      }
+    }
+  }
+
+  /// Extracts the session ID from notification payloads for mutex purposes
+  @visibleForTesting
+  Future<String?> extractSessionId(
+    AtNotification notification,
+    String notificationKey,
+  ) async {
+    try {
+      if (notificationKey == 'ssh_request' ||
+          notificationKey == 'npt_request') {
+        // Parse the JSON payload to extract session ID
+        final envelope = jsonDecode(notification.value!);
+        final Map<String, dynamic> params = envelope['payload'];
+        return params['sessionId'] as String?;
+      } else if (notificationKey == 'sshd') {
+        // Legacy format: notification value is `$remoteForwardPort $remotePort $username $remoteHost $sessionId`
+        List<String> sshList = notification.value!.split(' ');
+        if (sshList.length >= 5) {
+          // sshnp >=2.0.0 clients send sessionId as the 5th parameter
+          return sshList[4];
+        } else {
+          // sshnp <2.0.0 clients do not send sessionId - generate one based on notification ID
+          // This ensures the same sessionId is generated consistently for the same notification
+          return 'legacy_${notification.id}';
+        }
+      }
+      return null;
+    } catch (e) {
+      logger.warning('Failed to extract session ID from notification: $e');
+      return null;
+    }
+  }
+
   void _handlePingNotification(AtNotification notification) {
     logger.info(
       'ping received from ${notification.from} notification id : ${notification.id}',
@@ -426,7 +524,8 @@ class SshnpdImpl with AtClientBindings, ApkamSigning implements Sshnpd {
       ..metadata = (Metadata()
         ..isPublic = false
         ..isEncrypted = true
-        ..ttl = 10000 // allow only ten seconds before this record expires
+        ..ttl =
+            10000 // allow only ten seconds before this record expires
         ..namespaceAware = true);
 
     /// send a heartbeat back
@@ -1289,19 +1388,20 @@ class SshnpdImpl with AtClientBindings, ApkamSigning implements Sshnpd {
     // Lastly, we want to ensure that if the connection isn't used then it closes after 15 seconds
     // or once the last connection via the remote port has ended. For that we append 'sleep 15' to
     // the ssh command.
-    List<String> args = '$username@$host'
-            ' -p $port'
-            ' -i ${pemFile.absolute.path}'
-            ' -R $remoteForwardPort:localhost:$localSshdPort'
-            ' -o LogLevel=VERBOSE'
-            ' -t -t'
-            ' -o StrictHostKeyChecking=accept-new'
-            ' -o IdentitiesOnly=yes'
-            ' -o BatchMode=yes'
-            ' -o ExitOnForwardFailure=yes'
-            ' -f' // fork after authentication
-            ' sleep 15'
-        .split(' ');
+    List<String> args =
+        '$username@$host'
+                ' -p $port'
+                ' -i ${pemFile.absolute.path}'
+                ' -R $remoteForwardPort:localhost:$localSshdPort'
+                ' -o LogLevel=VERBOSE'
+                ' -t -t'
+                ' -o StrictHostKeyChecking=accept-new'
+                ' -o IdentitiesOnly=yes'
+                ' -o BatchMode=yes'
+                ' -o ExitOnForwardFailure=yes'
+                ' -f' // fork after authentication
+                ' sleep 15'
+            .split(' ');
     logger.info('$sessionId | Executing $opensshBinaryPath ${args.join(' ')}');
 
     // Because of the options we are using, we can wait for this process
@@ -1396,8 +1496,10 @@ class SshnpdImpl with AtClientBindings, ApkamSigning implements Sshnpd {
     var metaData = Metadata()
       ..isPublic = false
       ..isEncrypted = true
-      ..ttr = -1 // we want this to be cacheable by managerAtsign
-      ..ccd = true // we want cached copies to be deleted if the key is deleted
+      ..ttr =
+          -1 // we want this to be cacheable by managerAtsign
+      ..ccd =
+          true // we want cached copies to be deleted if the key is deleted
       ..namespaceAware = true;
 
     for (final managerAtsign in managerAtsigns) {
@@ -1447,9 +1549,12 @@ class SshnpdImpl with AtClientBindings, ApkamSigning implements Sshnpd {
     var metaData = Metadata()
       ..isPublic = false
       ..isEncrypted = true
-      ..ttr = -1 // we want this to be cacheable by managerAtsign
-      ..ccd = true // we want cached copies to be deleted if the key is deleted
-      ..ttl = ttl // but to expire after 30 days
+      ..ttr =
+          -1 // we want this to be cacheable by managerAtsign
+      ..ccd =
+          true // we want cached copies to be deleted if the key is deleted
+      ..ttl =
+          ttl // but to expire after 30 days
       ..updatedAt = DateTime.now()
       ..namespaceAware = true;
 

--- a/packages/dart/noports_core/test/sshnpd/sshnpd_mutex_test.dart
+++ b/packages/dart/noports_core/test/sshnpd/sshnpd_mutex_test.dart
@@ -1,0 +1,254 @@
+import 'dart:convert';
+import 'package:at_client/at_client.dart';
+import 'package:test/test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:noports_core/src/sshnpd/sshnpd_impl.dart';
+import 'package:noports_core/src/common/types.dart';
+
+// Mock classes
+class MockAtClient extends Mock implements AtClient {}
+
+class MockAtNotification extends Mock implements AtNotification {}
+
+class FakeAtKey extends Fake implements AtKey {}
+
+class FakePutRequestOptions extends Fake implements PutRequestOptions {}
+
+void main() {
+  group('SshnpdImpl Session Mutex Tests', () {
+    late MockAtClient mockAtClient;
+    late SshnpdImpl sshnpd;
+
+    setUpAll(() {
+      // Register fallback values for mocktail
+      registerFallbackValue(FakeAtKey());
+      registerFallbackValue(FakePutRequestOptions());
+    });
+
+    setUp(() {
+      mockAtClient = MockAtClient();
+
+      // Create SshnpdImpl instance with minimal required parameters
+      sshnpd = SshnpdImpl(
+        atClient: mockAtClient,
+        username: 'testuser',
+        homeDirectory: '/home/testuser',
+        device: 'testdevice',
+        managerAtsigns: ['@manager'],
+        policyManagerAtsign: null,
+        sshClient: SupportedSshClient.openssh,
+        makeDeviceInfoVisible: false,
+        addSshPublicKeys: false,
+        localSshdPort: 22,
+        sshPublicKeyPermissions: '',
+        ephemeralPermissions: '',
+        sshAlgorithm: SupportedSshAlgorithm.rsa,
+        deviceGroup: 'default',
+        version: '1.0.0',
+        permitOpen: ['*:*'],
+      );
+
+      // Set up common mock behaviors
+      when(() => mockAtClient.getCurrentAtSign()).thenReturn('@testdevice');
+    });
+
+    test(
+      'extractSessionId should extract session ID from ssh_request notification',
+      () async {
+        // Arrange
+        final mockNotification = MockAtNotification();
+        final sessionId = 'test-session-123';
+        final payload = {
+          'sessionId': sessionId,
+          'host': 'example.com',
+          'port': 22,
+          'direct': true,
+        };
+        final envelope = {
+          'payload': payload,
+          'signature': 'test-signature',
+          'hashingAlgo': 'sha256',
+          'signingAlgo': 'rsa2048',
+        };
+
+        when(() => mockNotification.value).thenReturn(jsonEncode(envelope));
+
+        // Act
+        final result = await sshnpd.extractSessionId(
+          mockNotification,
+          'ssh_request',
+        );
+
+        // Assert
+        expect(result, equals(sessionId));
+      },
+    );
+
+    test(
+      'extractSessionId should extract session ID from legacy sshd notification with session ID',
+      () async {
+        // Arrange
+        final mockNotification = MockAtNotification();
+        final sessionId = 'legacy-session-456';
+        final legacyPayload = '8080 22 testuser example.com $sessionId';
+
+        when(() => mockNotification.value).thenReturn(legacyPayload);
+
+        // Act
+        final result = await sshnpd.extractSessionId(mockNotification, 'sshd');
+
+        // Assert
+        expect(result, equals(sessionId));
+      },
+    );
+
+    test(
+      'extractSessionId should generate session ID for legacy sshd notification without session ID',
+      () async {
+        // Arrange
+        final mockNotification = MockAtNotification();
+        final notificationId = 'notification-123';
+        final legacyPayload = '8080 22 testuser example.com'; // No session ID
+
+        when(() => mockNotification.value).thenReturn(legacyPayload);
+        when(() => mockNotification.id).thenReturn(notificationId);
+
+        // Act
+        final result = await sshnpd.extractSessionId(mockNotification, 'sshd');
+
+        // Assert
+        expect(result, equals('legacy_$notificationId'));
+      },
+    );
+
+    test(
+      'extractSessionId should return null for non-session-based notifications',
+      () async {
+        // Arrange
+        final mockNotification = MockAtNotification();
+
+        when(() => mockNotification.value).thenReturn('test-value');
+
+        // Act
+        final result = await sshnpd.extractSessionId(mockNotification, 'ping');
+
+        // Assert
+        expect(result, isNull);
+      },
+    );
+
+    test(
+      'tryAcquireSessionMutex should return true when mutex is acquired successfully',
+      () async {
+        // Arrange
+        final mockNotification = MockAtNotification();
+        final sessionId = 'test-session-789';
+        final payload = {
+          'sessionId': sessionId,
+          'host': 'example.com',
+          'port': 22,
+          'direct': true,
+        };
+        final envelope = {
+          'payload': payload,
+          'signature': 'test-signature',
+          'hashingAlgo': 'sha256',
+          'signingAlgo': 'rsa2048',
+        };
+
+        when(() => mockNotification.value).thenReturn(jsonEncode(envelope));
+        when(() => mockNotification.from).thenReturn('@client');
+
+        // Mock successful mutex acquisition
+        when(
+          () => mockAtClient.put(
+            any(),
+            'lock',
+            putRequestOptions: any(named: 'putRequestOptions'),
+          ),
+        ).thenAnswer((_) async => true);
+
+        // Act
+        final result = await sshnpd.tryAcquireSessionMutex(
+          mockNotification,
+          'ssh_request',
+        );
+
+        // Assert
+        expect(result, isTrue);
+        verify(
+          () => mockAtClient.put(
+            any(),
+            'lock',
+            putRequestOptions: any(named: 'putRequestOptions'),
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'tryAcquireSessionMutex should return false when mutex acquisition fails due to immutable key',
+      () async {
+        // Arrange
+        final mockNotification = MockAtNotification();
+        final sessionId = 'test-session-conflict';
+        final payload = {
+          'sessionId': sessionId,
+          'host': 'example.com',
+          'port': 22,
+          'direct': true,
+        };
+        final envelope = {
+          'payload': payload,
+          'signature': 'test-signature',
+          'hashingAlgo': 'sha256',
+          'signingAlgo': 'rsa2048',
+        };
+
+        when(() => mockNotification.value).thenReturn(jsonEncode(envelope));
+        when(() => mockNotification.from).thenReturn('@client');
+
+        // Mock failed mutex acquisition (immutable key already exists)
+        when(
+          () => mockAtClient.put(
+            any(),
+            'lock',
+            putRequestOptions: any(named: 'putRequestOptions'),
+          ),
+        ).thenThrow(Exception('Cannot update immutable key'));
+
+        // Act
+        final result = await sshnpd.tryAcquireSessionMutex(
+          mockNotification,
+          'ssh_request',
+        );
+
+        // Assert
+        expect(result, isFalse);
+      },
+    );
+
+    test(
+      'tryAcquireSessionMutex should return true when session ID extraction fails',
+      () async {
+        // Arrange
+        final mockNotification = MockAtNotification();
+
+        when(() => mockNotification.value).thenReturn('invalid-json');
+        when(() => mockNotification.from).thenReturn('@client');
+
+        // Act
+        final result = await sshnpd.tryAcquireSessionMutex(
+          mockNotification,
+          'ssh_request',
+        );
+
+        // Assert
+        expect(
+          result,
+          isTrue,
+        ); // Should proceed without mutex for backward compatibility
+      },
+    );
+  });
+}


### PR DESCRIPTION

**- What I did**
Added functionality to sshnpd to be able to run multiple sshnpd for redundancy or load balancing

**- How I did it**
Used the Mutex code from srvd and added it to the sshnpd code base so only one sshnpd replies

**- How to verify it**
Tested by hand and passed tests

**- Description for the changelog**
sshnpd load balacing / redundancy support similar to the srvd existing solution using mutex code
