### PR TITLE
docs: Correct repo name

### DIFF
--- a/packages/dart/npt_flutter/README.md
+++ b/packages/dart/npt_flutter/README.md
@@ -35,7 +35,7 @@ NoPorts Desktop is a Flutter application that provides secure SSH connections wi
 1. Clone the repository:
 
    ```bash
-   git clone https://github.com/atsign-foundation/sshnoports.git
+   git clone https://github.com/atsign-foundation/noports.git
    cd sshnoports/packages/dart/npt_flutter
    ```
 


### PR DESCRIPTION
README for npt_flutter still references old repo name

**- What I did**

s/ssh//

**- How to verify it**

Rich diff

**- Description for the changelog**

docs: Correct repo name
