### PR TITLE
fix: `*:*` for permit-open NoPorts Desktop UI

### DIFF
--- a/packages/dart/npt_flutter/changelog.md
+++ b/packages/dart/npt_flutter/changelog.md
@@ -1,3 +1,7 @@
+## 1.6.4+23
+
+- FIX: policy permit open host and port form validation
+
 ## 1.6.3+22
 
 - **FIX**: atSigns are no longer removed from the keychain after an enrollment occurs on windows devices.

--- a/packages/dart/npt_flutter/lib/util/form_validator.dart
+++ b/packages/dart/npt_flutter/lib/util/form_validator.dart
@@ -118,26 +118,18 @@ class FormValidator {
       return strings.validationErrorEmptyField;
     }
 
-    // Check if the value contains exactly one colon
+    // Check if the value contains at least one colon
     if (!value!.contains(':')) {
-      return 'Host:port format must contain exactly one colon (:)';
+      return 'Host:port format must contain a colon (:) separating host and port';
     }
 
-    // Split by colon and validate parts
+    // Split by colon - IPv6 addresses like ::1:443 will have multiple parts
     final parts = value.split(':');
-    if (parts.length != 2) {
-      return 'Host:port format must contain exactly one colon (:)';
+    if (parts.length < 2) {
+      return 'Host:port format must contain a colon (:) separating host and port';
     }
 
-    // Validate host part (first part)
-    final host = parts.first;
-    
-    // Check if empty
-    if (host.isEmpty) {
-      return 'Host part cannot be empty';
-    }
-
-    // Validate port part (last part)
+    // Port is always the last part
     final portStr = parts.last;
     if (portStr.isEmpty) {
       return 'Port part cannot be empty';
@@ -149,6 +141,16 @@ class FormValidator {
       if (port == null || !(port >= 1 && port <= 65535)) {
         return 'Port must be a valid number between 1 and 65535, or use * for wildcard';
       }
+    }
+
+    // Host is everything except the last part (the port)
+    // Rebuild the host by joining all parts except the last with ':'
+    final hostParts = parts.sublist(0, parts.length - 1);
+    final host = hostParts.join(':');
+
+    // Check if host is empty
+    if (host.isEmpty) {
+      return 'Host part cannot be empty';
     }
 
     return null;

--- a/packages/dart/npt_flutter/lib/util/form_validator.dart
+++ b/packages/dart/npt_flutter/lib/util/form_validator.dart
@@ -131,19 +131,22 @@ class FormValidator {
 
     // Validate host part (first part)
     final host = parts[0];
-    if (host.isEmpty) {
+    // Allow wildcard for host, otherwise validate it's not empty
+    if (host != '*' && host.isEmpty) {
       return 'Host part cannot be empty';
     }
 
     // Validate port part (last part)
     final portStr = parts.last;
-    if (portStr.isEmpty) {
-      return 'Port part cannot be empty';
-    }
-
-    final port = int.tryParse(portStr);
-    if (port == null || !(port >= 1 && port <= 65535)) {
-      return 'Port must be a valid number between 1 and 65535';
+    // Allow wildcard for port, otherwise validate it's a valid port number
+    if (portStr != '*') {
+      if (portStr.isEmpty) {
+        return 'Port part cannot be empty';
+      }
+      final port = int.tryParse(portStr);
+      if (port == null || !(port >= 1 && port <= 65535)) {
+        return 'Port must be a valid number between 1 and 65535, or use * for wildcard';
+      }
     }
 
     return null;

--- a/packages/dart/npt_flutter/lib/util/form_validator.dart
+++ b/packages/dart/npt_flutter/lib/util/form_validator.dart
@@ -112,10 +112,8 @@ class FormValidator {
   }
 
   static String? validateHostPortField(String? value) {
-    final strings = AppLocalizations.of(App.navState.currentContext!)!;
-
     if (value?.isEmpty ?? true) {
-      return strings.validationErrorEmptyField;
+      return 'This field is required';
     }
 
     // Check if the value contains at least one colon

--- a/packages/dart/npt_flutter/lib/util/form_validator.dart
+++ b/packages/dart/npt_flutter/lib/util/form_validator.dart
@@ -118,31 +118,31 @@ class FormValidator {
       return strings.validationErrorEmptyField;
     }
 
-    // Check if the value contains at least one colon
+    // Check if the value contains exactly one colon
     if (!value!.contains(':')) {
-      return 'Host:port format must contain at least one colon (:)';
+      return 'Host:port format must contain exactly one colon (:)';
     }
 
     // Split by colon and validate parts
     final parts = value.split(':');
-    if (parts.length < 2) {
-      return 'Host:port format must contain at least one colon (:)';
+    if (parts.length != 2) {
+      return 'Host:port format must contain exactly one colon (:)';
     }
 
     // Validate host part (first part)
     final host = parts[0];
     // Allow wildcard for host, otherwise validate it's not empty
-    if (host != '*' && host.isEmpty) {
+    if (host.isEmpty) {
       return 'Host part cannot be empty';
     }
 
     // Validate port part (last part)
     final portStr = parts.last;
+    if (portStr.isEmpty) {
+      return 'Port part cannot be empty';
+    }
     // Allow wildcard for port, otherwise validate it's a valid port number
     if (portStr != '*') {
-      if (portStr.isEmpty) {
-        return 'Port part cannot be empty';
-      }
       final port = int.tryParse(portStr);
       if (port == null || !(port >= 1 && port <= 65535)) {
         return 'Port must be a valid number between 1 and 65535, or use * for wildcard';

--- a/packages/dart/npt_flutter/lib/util/form_validator.dart
+++ b/packages/dart/npt_flutter/lib/util/form_validator.dart
@@ -130,8 +130,9 @@ class FormValidator {
     }
 
     // Validate host part (first part)
-    final host = parts[0];
-    // Allow wildcard for host, otherwise validate it's not empty
+    final host = parts.first;
+    
+    // Check if empty
     if (host.isEmpty) {
       return 'Host part cannot be empty';
     }
@@ -141,6 +142,7 @@ class FormValidator {
     if (portStr.isEmpty) {
       return 'Port part cannot be empty';
     }
+
     // Allow wildcard for port, otherwise validate it's a valid port number
     if (portStr != '*') {
       final port = int.tryParse(portStr);

--- a/packages/dart/npt_flutter/pubspec.yaml
+++ b/packages/dart/npt_flutter/pubspec.yaml
@@ -16,13 +16,13 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.6.3+22
+version: 1.6.4+23
 msix_config:
   display_name: "NoPorts Desktop"
   publisher_display_name: Atsign Inc
   identity_name: TheCompany.NoPortsDesktop
   publisher: CN=BBFE1D0B-F713-4C7F-B375-5EA851CBB1FF
-  msix_version: 1.6.3.0
+  msix_version: 1.6.4.0
   logo_path: "assets/logo.png"
   capabilities: internetClient
   store: true

--- a/packages/dart/npt_flutter/test/util/form_validator_test.dart
+++ b/packages/dart/npt_flutter/test/util/form_validator_test.dart
@@ -1,168 +1,124 @@
-import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:npt_flutter/app.dart';
+import 'package:test/test.dart';
 import 'package:npt_flutter/util/form_validator.dart';
-import 'package:npt_flutter/localization/app_localizations.dart';
 
 void main() {
-  setUpAll(() async {
-    TestWidgetsFlutterBinding.ensureInitialized();
-  });
-
-  Widget createApp() {
-    return MaterialApp(
-      navigatorKey: App.navState,
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: Scaffold(body: Container()),
-    );
-  }
-
   group('validateHostPortField', () {
-    testWidgets('should accept valid localhost with port', (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should accept valid localhost with port', () {
       final result = FormValidator.validateHostPortField('localhost:8080');
       expect(result, isNull);
     });
 
-    testWidgets('should accept valid IPv4 address with port', (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should accept valid IPv4 address with port', () {
       final result = FormValidator.validateHostPortField('127.0.0.1:443');
       expect(result, isNull);
     });
 
-    testWidgets('should accept valid IPv6 loopback with port (::1:443)',
-        (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should accept valid IPv6 loopback with port (::1:443)', () {
       final result = FormValidator.validateHostPortField('::1:443');
       expect(result, isNull);
     });
 
-    testWidgets('should accept valid IPv6 address with port (fe80::1:8080)',
-        (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should accept valid IPv6 address with port (fe80::1:8080)', () {
       final result = FormValidator.validateHostPortField('fe80::1:8080');
       expect(result, isNull);
     });
 
-    testWidgets('should accept valid full IPv6 address with port',
-        (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should accept valid full IPv6 address with port', () {
       final result = FormValidator.validateHostPortField(
           '2001:0db8:85a3::8a2e:0370:7334:22');
       expect(result, isNull);
     });
 
-    testWidgets('should accept wildcard host with wildcard port (*:*)',
-        (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should accept wildcard host with wildcard port (*:*)', () {
       final result = FormValidator.validateHostPortField('*:*');
       expect(result, isNull);
     });
 
-    testWidgets('should accept localhost with wildcard port (localhost:*)',
-        (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should accept localhost with wildcard port (localhost:*)', () {
       final result = FormValidator.validateHostPortField('localhost:*');
       expect(result, isNull);
     });
 
-    testWidgets('should accept IPv6 with wildcard port (::1:*)',
-        (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should accept IPv6 with wildcard port (::1:*)', () {
       final result = FormValidator.validateHostPortField('::1:*');
       expect(result, isNull);
     });
 
-    testWidgets('should accept minimum port number (1)', (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should accept minimum port number (1)', () {
       final result = FormValidator.validateHostPortField('localhost:1');
       expect(result, isNull);
     });
 
-    testWidgets('should accept maximum port number (65535)', (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should accept maximum port number (65535)', () {
       final result = FormValidator.validateHostPortField('localhost:65535');
       expect(result, isNull);
     });
 
-    testWidgets('should reject empty value', (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should reject empty value', () {
       final result = FormValidator.validateHostPortField('');
       expect(result, isNotNull);
       expect(result, contains('field'));
     });
 
-    testWidgets('should reject null value', (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should reject null value', () {
       final result = FormValidator.validateHostPortField(null);
       expect(result, isNotNull);
       expect(result, contains('field'));
     });
 
-    testWidgets('should reject value without colon', (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should reject value without colon', () {
       final result = FormValidator.validateHostPortField('localhost8080');
       expect(result, isNotNull);
       expect(result, contains('colon'));
     });
 
-    testWidgets('should reject empty host with port (:8080)', (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should reject empty host with port (:8080)', () {
       final result = FormValidator.validateHostPortField(':8080');
       expect(result, isNotNull);
       expect(result, contains('Host part cannot be empty'));
     });
 
-    testWidgets('should reject host without port (localhost:)', (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should reject host without port (localhost:)', () {
       final result = FormValidator.validateHostPortField('localhost:');
       expect(result, isNotNull);
       expect(result, contains('Port part cannot be empty'));
     });
 
-    testWidgets('should reject invalid port (non-numeric)', (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should reject invalid port (non-numeric)', () {
       final result = FormValidator.validateHostPortField('localhost:abc');
       expect(result, isNotNull);
       expect(result, contains('Port must be a valid number'));
     });
 
-    testWidgets('should reject port 0', (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should reject port 0', () {
       final result = FormValidator.validateHostPortField('localhost:0');
       expect(result, isNotNull);
       expect(result, contains('Port must be a valid number'));
     });
 
-    testWidgets('should reject port above 65535', (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should reject port above 65535', () {
       final result = FormValidator.validateHostPortField('localhost:65536');
       expect(result, isNotNull);
       expect(result, contains('Port must be a valid number'));
     });
 
-    testWidgets('should reject negative port', (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should reject negative port', () {
       final result = FormValidator.validateHostPortField('localhost:-1');
       expect(result, isNotNull);
       expect(result, contains('Port must be a valid number'));
     });
 
-    testWidgets('should accept hostname with hyphens', (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should accept hostname with hyphens', () {
       final result = FormValidator.validateHostPortField('my-host-name:8080');
       expect(result, isNull);
     });
 
-    testWidgets('should accept FQDN with port', (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should accept FQDN with port', () {
       final result = FormValidator.validateHostPortField('example.com:443');
       expect(result, isNull);
     });
 
-    testWidgets('should accept subdomain with port', (tester) async {
-      await tester.pumpWidget(createApp());
+    test('should accept subdomain with port', () {
       final result =
           FormValidator.validateHostPortField('api.example.com:8080');
       expect(result, isNull);

--- a/packages/dart/npt_flutter/test/util/form_validator_test.dart
+++ b/packages/dart/npt_flutter/test/util/form_validator_test.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:npt_flutter/app.dart';
+import 'package:npt_flutter/util/form_validator.dart';
+import 'package:npt_flutter/localization/app_localizations.dart';
+
+void main() {
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+  });
+
+  Widget createApp() {
+    return MaterialApp(
+      navigatorKey: App.navState,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: Container()),
+    );
+  }
+
+  group('validateHostPortField', () {
+    testWidgets('should accept valid localhost with port', (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField('localhost:8080');
+      expect(result, isNull);
+    });
+
+    testWidgets('should accept valid IPv4 address with port', (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField('127.0.0.1:443');
+      expect(result, isNull);
+    });
+
+    testWidgets('should accept valid IPv6 loopback with port (::1:443)',
+        (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField('::1:443');
+      expect(result, isNull);
+    });
+
+    testWidgets('should accept valid IPv6 address with port (fe80::1:8080)',
+        (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField('fe80::1:8080');
+      expect(result, isNull);
+    });
+
+    testWidgets('should accept valid full IPv6 address with port',
+        (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField(
+          '2001:0db8:85a3::8a2e:0370:7334:22');
+      expect(result, isNull);
+    });
+
+    testWidgets('should accept wildcard host with wildcard port (*:*)',
+        (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField('*:*');
+      expect(result, isNull);
+    });
+
+    testWidgets('should accept localhost with wildcard port (localhost:*)',
+        (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField('localhost:*');
+      expect(result, isNull);
+    });
+
+    testWidgets('should accept IPv6 with wildcard port (::1:*)',
+        (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField('::1:*');
+      expect(result, isNull);
+    });
+
+    testWidgets('should accept minimum port number (1)', (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField('localhost:1');
+      expect(result, isNull);
+    });
+
+    testWidgets('should accept maximum port number (65535)', (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField('localhost:65535');
+      expect(result, isNull);
+    });
+
+    testWidgets('should reject empty value', (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField('');
+      expect(result, isNotNull);
+      expect(result, contains('field'));
+    });
+
+    testWidgets('should reject null value', (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField(null);
+      expect(result, isNotNull);
+      expect(result, contains('field'));
+    });
+
+    testWidgets('should reject value without colon', (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField('localhost8080');
+      expect(result, isNotNull);
+      expect(result, contains('colon'));
+    });
+
+    testWidgets('should reject empty host with port (:8080)', (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField(':8080');
+      expect(result, isNotNull);
+      expect(result, contains('Host part cannot be empty'));
+    });
+
+    testWidgets('should reject host without port (localhost:)', (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField('localhost:');
+      expect(result, isNotNull);
+      expect(result, contains('Port part cannot be empty'));
+    });
+
+    testWidgets('should reject invalid port (non-numeric)', (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField('localhost:abc');
+      expect(result, isNotNull);
+      expect(result, contains('Port must be a valid number'));
+    });
+
+    testWidgets('should reject port 0', (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField('localhost:0');
+      expect(result, isNotNull);
+      expect(result, contains('Port must be a valid number'));
+    });
+
+    testWidgets('should reject port above 65535', (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField('localhost:65536');
+      expect(result, isNotNull);
+      expect(result, contains('Port must be a valid number'));
+    });
+
+    testWidgets('should reject negative port', (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField('localhost:-1');
+      expect(result, isNotNull);
+      expect(result, contains('Port must be a valid number'));
+    });
+
+    testWidgets('should accept hostname with hyphens', (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField('my-host-name:8080');
+      expect(result, isNull);
+    });
+
+    testWidgets('should accept FQDN with port', (tester) async {
+      await tester.pumpWidget(createApp());
+      final result = FormValidator.validateHostPortField('example.com:443');
+      expect(result, isNull);
+    });
+
+    testWidgets('should accept subdomain with port', (tester) async {
+      await tester.pumpWidget(createApp());
+      final result =
+          FormValidator.validateHostPortField('api.example.com:8080');
+      expect(result, isNull);
+    });
+  });
+}


### PR DESCRIPTION
closes #2254 

**- What I did**
- Fixed form validation for host and ports
- Added support for iPv6 host and port in Policy
- form validator tests
- Updated pubspec.yaml
- Updated CHANGELOG.md

**- How I did it**

- Using Claude

**- How to verify it**

## Test 1: `*:*`

<img width="1036" height="697" alt="image" src="https://github.com/user-attachments/assets/59ba810d-d930-472d-acc4-6249fb12a4ff" />

at_repl inspection:

<img width="426" height="522" alt="image" src="https://github.com/user-attachments/assets/459e5037-f88d-49e4-9aab-f4001958afe8" />

## Test 2: `localhost:*, *:443, *:*`

<img width="432" height="432" alt="image" src="https://github.com/user-attachments/assets/e6e4f228-637f-4883-bbab-3d3b5af920f9" />

at_repl inspection:

<img width="393" height="568" alt="image" src="https://github.com/user-attachments/assets/fe240444-7fa7-4336-8034-c0da93293539" />

## Test 3: host but no port (e.g. `myhost`)

Does not allow (as expected):

<img width="910" height="524" alt="image" src="https://github.com/user-attachments/assets/b5644698-525c-40dc-be6d-2cf5e4d50d2e" />

Doesn't allow

## Test 4: port but no host (e.g. `11111`)

Does not allow (as expected):

<img width="848" height="526" alt="image" src="https://github.com/user-attachments/assets/81b8f401-540c-42b7-a753-1df558eb0b9c" />

## Test 5: positive out of range port

Does not allow (as expected):

<img width="788" height="519" alt="image" src="https://github.com/user-attachments/assets/cf50ae5c-5241-4c6d-a98d-ea768ea44909" />

## Test 6: negative out of range port

Does not allow (as expected):

<img width="777" height="541" alt="image" src="https://github.com/user-attachments/assets/f42a0a06-4cbb-48e0-a3de-05965a5d84b5" />

## Test 7: 0 port

Does not allow (as expected):

<img width="785" height="533" alt="image" src="https://github.com/user-attachments/assets/1cc55dde-5bc1-4331-b859-80e8c9c8491c" />

**- Description for the changelog**
fix: `*:*` for permit-open NoPorts Desktop UI
