### PR TITLE
feat: proxy support for `npt_flutter`

### DIFF
--- a/packages/dart/npt_flutter/pubspec.yaml
+++ b/packages/dart/npt_flutter/pubspec.yaml
@@ -38,7 +38,7 @@ environment:
 # versions available, run `flutter pub outdated`.
 dependencies:
   adaptive_theme: ^3.6.0
-  at_auth: ^2.0.7
+  at_auth: ^2.4.0
   at_backupkey_flutter: ^4.0.16
   at_client_mobile: ^3.2.24
   at_client: ^3.8.0


### PR DESCRIPTION
**- What I did**
- Added proxy support to NoPorts Desktop

**- How I did it**
- updated at_auth to ^2.4.0 in npt_flutter

**- How to verify it**
Build NoPorts Desktop and set the root Domain as this (you may need to "reset" your atSign aka remove your atSign)

<img width="1047" height="513" alt="image" src="https://github.com/user-attachments/assets/e4620504-61e5-494e-bc28-e0ba348c5538" />

`proxy:proxy0001.atsign.org:443` is our proxy server that points to production

I get this log `flutter: Emitted State   | OnboardingState(@tastelessbanana, onboarded, proxy:proxy0001.atsign.org:443)`

**- Description for the changelog**
feat: proxy support for `npt_flutter`
