### PR TITLE
fix: use KillMode=process for sshnpd.service

### DIFF
--- a/packages/dart/sshnoports/bundles/shell/systemd/sshnpd.service
+++ b/packages/dart/sshnoports/bundles/shell/systemd/sshnpd.service
@@ -9,6 +9,7 @@ WantedBy=multi-user.target
 Type=simple
 Restart=always
 RestartSec=3
+KillMode=process
 
 # The line below runs the sshnpd service, with the options set in
 # /etc/systemd/system/sshnpd.d/override.conf.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

fixes: https://github.com/atsign-foundation/noports/issues/2159

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: use KillMode=process for sshnpd.service
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
