### PR TITLE
build(deps): at_client 3.8.0, at_cli_commons 3.0.0, at_onboarding_cli 1.13.0; rc version 5.12.1

### DIFF
--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -85,11 +85,10 @@ packages:
   at_cli_commons:
     dependency: "direct main"
     description:
-      path: "packages/at_cli_commons"
-      ref: "at_cli_commons-3.0.1"
-      resolved-ref: "63b8758aa9e01dc6a124ca258108290b65505dd0"
-      url: "https://github.com/atsign-foundation/at_client_sdk"
-    source: git
+      name: at_cli_commons
+      sha256: f6653791ac37df5097dd39433a62b3372c4c644cd03729e599eb4c85990c9431
+      url: "https://pub.dev"
+    source: hosted
     version: "3.0.1"
   at_client:
     dependency: "direct main"

--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -86,18 +86,18 @@ packages:
     dependency: "direct main"
     description:
       name: at_cli_commons
-      sha256: "8a651a9baf9c83e689bd80a5e9b4e1b2bb3e2f147475fdefa4cf48a9eb78fd92"
+      sha256: "73f5b651d3b7074f3516a61b8ff27374eb22364dbe712432a811678ae844bc5f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.0"
   at_client:
     dependency: "direct main"
     description:
       name: at_client
-      sha256: ab0caa6f54a3d0a325dab30dfab8b12e358d1f7ee1ca952137d3913ef6cf8c16
+      sha256: "17f92dc153308b7a0809aa52d311d2f85965bfdd94678f4718a6502cbf34e4e3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.7.0"
+    version: "3.8.0"
   at_commons:
     dependency: transitive
     description:

--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -592,7 +592,7 @@ packages:
       path: "../../../packages/dart/noports_core"
       relative: true
     source: path
-    version: "6.8.0"
+    version: "6.8.1"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -85,11 +85,12 @@ packages:
   at_cli_commons:
     dependency: "direct main"
     description:
-      name: at_cli_commons
-      sha256: "73f5b651d3b7074f3516a61b8ff27374eb22364dbe712432a811678ae844bc5f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.0"
+      path: "packages/at_cli_commons"
+      ref: "at_cli_commons-3.0.1"
+      resolved-ref: "63b8758aa9e01dc6a124ca258108290b65505dd0"
+      url: "https://github.com/atsign-foundation/at_client_sdk"
+    source: git
+    version: "3.0.1"
   at_client:
     dependency: "direct main"
     description:

--- a/apps/admin/admin_api/pubspec.yaml
+++ b/apps/admin/admin_api/pubspec.yaml
@@ -19,6 +19,11 @@ dependencies:
     path: ../../../packages/dart/noports_core
 
 dependency_overrides:
+  at_cli_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk
+      ref: at_cli_commons-3.0.1
+      path: packages/at_cli_commons
   alfred:
     git:
       ref: cc-directory-4-windows

--- a/apps/admin/admin_api/pubspec.yaml
+++ b/apps/admin/admin_api/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 # Add regular dependencies here.
 dependencies:
   alfred: 1.1.2+1
-  at_client: ^3.7.0
+  at_client: ^3.8.0
   json_annotation: 4.9.0
-  at_cli_commons: 2.2.0
+  at_cli_commons: ^3.0.0
   args: 2.7.0
   meta: 1.17.0
   noports_core:

--- a/apps/admin/admin_api/pubspec.yaml
+++ b/apps/admin/admin_api/pubspec.yaml
@@ -12,18 +12,13 @@ dependencies:
   alfred: 1.1.2+1
   at_client: ^3.8.0
   json_annotation: 4.9.0
-  at_cli_commons: ^3.0.0
+  at_cli_commons: ^3.0.1
   args: 2.7.0
   meta: 1.17.0
   noports_core:
     path: ../../../packages/dart/noports_core
 
 dependency_overrides:
-  at_cli_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_client_sdk
-      ref: at_cli_commons-3.0.1
-      path: packages/at_cli_commons
   alfred:
     git:
       ref: cc-directory-4-windows

--- a/packages/dart/noports_core/CHANGELOG.md
+++ b/packages/dart/noports_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.8.1
+
+- build(deps): at_client -> 3.8.0, at_cli_commons -> 3.0.0
+
 # 6.8.0
 
 - feat: Enable npt clients to choose which local IP address to bind to, 

