### PR TITLE
fix: Remove SLSA for workflow

### DIFF
--- a/.github/workflows/dockerhub_sshnpd.yml
+++ b/.github/workflows/dockerhub_sshnpd.yml
@@ -169,13 +169,6 @@ jobs:
           IMAGES="${IMAGE}@${IMAGE_DIGEST}"
           IMAGES+=" atsigncompany/${{ matrix.name }}:${{ env.TAG2 }}@${IMAGE_DIGEST}"
           cosign sign --yes ${IMAGES}
-      - name: Upload image digest file
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: all-image-digests # A single name for the artifact bundle
-          path: ./*_digest.json
-          # GitHub collects all files uploaded with this name across the matrix runs
-          # into a single artifact that the next job can download.
       # Promote to canary
       - name: Update and sign canary tag
         if: startsWith(github.ref, 'refs/tags/v')
@@ -192,38 +185,3 @@ jobs:
           IMAGES="${CANARY}@${CANARY_DIGEST}"
           IMAGES+=" atsigncompany/${{ matrix.name }}:canary-${{ github.ref_name }}@${CANARY_DIGEST}"
           cosign sign --yes ${IMAGES}
-
-  aggregate_digests:
-    runs-on: ubuntu-latest
-    needs: [docker_combine]
-    outputs:
-      slsa_matrix: ${{ steps.create_matrix.outputs.matrix_json }}
-    steps:
-      - name: Download all-image-digests artifact
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
-        with:
-          name: all-image-digests
-          path: ./digests
-      - name: Combine digests into a single JSON array
-        id: create_matrix
-        run: |
-          MATRIX_JSON=$(jq -s '.' ./digests/*_digest.json)
-          echo "matrix_json=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
-          echo "::notice::Generated SLSA Matrix JSON: ${MATRIX_JSON}"
-
-  slsa_provenance:
-    needs: [aggregate_digests]
-    permissions:
-      actions: read # for detecting the Github Actions environment.
-      id-token: write # for creating OIDC tokens for signing.
-      packages: write # for uploading attestations.
-    strategy:
-      matrix:
-        image_data: ${{ fromJson(needs.aggregate_digests.outputs.slsa_matrix) }}
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
-    with:
-      image: ${{ matrix.image_data.name }}
-      digest: ${{ matrix.image_data.digest }}
-    secrets:
-      registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
-      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Marshalling the digests via uploaded artifacts isn't working as it should. I'll take another pass once it's been shaken out in a test repo.

**- What I did**

Remove artifact upload and the SLSA attestation that depends on it.

**- How to verify it**

Docker workflow on merging this PR should run clean

**- Description for the changelog**

fix: Remove SLSA for workflow