### PR TITLE
fix(windows-msi): config wasn't being placed in ProgramData and service install was trying to start

### DIFF
--- a/packages/csharp/WindowsBinaryService/Program.cs
+++ b/packages/csharp/WindowsBinaryService/Program.cs
@@ -17,6 +17,11 @@ if (!EventLog.SourceExists("NoPorts"))
 {
     EventLog.CreateEventSource("NoPorts", ServiceConfig.Name);
 }
+// The source can exist without the log existing.....?
+if (!EventLog.Exists(ServiceConfig.Name))
+{
+    EventLog.CreateEventSource("NoPorts", ServiceConfig.Name);
+}
 builder.Logging.AddEventLog(eventLogSettings =>
 {
     eventLogSettings.LogName = ServiceConfig.Name;

--- a/tools/windows-msi/noports.wxs
+++ b/tools/windows-msi/noports.wxs
@@ -66,7 +66,7 @@
               Name="srv.exe" KeyPath="yes" />
       </Component>
 
-     <Component Id="sshnpd_config" Guid="*" Directory="APPDATADIR">
+     <Component Id="sshnpd_config" Guid="2812ad14-207e-4ab1-983b-92a65eb201a2" Directory="APPDATADIR">
         <File Id="sshnpd_configfile" Source="bin\sshnpd.yaml" 
               Name="sshnpd.yaml" KeyPath="yes" />
       </Component>

--- a/tools/windows-msi/noports.wxs
+++ b/tools/windows-msi/noports.wxs
@@ -100,7 +100,7 @@
                              Account="NT AUTHORITY\LocalService"/> 
         <ServiceControl Id="StartNoPortsService"
                              Name="[SERVICE_NAME]"
-                             Start="install"
+                             Start="no"
                              Stop="both"
                              Remove="uninstall"
                              Wait="yes" />

--- a/tools/windows-msi/noports.wxs
+++ b/tools/windows-msi/noports.wxs
@@ -66,7 +66,7 @@
               Name="srv.exe" KeyPath="yes" />
       </Component>
 
-     <Component Id="sshnpd_config" Guid="*">
+     <Component Id="sshnpd_config" Guid="*" Directory="APPDATADIR">
         <File Id="sshnpd_configfile" Source="bin\sshnpd.yaml" 
               Name="sshnpd.yaml" KeyPath="yes" />
       </Component>


### PR DESCRIPTION
**- What I did**
 - static guid for config
 - directory was missing from config object
 - service install now doesn't try starting the service.
 
**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix(windows-msi): config wasn't being placed in ProgramData and service install was trying to start
