### PR TITLE
ci: Add SLSA to images

### DIFF
--- a/.github/workflows/dockerhub_sshnpd.yml
+++ b/.github/workflows/dockerhub_sshnpd.yml
@@ -170,7 +170,7 @@ jobs:
           IMAGES+=" atsigncompany/${{ matrix.name }}:${{ env.TAG2 }}@${IMAGE_DIGEST}"
           cosign sign --yes ${IMAGES}
       - name: Upload image digest file
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: digests-${{ matrix.name }}
           path: ./${{ matrix.name }}_digest.json
@@ -200,7 +200,7 @@ jobs:
       slsa_matrix: ${{ steps.create_matrix.outputs.matrix_json }}
     steps:
       - name: Download all-image-digests artifact
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           pattern: digests-*
           path: ./digests

--- a/.github/workflows/dockerhub_sshnpd.yml
+++ b/.github/workflows/dockerhub_sshnpd.yml
@@ -169,6 +169,13 @@ jobs:
           IMAGES="${IMAGE}@${IMAGE_DIGEST}"
           IMAGES+=" atsigncompany/${{ matrix.name }}:${{ env.TAG2 }}@${IMAGE_DIGEST}"
           cosign sign --yes ${IMAGES}
+      - name: Upload image digest file
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: digests-${{ matrix.name }}
+          path: ./${{ matrix.name }}_digest.json
+          # GitHub collects all files uploaded with this name across the matrix runs
+          # into a single artifact that the next job can download.
       # Promote to canary
       - name: Update and sign canary tag
         if: startsWith(github.ref, 'refs/tags/v')
@@ -185,3 +192,43 @@ jobs:
           IMAGES="${CANARY}@${CANARY_DIGEST}"
           IMAGES+=" atsigncompany/${{ matrix.name }}:canary-${{ github.ref_name }}@${CANARY_DIGEST}"
           cosign sign --yes ${IMAGES}
+
+  aggregate_digests:
+    runs-on: ubuntu-latest
+    needs: [docker_combine]
+    outputs:
+      slsa_matrix: ${{ steps.create_matrix.outputs.matrix_json }}
+    steps:
+      - name: Download all-image-digests artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          pattern: digests-*
+          path: ./digests
+          merge-multiple: true
+      - name: Combine digests into a single JSON array
+        id: create_matrix
+        run: |
+          MATRIX_JSON=$(jq -s '.' ./digests/*_digest.json)
+          {
+            echo "matrix_json<<EOF"
+            echo "${MATRIX_JSON}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "::notice::Generated SLSA Matrix JSON: ${MATRIX_JSON}"
+
+  slsa_provenance:
+    needs: [aggregate_digests]
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    strategy:
+      matrix:
+        image_data: ${{ fromJson(needs.aggregate_digests.outputs.slsa_matrix) }}
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      image: ${{ matrix.image_data.name }}
+      digest: ${{ matrix.image_data.digest }}
+    secrets:
+      registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Fixes #2236

**- What I did**

Corrected image digest marshalling so that we can generate SLSA attestations for images built in a matrix.

**- How I did it**

1. The combine images job generates a digest that's sent to a job specific file.
2. The files are then aggregated into a single JSON document.
3. Then that JSON document is passed into the SLSA job.

**- How to verify it**

A workflow_dispatch [run](https://github.com/atsign-foundation/noports/actions/runs/18843363105) was done against this branch

**- Description for the changelog**

ci: Add SLSA to images
