### PR TITLE
fix: npt_flutter read the correct heartbeat key namespace and unify the heartbeat rpc notifications to use `sshnp` namespace

### DIFF
--- a/packages/dart/npt_flutter/lib/features/policy/cubit/status_light/policy_status_light_cubit.dart
+++ b/packages/dart/npt_flutter/lib/features/policy/cubit/status_light/policy_status_light_cubit.dart
@@ -19,7 +19,7 @@ final class PolicyStatusLightCubit
       final AtKey atKey = AtKey()
         ..key = 'heartbeat'
         ..sharedBy = atClient.getCurrentAtSign()
-        ..namespace = atClient.getPreferences()!.namespace!;
+        ..namespace = 'sshnp';
 
       final AtValue atValue = await atClient.get(
         atKey,

--- a/packages/dart/npt_flutter/lib/features/policy/cubit/status_light/policy_status_light_cubit.dart
+++ b/packages/dart/npt_flutter/lib/features/policy/cubit/status_light/policy_status_light_cubit.dart
@@ -124,7 +124,7 @@ final class PolicyStatusLightCubit
     final rpc = AtRpcClient(
       serverAtsign: atClient.getCurrentAtSign()!,
       atClient: atClient,
-      baseNameSpace: 'sshnp.noports',
+      baseNameSpace: 'sshnp',
       domainNameSpace: 'npp_atserver_heartbeat',
     );
 

--- a/packages/dart/sshnoports/bin/npp_atserver.dart
+++ b/packages/dart/sshnoports/bin/npp_atserver.dart
@@ -129,7 +129,7 @@ void main(List<String> args) async {
   logger.shout('Starting AtRpc Server to listen for forced heartbeats...');
   AtRpc(
     atClient: atClient,
-    baseNameSpace: 'sshnp.noports',
+    baseNameSpace: 'sshnp',
     domainNameSpace: 'npp_atserver_heartbeat',
     callbacks: _HeartbeatHelper(atClient: atClient),
     allowList: {atClient.getCurrentAtSign()!}.toSet(),


### PR DESCRIPTION
**- What I did**

## **first thing is the heartbeat key fix**

You get this error message when trying to read the Policy Server's heartbeat on NoPorts Desktop (`heartbeat.noports@` <- incorrect)

<img width="779" height="93" alt="image" src="https://github.com/user-attachments/assets/7e27aa39-4c0c-4891-b123-eacc0759e438" />

But that key will never exist because the actual key's name is this: `heartbeat.sshnp@` <- correct

<img width="699" height="332" alt="image" src="https://github.com/user-attachments/assets/35902c47-ffbe-41ba-81db-2ee57103ac6c" />

## **second thing is changing the atrpc base namespace from `sshnp.noports` to just `sshnp`**

After some thought, I think that both the NoPorts Desktop client and Policy server should just be using the `sshnp` namespace because it is guaranteed that the client's APKAM keys using either of these services will be allowed on the `sshnp` namespace, but might not always be the `noports` namespace.

For some context, the `noports` namespace is used in NoPorts Desktop and `sshnp` is used in `sshnoports/bin/` applications. These two types of applications will surely be used by APKAM keys that have access to the `sshnp` space, but might not always have access to the `noports` namespace.

For some more additional context, we had a `namespaceAware=true` bug that was fixed in `at_client: ^3.8.0` which is why it was `sshnp.noports` in the first place, but now that it is fixed, we should just change it to `sshnp` to make things simple.

A good take away from this is that when you are writing same atSign to same atSign notifications code within NoPorts , developer should use the `sshnp` namespace so that everything works good

**- Description for changelog**
fix: npt_flutter read the correct heartbeat key namespace and unify the heartbeat rpc notifications to use `sshnp` namespace