### PR TITLE
docs: Link to public sbomified profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/noports/badge)](https://securityscorecards.dev/viewer/?uri=github.com/atsign-foundation/noports&sort_by=check-score&sort_direction=desc)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8102/badge)](https://www.bestpractices.dev/projects/8102)
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
-[![sbomified](https://sbomify.com/assets/images/logo/badge.svg)](https://app.sbomify.com/component/-93khk8pUi)
+[![sbomified](https://sbomify.com/assets/images/logo/badge.svg)](https://app.sbomify.com/public/product/h4kKfn8vMA/)
 
 # noports
 


### PR DESCRIPTION
The link behind the sbomified badge presently leads to a page that's login protected

**- What I did**

Fixed link to point to public profile

**- How I did it**

Copied link from sbomify Products page (after adding some links to NoPorts docs etc.)

**- How to verify it**

Rich diff

**- Description for the changelog**

docs: Link to public sbomified profile
