### PR TITLE
fix: policy status light and npp_atserver time synchronization

### DIFF
--- a/packages/dart/npt_flutter/lib/features/policy/cubit/status_light/policy_status_light_cubit.dart
+++ b/packages/dart/npt_flutter/lib/features/policy/cubit/status_light/policy_status_light_cubit.dart
@@ -84,15 +84,14 @@ final class PolicyStatusLightCubit
 
       final Duration interval = Duration(seconds: intervalObject);
 
-      final DateTime nowUtc = DateTime.now().toUtc();
+      final DateTime nowUtc = DateTime.timestamp().toUtc();
       final DateTime heartbeatUtc = timestamp.toUtc();
       final Duration delta = nowUtc.difference(heartbeatUtc);
 
-      bool isFresh = false;
-      if (!delta.isNegative) {
-        // e.g. if interval is 60 seconds, then heartbeat is fresh if last heartbeat was within the last 60 seconds
-        isFresh = delta <= interval;
-      }
+      // e.g. if interval is 60 seconds, then heartbeat is fresh if last heartbeat was within the last 60 seconds
+      bool isFresh = !delta.isNegative && delta <= interval;
+
+      logger.info('Heartbeat check: nowUtc=$nowUtc, heartbeatUtc=$heartbeatUtc, delta=$delta, interval=$interval, isFresh=$isFresh');
 
       final LightState lightState = isFresh ? LightState.green : LightState.red;
       final String message = _buildMessage(delta, heartbeatUtc);

--- a/packages/dart/sshnoports/bin/npp_atserver.dart
+++ b/packages/dart/sshnoports/bin/npp_atserver.dart
@@ -213,7 +213,7 @@ class Handler implements NPARequestHandler {
 }
 
 Future<bool> _updateHeartbeatKey(final AtClient atClient) async {
-  final timestamp = DateTime.now();
+  final timestamp = DateTime.timestamp().toUtc();
   final atKey = AtKey()
         ..key = 'heartbeat'
         ..sharedBy = atClient.getCurrentAtSign()


### PR DESCRIPTION
**- What I did**

- Fixed the heartbeat giving weird negative numbers
- Found out that the issue was because two machines with different timezones wouldn't do the time math correctly.
- This PR is related to https://github.com/atsign-foundation/noports/issues/2209

**- How I did it**

- Use `DateTime.timestamp()` instead of `DateTime.now()`. `DateTime.timestamp()` will give a UTC timestamp versus `DateTime.now()` which will give a local timezone timestamp. See docs: https://api.flutter.dev/flutter/dart-core/DateTime-class.html

**- How to verify it**

See my "TIL" here: https://github.com/atsign-foundation/noports/issues/2209#issuecomment-3406751794

**- Description for the changelog**
fix: policy status light and npp_atserver time synchronization