### PR TITLE
feat: sshnpd config file support using config package

### DIFF
--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd.dart
@@ -90,6 +90,7 @@ abstract class Sshnpd {
     AtClient? atClient,
     FutureOr<AtClient> Function(SshnpdParams)? atClientGenerator,
     void Function(Object, StackTrace)? usageCallback,
+    void Function()? helpCallback,
     required String version,
   }) async {
     return SshnpdImpl.fromCommandLineArgs(
@@ -97,6 +98,7 @@ abstract class Sshnpd {
       atClient: atClient,
       atClientGenerator: atClientGenerator,
       usageCallback: usageCallback,
+      helpCallback: helpCallback,
       version: version,
     );
   }

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_config.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_config.dart
@@ -1,0 +1,357 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:config/config.dart';
+import 'package:noports_core/sshnp_foundation.dart';
+import 'package:yaml/yaml.dart';
+
+const OptionGroup mainGroup = OptionGroup("atSign Options");
+const OptionGroup deviceConfigGroup = OptionGroup(
+  "Device Configuration Options",
+);
+const OptionGroup accessControlGroup = OptionGroup("Access Control Options");
+const OptionGroup sshGroup = OptionGroup("Sshd Configuration Options");
+const OptionGroup runtimeGroup = OptionGroup("Runtime Options");
+
+File _defaultConfigFilePath() {
+  switch (Platform.operatingSystem) {
+    case "windows":
+      final programData = Platform.environment['ProgramData'];
+      return File("$programData/NoPorts/sshnpd.yaml");
+    case "macos":
+      // TODO
+      return File("/NoPorts/sshnpd.yaml");
+    default:
+      return File("/etc/noports/sshnpd.yaml");
+  }
+}
+
+enum SshnpdOption<V> implements OptionDefinition<V> {
+  // Config must be the first option otherwise this errors
+  configFile(
+    FileOption(
+      argName: "config",
+      envName: "SSHNPD_CONFIG",
+      helpText: "The path to a config file",
+      fromDefault: _defaultConfigFilePath,
+      mandatory: false,
+      mode: PathExistMode.mayExist,
+      group: runtimeGroup,
+    ),
+  ),
+
+  // atSign Options Group
+  keyfile(
+    StringOption(
+      argName: 'key-file',
+      configKey: '/atsign/keys',
+      argAliases: ['keyFile'],
+      argAbbrev: 'k',
+      mandatory: false,
+      helpText:
+          'Sending atSign\'s keyFile if not in ~/.atsign/keys/'
+          '  Alias: --keyFile',
+      group: mainGroup,
+    ),
+  ),
+
+  atsign(
+    StringOption(
+      argName: 'atsign',
+      configKey: '/atsign/atsign',
+      argAbbrev: 'a',
+      mandatory: true,
+      helpText: 'atSign of this device',
+      group: mainGroup,
+    ),
+  ),
+
+  rootServer(
+    StringOption(
+      argName: 'root-server',
+      configKey: '/atsign/root',
+      argAliases: ['root-domain'],
+      mandatory: false,
+      defaultsTo: 'root.atsign.org',
+      helpText:
+          'atDirectory domain.'
+          ' Alias (for backwards compatibility): --root-domain',
+      group: mainGroup,
+    ),
+  ),
+
+  // Access Control Group
+  managers(
+    MultiStringOption(
+      argName: 'managers',
+      configKey: '/access/managers',
+      argAliases: ['manager'],
+      argAbbrev: 'm',
+      mandatory: false,
+      helpText:
+          'atSign or list of atSigns (comma separated)'
+          ' that this device will accept requests from.'
+          ' At least one of --managers and --policy-manager must be supplied.'
+          ' If both --managers and --policy-manager are supplied then '
+          ' the daemon will check with the --policy-manager atSign re '
+          ' requests which come from atSigns not in the --managers list.',
+      group: accessControlGroup,
+    ),
+  ),
+
+  policyManager(
+    StringOption(
+      argName: 'policy-manager',
+      configKey: '/access/policy',
+      argAbbrev: 'p',
+      mandatory: false,
+      helpText:
+          'The atSign which this device will use to decide whether or not to '
+          ' accept requests from some client atSign. '
+          ' At least one of --managers and --policy-manager must be supplied.'
+          ' If both --managers and --policy-manager are supplied then '
+          ' the daemon will check with the --policy-manager atSign re '
+          ' requests which come from atSigns not in the --managers list.',
+      group: accessControlGroup,
+    ),
+  ),
+
+  permitOpen(
+    MultiStringOption(
+      argName: 'permit-open',
+      configKey: '/access/permitopen',
+      argAliases: ['po'],
+      mandatory: false,
+      helpText:
+          'Comma separated-list of host:port to which the daemon will permit'
+          ' a connection from an authorized client. Hosts may be dns names or'
+          ' ip addresses.'
+          ' Alias: --po',
+      group: accessControlGroup,
+    ),
+  ),
+
+  // Device Configuration Group
+  device(
+    StringOption(
+      argName: 'device',
+      configKey: '/device/name',
+      argAbbrev: 'd',
+      mandatory: false,
+      defaultsTo: "default",
+      helpText:
+          'This daemon will operate with this device name;'
+          ' allows multiple devices to share an atSign.',
+      group: deviceConfigGroup,
+    ),
+  ),
+
+  deviceGroup(
+    StringOption(
+      argName: 'device-group',
+      configKey: '/device/group',
+      argAliases: ['dg'],
+      mandatory: false,
+      defaultsTo: DefaultSshnpdArgs.deviceGroupName,
+      helpText:
+          'The name of this device\'s group. When delegated authorization'
+          ' is being used then the group name is sent to the authorizer'
+          ' service as well as the device name, this daemon\'s atSign, '
+          ' and the client atSign which is requesting a connection.'
+          ' Alias: --dg',
+      group: deviceConfigGroup,
+    ),
+  ),
+
+  hide(
+    FlagOption(
+      argName: 'hide',
+      configKey: '/device/hide',
+      argAbbrev: 'h',
+      defaultsTo: false,
+      helpText:
+          'Hides the device from advertising its information to the manager'
+          ' atSign. Even with this enabled, sshnpd will still respond to ping'
+          ' requests from the manager. (This takes priority over -u / --un-hide)',
+      group: deviceConfigGroup,
+    ),
+  ),
+
+  unHide(
+    FlagOption(
+      argName: 'un-hide',
+      argAbbrev: 'u',
+      argAliases: ['username'],
+      defaultsTo: true,
+      hide: true,
+      group: deviceConfigGroup,
+    ),
+  ),
+
+  // Sshd Configuration Group
+  addSshPublicKey(
+    FlagOption(
+      argName: 'sshpublickey',
+      configKey: '/ssh/add-publickeys',
+      argAbbrev: 's',
+      defaultsTo: false,
+      helpText:
+          'When set, will update authorized_keys'
+          ' to include public key sent by manager',
+      group: sshGroup,
+    ),
+  ),
+
+  sshClient(
+    EnumOption(
+      enumParser: EnumParser(SupportedSshClient.values),
+      argName: 'ssh-client',
+      configKey: '/ssh/client',
+      mandatory: false,
+      defaultsTo: DefaultSshnpdArgs.sshClient,
+      helpText: 'What to use for outbound ssh connections.',
+      group: sshGroup,
+    ),
+  ),
+
+  localSshdPort(
+    IntOption(
+      argName: 'local-sshd-port',
+      configKey: '/ssh/sshd-port',
+      mandatory: false,
+      defaultsTo: DefaultSshnpdArgs.localSshdPort,
+      helpText: 'port on which sshd is listening locally on localhost',
+      min: 1,
+      max: 65535,
+      group: sshGroup,
+    ),
+  ),
+
+  sshPublicKeyPermissions(
+    MultiStringOption(
+      argName: 'sshpublickey-permissions',
+      configKey: '/ssh/publickey-permissions',
+      argAbbrev: 'S',
+      defaultsTo: [],
+      helpText:
+          'When --sshpublickey is enabled, will include the specified permissions'
+          ' in the public key entry in authorized_keys',
+      group: sshGroup,
+    ),
+  ),
+
+  sshEphemeralPermissions(
+    MultiStringOption(
+      argName: 'ephemeral-permissions',
+      configKey: '/ssh/ephemeral-permissions',
+      mandatory: false,
+      defaultsTo: [],
+      helpText:
+          'The permissions which will be added to the authorized_keys file'
+          ' for the ephemeral public keys which are generated when a client'
+          ' is connecting via forward ssh'
+          ' e.g. PermitOpen="host-1:3389",PermitOpen="localhost:80"',
+      group: sshGroup,
+    ),
+  ),
+
+  sshAlgorithm(
+    EnumOption(
+      enumParser: EnumParser(SupportedSshAlgorithm.values),
+      argName: 'ssh-algorithm',
+      configKey: '/ssh/algorithm',
+      defaultsTo: DefaultArgs.sshAlgorithm,
+      helpText: 'Use RSA 4096 keys rather than the default ED25519 keys',
+      group: sshGroup,
+    ),
+  ),
+
+  // Runtime Options
+  storagePath(
+    DirOption(
+      argName: 'storage-path',
+      configKey: '/runtime/storage-path',
+      mandatory: false,
+      helpText:
+          'Directory for local storage.'
+          r' Defaults to $HOME/.atsign/storage/$atSign/.npd/$deviceName/',
+      group: runtimeGroup,
+    ),
+  ),
+
+  clearCachedPks(
+    FlagOption(
+      argName: 'clear-cached-pks',
+      configKey: '/runtime/clear-cached-pks',
+      helpText: 'Clear cached public keys',
+      hide: true,
+      defaultsTo: false,
+      group: runtimeGroup,
+    ),
+  ),
+
+  verbose(
+    FlagOption(
+      argName: 'verbose',
+      configKey: '/runtime/verbose',
+      argAbbrev: 'v',
+      defaultsTo: false,
+      helpText: 'More logging',
+      group: runtimeGroup,
+    ),
+  ),
+
+  help(
+    FlagOption(
+      argName: 'help',
+      defaultsTo: false,
+      helpText: 'Show usage',
+      group: runtimeGroup,
+    ),
+  );
+
+  const SshnpdOption(this.option);
+
+  @override
+  final ConfigOptionBase<V> option;
+
+  static ArgParser get argParser {
+    final parser = ArgParser(
+      usageLineLength: stdout.hasTerminal ? stdout.terminalColumns : null,
+    );
+    values.prepareForParsing(parser);
+    return parser;
+  }
+
+  static String get usage => argParser.usage;
+}
+
+class SshnpdConfigBroker implements ConfigurationBroker {
+  ({ConfigurationSource? config})? _cached;
+
+  @override
+  Object? valueOrNull(String key, Configuration<OptionDefinition> cfg) {
+    if (_cached == null) {
+      var file = cfg.value(SshnpdOption.configFile);
+      _cached ??= (
+        config: file.existsSync()
+            ? ConfigurationParser.fromFile(file.path)
+            : null,
+      );
+    }
+    var value = _cached?.config?.valueOrNull(key);
+    switch (key) {
+      case '/access/managers':
+      case '/access/permitopen':
+      case '/ssh/publickey-permissions':
+      case '/ssh/ephemeral-permissions':
+        if (value is YamlList) {
+          value = List.from(value);
+        }
+        if (value is List<dynamic>) {
+          value = value.cast<String>();
+        }
+    }
+    return value;
+  }
+}

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_config.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_config.dart
@@ -19,8 +19,7 @@ File _defaultConfigFilePath() {
       final programData = Platform.environment['ProgramData'];
       return File("$programData/NoPorts/sshnpd.yaml");
     case "macos":
-      // TODO
-      return File("/NoPorts/sshnpd.yaml");
+      return File("/Library/Application Support/NoPorts/sshnpd.yaml");
     default:
       return File("/etc/noports/sshnpd.yaml");
   }

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -158,12 +158,16 @@ class SshnpdImpl with AtClientBindings, ApkamSigning implements Sshnpd {
     AtClient? atClient,
     FutureOr<AtClient> Function(SshnpdParams)? atClientGenerator,
     void Function(Object, StackTrace)? usageCallback,
+    void Function()? helpCallback,
     required String version,
   }) async {
     try {
       SshnpdParams p;
       try {
-        p = await SshnpdParams.fromArgs(args);
+        p = await SshnpdParams.fromArgs(
+          args,
+          helpCallback: helpCallback,
+        );
       } on FormatException catch (e) {
         throw ArgumentError(e.message);
       }

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
@@ -71,7 +71,7 @@ class SshnpdParams {
     }
 
     if (c.errors.isNotEmpty) {
-      throw c.errors.first;
+      throw ArgumentError(c.errors.first);
     }
 
     String deviceAtsign = c.value(SshnpdOption.atsign).toAtsign();

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
@@ -1,10 +1,10 @@
-import 'dart:io';
-
-import 'package:args/args.dart';
 import 'package:at_cli_commons/at_cli_commons.dart';
+import 'package:at_client/at_client.dart';
+import 'package:config/config.dart';
 import 'package:noports_core/src/common/default_args.dart';
 import 'package:noports_core/src/common/types.dart';
 import 'package:noports_core/src/common/validation_utils.dart';
+import 'package:noports_core/src/sshnpd/sshnpd_config.dart';
 
 class SshnpdParams {
   final String device;
@@ -27,9 +27,6 @@ class SshnpdParams {
   final String storagePath;
   final String permitOpen;
   final bool clearCachedPKs;
-
-  // Non param variables
-  static final ArgParser parser = _createArgParser();
 
   SshnpdParams({
     required this.device,
@@ -58,85 +55,97 @@ class SshnpdParams {
     }
   }
 
-  static Future<SshnpdParams> fromArgs(List<String> args) async {
+  static Future<SshnpdParams> fromArgs(
+    List<String> args, {
+    void Function()? helpCallback,
+  }) async {
     // Arg check
-    ArgResults r = parser.parse(args);
+    final Configuration c = Configuration<SshnpdOption>.resolveNoExcept(
+      options: SshnpdOption.values,
+      args: args,
+      configBroker: SshnpdConfigBroker(),
+    );
 
-    String deviceAtsign = r['atsign'];
+    if (c.value(SshnpdOption.help)) {
+      helpCallback?.call();
+    }
 
-    if (!r.wasParsed('managers') && !r.wasParsed('policy-manager')) {
+    if (c.errors.isNotEmpty) {
+      throw c.errors.first;
+    }
+
+    String deviceAtsign = c.value(SshnpdOption.atsign).toAtsign();
+
+    if (c.optionalValue(SshnpdOption.managers) == null &&
+        c.optionalValue(SshnpdOption.policyManager) == null) {
       throw ArgumentError(
         'At least one of --managers and --policy-manager'
         ' options must be supplied.',
       );
     }
-    final List<String> managerAtsigns;
-    if (r.wasParsed('managers')) {
-      managerAtsigns = r['managers']
-          .toString()
-          .split(',')
-          .map((e) => e.trim().toLowerCase())
-          .toList();
-    } else {
-      managerAtsigns = [];
-    }
     String homeDirectory = getHomeDirectory()!;
 
-    SupportedSshClient sshClient = SupportedSshClient.values.firstWhere(
-      (c) => c.toString() == r['ssh-client'],
-      orElse: () => DefaultSshnpdArgs.sshClient,
-    );
-
     // Do we have a valid device name?
-    String device = r['device'];
+    String device = c.value(SshnpdOption.device);
     // First of all let's snakify it
     device = snakifyDeviceName(device);
     // and now check it against desired regex
     if (invalidDeviceName(device)) {
       throw ArgumentError(invalidDeviceNameMsg);
     }
-    bool makeDeviceInfoVisible = r['un-hide'];
-    if (r.wasParsed('hide')) {
-      makeDeviceInfoVisible = !r['hide'];
-    }
+    bool makeDeviceInfoVisible =
+        !(c.optionalValue(SshnpdOption.hide) ?? !c.value(SshnpdOption.unHide));
     // Normalize/validate the sshPublicKeyPermissions
-    String normalizedPermissions = r['sshpublickey-permissions'].trim();
+    String normalizedPermissions = c
+        .value(SshnpdOption.sshPublicKeyPermissions)
+        .map((e) => e.trim())
+        .toList()
+        .join(",");
     // don't remove newlines, since internal whitespace may be important to what they are trying to do
     if (RegExp(r'[\r\n]').hasMatch(normalizedPermissions)) {
       // bad input... newlines are dangerous
       throw ArgumentError(invalidSshKeyPermissionsMsg);
     }
 
-    var permitOpen = r['permit-open'];
+    var permitOpen = c.optionalValue(SshnpdOption.permitOpen)?.join(",");
     // #1295 - if we have a policy-manager arg and no permit-open arg
     // then we set permit-open '*:*' (since the policy manager will
     // be taking care of decisions in any event)
-    if (r.wasParsed('policy-manager') && !r.wasParsed('permit-open')) {
-      permitOpen = '*:*';
-    }
+    permitOpen ??= c.optionalValue(SshnpdOption.policyManager) == null
+        ? DefaultSshnpdArgs.permitOpen
+        : '*:*';
+
+    final managers = c
+        .optionalValue(SshnpdOption.managers)
+        ?.map((m) => m.toAtsign())
+        .toList();
+
     return SshnpdParams(
       device: device,
       username: getUserName(throwIfNull: true)!,
       homeDirectory: homeDirectory,
-      managerAtsigns: managerAtsigns,
-      policyManagerAtsign: r['policy-manager'],
+      managerAtsigns: managers ?? [],
+      policyManagerAtsign: c
+          .optionalValue(SshnpdOption.policyManager)
+          ?.toAtsign(),
       atKeysFilePath:
-          r['key-file'] ??
+          c.optionalValue(SshnpdOption.keyfile) ??
           getDefaultAtKeysFilePath(homeDirectory, deviceAtsign),
       deviceAtsign: deviceAtsign,
-      verbose: r['verbose'],
+      verbose: c.value(SshnpdOption.verbose),
       makeDeviceInfoVisible: makeDeviceInfoVisible,
-      addSshPublicKeys: r['sshpublickey'],
-      sshClient: sshClient,
-      rootDomain: r['root-server'] ?? 'root.atsign.org',
-      localSshdPort:
-          int.tryParse(r['local-sshd-port']) ?? DefaultSshnpdArgs.localSshdPort,
+      addSshPublicKeys: c.value(SshnpdOption.addSshPublicKey),
+      sshClient: c.value(SshnpdOption.sshClient),
+      rootDomain: c.value(SshnpdOption.rootServer),
+      localSshdPort: c.value(SshnpdOption.localSshdPort),
       sshPublicKeyPermissions: normalizedPermissions,
-      ephemeralPermissions: r['ephemeral-permissions'],
-      sshAlgorithm: SupportedSshAlgorithm.fromString(r['ssh-algorithm']),
-      deviceGroup: r['device-group'],
+      ephemeralPermissions: c
+          .value(SshnpdOption.sshEphemeralPermissions)
+          .join(","),
+      sshAlgorithm: c.value(SshnpdOption.sshAlgorithm),
+      deviceGroup: c.value(SshnpdOption.deviceGroup),
       storagePath:
-          r['storage-path'] ??
+          c.optionalValue(SshnpdOption.storagePath)?.path ??
           standardAtClientStoragePath(
             baseDir: homeDirectory,
             atSign: deviceAtsign,
@@ -144,194 +153,7 @@ class SshnpdParams {
             uniqueID: device,
           ),
       permitOpen: permitOpen,
-      clearCachedPKs: r['clear-cached-pks'],
+      clearCachedPKs: c.value(SshnpdOption.clearCachedPks),
     );
-  }
-
-  static ArgParser _createArgParser() {
-    var parser = ArgParser(
-      usageLineLength: stdout.hasTerminal ? stdout.terminalColumns : null,
-    );
-
-    // Basic arguments
-    parser.addOption(
-      'key-file',
-      abbr: 'k',
-      mandatory: false,
-      aliases: const ['keyFile'],
-      help:
-          'Sending atSign\'s keyFile if not in ~/.atsign/keys/'
-          '  Alias: --keyFile',
-    );
-
-    parser.addOption(
-      'atsign',
-      abbr: 'a',
-      mandatory: true,
-      help: 'atSign of this device',
-    );
-
-    parser.addOption(
-      'managers',
-      aliases: ['manager'],
-      abbr: 'm',
-      mandatory: false,
-      help:
-          'atSign or list of atSigns (comma separated)'
-          ' that this device will accept requests from.'
-          ' At least one of --managers and --policy-manager must be supplied.'
-          ' If both --managers and --policy-manager are supplied then '
-          ' the daemon will check with the --policy-manager atSign re '
-          ' requests which come from atSigns not in the --managers list.',
-    );
-
-    parser.addOption(
-      'policy-manager',
-      abbr: 'p',
-      mandatory: false,
-      help:
-          'The atSign which this device will use to decide whether or not to '
-          ' accept requests from some client atSign. '
-          ' At least one of --managers and --policy-manager must be supplied.'
-          ' If both --managers and --policy-manager are supplied then '
-          ' the daemon will check with the --policy-manager atSign re '
-          ' requests which come from atSigns not in the --managers list.',
-    );
-
-    parser.addOption(
-      'device',
-      abbr: 'd',
-      mandatory: false,
-      defaultsTo: "default",
-      help:
-          'This daemon will operate with this device name;'
-          ' allows multiple devices to share an atSign.'
-          ' $deviceNameFormatHelp',
-    );
-
-    parser.addFlag(
-      'sshpublickey',
-      abbr: 's',
-      defaultsTo: false,
-      help:
-          'When set, will update authorized_keys'
-          ' to include public key sent by manager',
-    );
-
-    parser.addFlag(
-      'hide',
-      abbr: 'h',
-      negatable: false,
-      defaultsTo: false,
-      help:
-          'Hides the device from advertising its information to the manager'
-          ' atSign. Even with this enabled, sshnpd will still respond to ping'
-          ' requests from the manager. (This takes priority over -u / --un-hide)',
-    );
-
-    parser.addFlag(
-      'un-hide',
-      abbr: 'u',
-      aliases: const ['username'],
-      defaultsTo: true,
-      hide: true,
-    );
-
-    parser.addFlag('verbose', abbr: 'v', help: 'More logging');
-
-    parser.addOption(
-      'ssh-client',
-      mandatory: false,
-      defaultsTo: DefaultSshnpdArgs.sshClient.toString(),
-      allowed: SupportedSshClient.values.map((c) => c.toString()).toList(),
-      help: 'What to use for outbound ssh connections.',
-    );
-
-    parser.addOption(
-      'root-server',
-      aliases: const ['root-domain'],
-      mandatory: false,
-      defaultsTo: 'root.atsign.org',
-      help:
-          'atDirectory domain.'
-          ' Alias (for backwards compatibility): --root-domain',
-    );
-
-    parser.addOption(
-      'device-group',
-      aliases: const ['dg'],
-      mandatory: false,
-      defaultsTo: DefaultSshnpdArgs.deviceGroupName,
-      help:
-          'The name of this device\'s group. When delegated authorization'
-          ' is being used then the group name is sent to the authorizer'
-          ' service as well as the device name, this daemon\'s atSign, '
-          ' and the client atSign which is requesting a connection.'
-          ' Alias: --dg',
-    );
-
-    parser.addOption(
-      'local-sshd-port',
-      mandatory: false,
-      defaultsTo: DefaultSshnpdArgs.localSshdPort.toString(),
-      help: 'port on which sshd is listening locally on localhost',
-    );
-
-    parser.addOption(
-      'sshpublickey-permissions',
-      abbr: 'S',
-      defaultsTo: DefaultSshnpdArgs.sshPublicKeyPermissions,
-      help:
-          'When --sshpublickey is enabled, will include the specified permissions'
-          ' in the public key entry in authorized_keys',
-    );
-
-    parser.addOption(
-      'ephemeral-permissions',
-      mandatory: false,
-      defaultsTo: '',
-      help:
-          'The permissions which will be added to the authorized_keys file'
-          ' for the ephemeral public keys which are generated when a client'
-          ' is connecting via forward ssh'
-          ' e.g. PermitOpen="host-1:3389",PermitOpen="localhost:80"',
-    );
-
-    parser.addOption(
-      'ssh-algorithm',
-      defaultsTo: DefaultArgs.sshAlgorithm.toString(),
-      help: 'Use RSA 4096 keys rather than the default ED25519 keys',
-      allowed: SupportedSshAlgorithm.values.map((c) => c.toString()).toList(),
-    );
-
-    parser.addOption(
-      'storage-path',
-      mandatory: false,
-      help:
-          'Directory for local storage.'
-          r' Defaults to $HOME/.atsign/storage/$atSign/.npd/$deviceName/',
-    );
-
-    parser.addOption(
-      'permit-open',
-      aliases: ['po'],
-      mandatory: false,
-      defaultsTo: DefaultSshnpdArgs.permitOpen,
-      help:
-          'Comma separated-list of host:port to which the daemon will permit'
-          ' a connection from an authorized client. Hosts may be dns names or'
-          ' ip addresses.'
-          ' Alias: --po',
-    );
-
-    parser.addFlag(
-      'clear-cached-pks',
-      help: 'Clear cached public keys',
-      hide: true,
-    );
-
-    parser.addFlag('help', help: 'Show usage');
-
-    return parser;
   }
 }

--- a/packages/dart/noports_core/lib/sshnpd.dart
+++ b/packages/dart/noports_core/lib/sshnpd.dart
@@ -2,4 +2,5 @@ library noports_core_sshnpd;
 
 export 'src/sshnpd/sshnpd.dart';
 export 'src/sshnpd/sshnpd_params.dart';
+export 'src/sshnpd/sshnpd_config.dart';
 export 'src/common/types.dart';

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -27,6 +27,8 @@ dependencies:
   mutex: ^3.1.0
   json_annotation: ^4.9.0
   version: ^3.0.2
+  config: ^0.8.0
+  yaml: ^3.1.3
 
 dependency_overrides:
   dartssh2:

--- a/packages/dart/sshnoports/bin/sshnpd.dart
+++ b/packages/dart/sshnoports/bin/sshnpd.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-import 'package:args/args.dart';
 import 'package:at_cli_commons/at_cli_commons.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:noports_core/sshnp_foundation.dart';
@@ -13,13 +12,6 @@ void main(List<String> args) async {
   AtSignLogger.root_level = 'SEVERE';
   AtSignLogger.defaultLoggingHandler = AtSignLogger.stdErrLoggingHandler;
   late final Sshnpd sshnpd;
-
-  ArgResults r = SshnpdParams.parser.parse(args);
-  if (r.wasParsed('help')) {
-    printVersion();
-    stderr.writeln(SshnpdParams.parser.usage);
-    exit(0);
-  }
 
   try {
     sshnpd = await Sshnpd.fromCommandLineArgs(
@@ -34,8 +26,13 @@ void main(List<String> args) async {
       ),
       usageCallback: (e, s) {
         printVersion();
-        stderr.writeln(SshnpdParams.parser.usage);
+        stderr.writeln(SshnpdOption.usage);
         stderr.writeln('\n$e');
+      },
+      helpCallback: () {
+        printVersion();
+        stderr.writeln(SshnpdOption.usage);
+        exit(0);
       },
       version: packageVersion,
     );
@@ -43,13 +40,16 @@ void main(List<String> args) async {
     exit(1);
   }
 
-  await runZonedGuarded(() async {
-    await sshnpd.init();
-    await sshnpd.run();
-  }, (Object error, StackTrace stackTrace) async {
-    stderr.writeln('Error: ${error.toString()}');
-    stderr.writeln('Stack Trace: ${stackTrace.toString()}');
-    await stderr.flush().timeout(Duration(milliseconds: 100));
-    exit(1);
-  });
+  await runZonedGuarded(
+    () async {
+      await sshnpd.init();
+      await sshnpd.run();
+    },
+    (Object error, StackTrace stackTrace) async {
+      stderr.writeln('Error: ${error.toString()}');
+      stderr.writeln('Stack Trace: ${stackTrace.toString()}');
+      await stderr.flush().timeout(Duration(milliseconds: 100));
+      exit(1);
+    },
+  );
 }

--- a/packages/dart/sshnoports/bin/sshnpd.dart
+++ b/packages/dart/sshnoports/bin/sshnpd.dart
@@ -38,6 +38,9 @@ void main(List<String> args) async {
     );
   } on ArgumentError catch (_) {
     exit(1);
+  } catch (e, s) {
+    print("Unknown Error, please contact support: $e\n$s");
+    exit(1);
   }
 
   await runZonedGuarded(

--- a/packages/dart/sshnoports/bundles/core/config/sshnpd.yaml
+++ b/packages/dart/sshnoports/bundles/core/config/sshnpd.yaml
@@ -1,0 +1,99 @@
+# Main service's atSign authentication information
+atsign:
+  # The atsign to run the service as 
+  # Examples:
+  # `atsign: '@foobar_np'`
+  # `atsign: foobar_np`
+  # Don't do the following:
+  # `atsign: @foobar_np`
+  # The '@' symbol is a special character in yaml.
+  # TODO: MANDATORY SETTING
+  atsign: 
+
+  # The path to the .atKeys file for the atsign, only needed if not
+  # located at the default path.
+  # The default value is dependent on the home directory and the atsign.
+  # Default for the 'atsign' example above:
+  # `keys: ~/.atsign/keys/@foobar_np_key.atKeys`
+  keys: 
+
+  # The root configuration for the atPlatform
+  # Examples:
+  # `root: root.atsign.org` (The default)
+  # `root: proxy:proxy0001.atsign.org:443` (Atsign's proxy for root.atsign.org)
+  # `root: my.enterprise.root:64` (When hosting your own atSigns)
+  # `root: proxy:my.enterprise.proxy:443` (When hosting your own atSigns with a proxy)
+  root: 
+
+# Configuration of access over NoPorts
+# TODO: At least one atSign must be listed under managers or policy
+access:
+  # A single atSign which serves as the policy manager. You must also run a policy
+  # service as that atSign to answer requests.
+  # Example: `policy: foobar03_np`
+  policy:
+
+  # A list of atsigns which serve as "managers" and have direct access to this device
+  # Only permit open permission apply to managers, policy is ignored for managers
+  # Example:
+  # ```
+  # managers:
+  #   - foobar01_np
+  #   - foobar02_np
+  # ```
+  managers:
+
+  # A list of host:port pairs which are allowed to be accessed on this device.
+  # Use policy for finite control by user.
+  # Use "*:*" to represent all host and all ports.
+  # If permit open is left empty, the default value is "localhost:22" and "localhost:3389" for ssh and rdp
+  permitopen:
+    - localhost:22
+
+# Additional device configuration
+device:
+  # Set a different device name for your NoPorts daemon
+  # Defaults to:
+  # `name: default`
+  name:
+
+  # Set a device group name. This setting is used for fleet management.
+  # Ask an Atsign team member about this setting if you plan to deploy a fleet.
+  group: 
+
+# Settings for how sshnp interacts with the NoPorts daemon
+ssh:
+  # Automatically add ssh public keys to the authorized_keys file
+  # This will add public keys to the authorized_keys file of the user sshnpd is running as
+  # This option should only be turned on if only ONE person will be accessing this machine
+  # This feature is for consumers and not recommended to be enabled in an enterprise setting
+  add-publickeys: false
+
+  # ssh-client can be set to `openssh` to use an external (openssh compatible) ssh binary on path (recommended)
+  # if you don't have an external ssh binary, then `dart` may be used to use the builtin ssh client.
+  ssh-client: openssh
+
+  # The port which sshnpd should expect to find the sshd bound to (on the internal interface)
+  sshd-port: 22
+
+  # Permissions for public keys added using the add-publickeys feature
+  # See the AUTHORIZED KEYS FILE FORMAT section in man sshd.
+  # This takes a list of options which will be prefixed to the line before the key
+  publickey-permissions:
+
+
+# Additional runtime settings for the service
+runtime:
+  # NoPorts caches some data for performance, use this
+  # to specify a different directory for the cache.
+  storage-path: 
+
+  # If you reset your one of your NoPorts atSigns
+  # Setting this to true will reset the cache so that
+  # NoPorts will pickup the atSign's new public key
+  clear-cached-pks: false
+
+  # Enable verbose logging, it's highly recommended that
+  # you leave this turned on.
+  verbose: true
+

--- a/packages/dart/sshnoports/bundles/core/config/sshnpd.yaml
+++ b/packages/dart/sshnoports/bundles/core/config/sshnpd.yaml
@@ -1,6 +1,6 @@
 # Main service's atSign authentication information
 atsign:
-  # The atsign to run the service as 
+  # The atsign to run the service as
   # Examples:
   # `atsign: '@foobar_np'`
   # `atsign: foobar_np`
@@ -42,6 +42,7 @@ access:
   #   - foobar02_np
   # ```
   managers:
+    # - your_atsign_here
 
   # A list of host:port pairs which are allowed to be accessed on this device.
   # Use policy for finite control by user.
@@ -49,13 +50,14 @@ access:
   # If permit open is left empty, the default value is "localhost:22" and "localhost:3389" for ssh and rdp
   permitopen:
     - localhost:22
+    - localhost:3389
 
 # Additional device configuration
 device:
   # Set a different device name for your NoPorts daemon
   # Defaults to:
   # `name: default`
-  name:
+  name: 
 
   # Set a device group name. This setting is used for fleet management.
   # Ask an Atsign team member about this setting if you plan to deploy a fleet.

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -273,6 +273,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  config:
+    dependency: "direct main"
+    description:
+      name: config
+      sha256: a25062b12993f0a45b34cdbde1808ec6ff3ab1c4c53f6b940c9e9f3fb5dcfad2
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.0"
   convert:
     dependency: transitive
     description:
@@ -673,6 +681,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  rfc_6901:
+    dependency: transitive
+    description:
+      name: rfc_6901
+      sha256: "6a43b1858dca2febaf93e15639aa6b0c49ccdfd7647775f15a499f872b018154"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   shelf:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   logging: 1.3.0
   chalkdart: ^2.3.3
   yaml: 3.1.3
+  config: ^0.8.0
 
 dependency_overrides:
   dartssh2:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Added optional sshnpd config file, with default location at the following paths:
  - Windows: C:/ProgramData/NoPorts/sshnpd.yaml
  - Macos: /Libraries/Application Support/NoPorts/sshnpd.yaml
  - Linux: /etc/noports/sshnpd.yaml

- Config file location may be changed by using:
  - SSHNPD_CONFIG environment variable
  - `--config` via cmdline args

- Resolution order for documentation [here](https://pub.dev/packages/config#resolution-order
- General principle followed:
  - cmdline args always take priority
  - there is only one way to specify configuration other than cmdline args:
    - environment variable for config file location
    - config file for everything else

**- How I did it**

**- How to verify it**

**- Description for the changelog**
feat: sshnpd config file support using config package

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