--- a/packages/dart/noports_core/lib/src/version.dart
+++ b/packages/dart/noports_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '6.8.0';
+const packageVersion = '6.8.1';

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   args: ^2.4.2
   at_chops: ^2.0.1
-  at_client: ^3.7.0
+  at_client: ^3.8.0
   at_commons: ^5.6.1
-  at_cli_commons: ^2.1.0
+  at_cli_commons: ^3.0.0
   at_utils: ^3.0.19
   cryptography: ^2.7.0
   dartssh2: ^2.8.2

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   at_chops: ^2.0.1
   at_client: ^3.8.0
   at_commons: ^5.6.1
-  at_cli_commons: ^3.0.0
+  at_cli_commons: ^3.0.1
   at_utils: ^3.0.19
   cryptography: ^2.7.0
   dartssh2: ^2.8.2
@@ -29,11 +29,6 @@ dependencies:
   version: ^3.0.2
 
 dependency_overrides:
-  at_cli_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_client_sdk
-      ref: at_cli_commons-3.0.1
-      path: packages/at_cli_commons
   dartssh2:
     git:
       url: https://github.com/atsign-foundation/dartssh2

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -29,6 +29,11 @@ dependencies:
   version: ^3.0.2
 
 dependency_overrides:
+  at_cli_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk
+      ref: at_cli_commons-3.0.1
+      path: packages/at_cli_commons
   dartssh2:
     git:
       url: https://github.com/atsign-foundation/dartssh2

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: noports_core
 description: Core library code for sshnoports
 homepage: https://docs.atsign.com/
 
-version: 6.8.0
+version: 6.8.1
 
 environment:
   sdk: ">=3.8.0"

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -957,7 +957,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.8.0"
+    version: "6.8.1"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -93,18 +93,18 @@ packages:
     dependency: transitive
     description:
       name: at_cli_commons
-      sha256: "8a651a9baf9c83e689bd80a5e9b4e1b2bb3e2f147475fdefa4cf48a9eb78fd92"
+      sha256: "73f5b651d3b7074f3516a61b8ff27374eb22364dbe712432a811678ae844bc5f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.0"
   at_client:
     dependency: "direct main"
     description:
       name: at_client
-      sha256: ab0caa6f54a3d0a325dab30dfab8b12e358d1f7ee1ca952137d3913ef6cf8c16
+      sha256: "17f92dc153308b7a0809aa52d311d2f85965bfdd94678f4718a6502cbf34e4e3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.7.0"
+    version: "3.8.0"
   at_client_mobile:
     dependency: "direct main"
     description:

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: at_cli_commons
-      sha256: "73f5b651d3b7074f3516a61b8ff27374eb22364dbe712432a811678ae844bc5f"
+      sha256: f6653791ac37df5097dd39433a62b3372c4c644cd03729e599eb4c85990c9431
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   at_client:
     dependency: "direct main"
     description:

--- a/packages/dart/npt_flutter/test/features/profile/repository/profile_repository_test.mocks.dart
+++ b/packages/dart/npt_flutter/test/features/profile/repository/profile_repository_test.mocks.dart
@@ -289,6 +289,7 @@ class MockAtClient extends _i1.Mock implements _i2.AtClient {
     String? sharedBy,
     String? sharedWith,
     bool? showHiddenKeys = false,
+    bool? useRemoteAtServer = false,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getAtKeys, [], {
@@ -296,6 +297,7 @@ class MockAtClient extends _i1.Mock implements _i2.AtClient {
               #sharedBy: sharedBy,
               #sharedWith: sharedWith,
               #showHiddenKeys: showHiddenKeys,
+              #useRemoteAtServer: useRemoteAtServer,
             }),
             returnValue: _i6.Future<List<_i2.AtKey>>.value(<_i2.AtKey>[]),
           )
@@ -307,6 +309,7 @@ class MockAtClient extends _i1.Mock implements _i2.AtClient {
     String? sharedBy,
     String? sharedWith,
     bool? showHiddenKeys = false,
+    bool? useRemoteAtServer = false,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getKeys, [], {
@@ -314,6 +317,7 @@ class MockAtClient extends _i1.Mock implements _i2.AtClient {
               #sharedBy: sharedBy,
               #sharedWith: sharedWith,
               #showHiddenKeys: showHiddenKeys,
+              #useRemoteAtServer: useRemoteAtServer,
             }),
             returnValue: _i6.Future<List<String>>.value(<String>[]),
           )

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.12.0';
+const packageVersion = '5.12.1';

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -77,18 +77,18 @@ packages:
     dependency: "direct main"
     description:
       name: at_cli_commons
-      sha256: "8a651a9baf9c83e689bd80a5e9b4e1b2bb3e2f147475fdefa4cf48a9eb78fd92"
+      sha256: "73f5b651d3b7074f3516a61b8ff27374eb22364dbe712432a811678ae844bc5f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.0"
   at_client:
     dependency: "direct main"
     description:
       name: at_client
-      sha256: ab0caa6f54a3d0a325dab30dfab8b12e358d1f7ee1ca952137d3913ef6cf8c16
+      sha256: "17f92dc153308b7a0809aa52d311d2f85965bfdd94678f4718a6502cbf34e4e3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.7.0"
+    version: "3.8.0"
   at_commons:
     dependency: "direct main"
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_onboarding_cli
-      sha256: "264be4a871a4d6cc417ae74886eebac36defc72297f4a9dd4dda37b720bdfbc0"
+      sha256: e6ab94bbfcbfeaf8211773a32b47be07726c33c364b9322fe21d97b6500a8311
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.13.0"
   at_persistence_secondary_server:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -76,11 +76,12 @@ packages:
   at_cli_commons:
     dependency: "direct main"
     description:
-      name: at_cli_commons
-      sha256: "73f5b651d3b7074f3516a61b8ff27374eb22364dbe712432a811678ae844bc5f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.0"
+      path: "packages/at_cli_commons"
+      ref: "at_cli_commons-3.0.1"
+      resolved-ref: "63b8758aa9e01dc6a124ca258108290b65505dd0"
+      url: "https://github.com/atsign-foundation/at_client_sdk"
+    source: git
+    version: "3.0.1"
   at_client:
     dependency: "direct main"
     description:

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -576,7 +576,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.8.0"
+    version: "6.8.1"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -76,11 +76,10 @@ packages:
   at_cli_commons:
     dependency: "direct main"
     description:
-      path: "packages/at_cli_commons"
-      ref: "at_cli_commons-3.0.1"
-      resolved-ref: "63b8758aa9e01dc6a124ca258108290b65505dd0"
-      url: "https://github.com/atsign-foundation/at_client_sdk"
-    source: git
+      name: at_cli_commons
+      sha256: f6653791ac37df5097dd39433a62b3372c4c644cd03729e599eb4c85990c9431
+      url: "https://pub.dev"
+    source: hosted
     version: "3.0.1"
   at_client:
     dependency: "direct main"

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -9,10 +9,10 @@ environment:
 dependencies:
   noports_core:
     path: "../noports_core"
-  at_onboarding_cli: 1.12.0
+  at_onboarding_cli: ^1.13.0
   at_commons: ^5.6.1
-  at_cli_commons: 2.2.0
-  at_client: ^3.7.0
+  at_cli_commons: ^3.0.0
+  at_client: ^3.8.0
   args: 2.7.0
   socket_connector: 2.3.3
   dartssh2: 2.11.0

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     path: "../noports_core"
   at_onboarding_cli: ^1.13.0
   at_commons: ^5.6.1
-  at_cli_commons: ^3.0.0
+  at_cli_commons: ^3.0.1
   at_client: ^3.8.0
   args: 2.7.0
   socket_connector: 2.3.3
@@ -23,11 +23,6 @@ dependencies:
   yaml: 3.1.3
 
 dependency_overrides:
-  at_cli_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_client_sdk
-      ref: at_cli_commons-3.0.1
-      path: packages/at_cli_commons
   dartssh2:
     git:
       url: https://github.com/atsign-foundation/dartssh2

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -23,6 +23,11 @@ dependencies:
   yaml: 3.1.3
 
 dependency_overrides:
+  at_cli_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk
+      ref: at_cli_commons-3.0.1
+      path: packages/at_cli_commons
   dartssh2:
     git:
       url: https://github.com/atsign-foundation/dartssh2

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.12.0
+version: 5.12.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
**- What I did**
- build(deps): at_client -> 3.8.0, at_cli_commons -> 3.0.0, at_onboarding_cli -> 1.13.0
- build: versions: no_ports_core 6.8.0 -> 6.8.1; sshnoports 5.12.0 -> 5.12.1

**- How I did it**
- Updated, then ran dart run melos bootstrap from repo root

**- How to verify it**
Tests pass
