### PR TITLE
feat(noports): consume at_client v3.9.2 to enable redundancy support for Policy Servers

### DIFF
--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -94,10 +94,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_client
-      sha256: "6f3597a886549bc0c3d76e7196bc10ba3c6539007d92b748222b5d0b4083e31c"
+      sha256: "5259886a09507a439be08bbaa79a360ecd936ac1baa2ae58b72c90357cdb4785"
       url: "https://pub.dev"
     source: hosted
-    version: "3.9.1"
+    version: "3.9.2"
   at_commons:
     dependency: transitive
     description:

--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -94,10 +94,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_client
-      sha256: "17f92dc153308b7a0809aa52d311d2f85965bfdd94678f4718a6502cbf34e4e3"
+      sha256: "3a9b5440faa2d8689714f17d1c3b4a1ef7de63e4ef13634f96b4665300131235"
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.0"
+    version: "3.9.0"
   at_commons:
     dependency: transitive
     description:

--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -94,10 +94,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_client
-      sha256: "3a9b5440faa2d8689714f17d1c3b4a1ef7de63e4ef13634f96b4665300131235"
+      sha256: "6f3597a886549bc0c3d76e7196bc10ba3c6539007d92b748222b5d0b4083e31c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.9.0"
+    version: "3.9.1"
   at_commons:
     dependency: transitive
     description:

--- a/apps/admin/admin_api/pubspec.yaml
+++ b/apps/admin/admin_api/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 # Add regular dependencies here.
 dependencies:
   alfred: 1.1.2+1
-  at_client: ^3.9.1
+  at_client: ^3.9.2
   json_annotation: 4.9.0
   at_cli_commons: ^3.0.1
   args: 2.7.0

--- a/apps/admin/admin_api/pubspec.yaml
+++ b/apps/admin/admin_api/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 # Add regular dependencies here.
 dependencies:
   alfred: 1.1.2+1
-  at_client: ^3.8.0
+  at_client: ^3.9.1
   json_annotation: 4.9.0
   at_cli_commons: ^3.0.1
   args: 2.7.0

--- a/packages/dart/noports_core/CHANGELOG.md
+++ b/packages/dart/noports_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.10.0
+
+- feat: enable redundancy support for Policy Services
+
 # 6.9.0
 
 - feat: add support for config file to sshnpd

--- a/packages/dart/noports_core/lib/src/npa/npa_impl.dart
+++ b/packages/dart/noports_core/lib/src/npa/npa_impl.dart
@@ -91,7 +91,6 @@ class NPAImpl with AtClientBindings implements NPA {
 
   @override
   Future<void> run() async {
-    // ignore: experimental_member_use
     AtRpc rpc = AtRpc(
       atClient: atClient,
       baseNameSpace: DefaultArgs.namespace,

--- a/packages/dart/noports_core/lib/src/npa/npa_impl.dart
+++ b/packages/dart/noports_core/lib/src/npa/npa_impl.dart
@@ -101,6 +101,7 @@ class NPAImpl with AtClientBindings implements NPA {
       allowAll: true,
       isClient: false,
       isServer: true,
+      enableRequestMutex: true
     );
 
     rpc.start();

--- a/packages/dart/noports_core/lib/src/npa/npa_impl.dart
+++ b/packages/dart/noports_core/lib/src/npa/npa_impl.dart
@@ -91,6 +91,7 @@ class NPAImpl with AtClientBindings implements NPA {
 
   @override
   Future<void> run() async {
+    // ignore: experimental_member_use
     AtRpc rpc = AtRpc(
       atClient: atClient,
       baseNameSpace: DefaultArgs.namespace,

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -1632,8 +1632,8 @@ class _NPAAuthChecker implements AuthChecker, AtRpcCallbacks {
   final Map<String, int> authCheckCache = {};
   final Map<int, Completer<NPAAuthCheckResponse>> completerMap = {};
 
-  // ignore: experimental_member_use
   _NPAAuthChecker(this.sshnpd) {
+    // ignore: experimental_member_use
     rpc = AtRpc(
       atClient: sshnpd.atClient,
       baseNameSpace: DefaultArgs.namespace,

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -1627,13 +1627,11 @@ abstract interface class AuthChecker {
 
 class _NPAAuthChecker implements AuthChecker, AtRpcCallbacks {
   final Sshnpd sshnpd;
-  // ignore: experimental_member_use
   late final AtRpc rpc;
   final Map<String, int> authCheckCache = {};
   final Map<int, Completer<NPAAuthCheckResponse>> completerMap = {};
 
   _NPAAuthChecker(this.sshnpd) {
-    // ignore: experimental_member_use
     rpc = AtRpc(
       atClient: sshnpd.atClient,
       baseNameSpace: DefaultArgs.namespace,

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -1627,10 +1627,12 @@ abstract interface class AuthChecker {
 
 class _NPAAuthChecker implements AuthChecker, AtRpcCallbacks {
   final Sshnpd sshnpd;
+  // ignore: experimental_member_use
   late final AtRpc rpc;
   final Map<String, int> authCheckCache = {};
   final Map<int, Completer<NPAAuthCheckResponse>> completerMap = {};
 
+  // ignore: experimental_member_use
   _NPAAuthChecker(this.sshnpd) {
     rpc = AtRpc(
       atClient: sshnpd.atClient,

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   args: ^2.4.2
   at_chops: ^2.0.1
-  at_client: ^3.9.1
+  at_client: ^3.9.2
   at_commons: ^5.6.1
   at_cli_commons: ^3.0.1
   at_utils: ^3.0.19

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   args: ^2.4.2
   at_chops: ^2.0.1
-  at_client: ^3.8.0
+  at_client: ^3.9.0
   at_commons: ^5.6.1
   at_cli_commons: ^3.0.1
   at_utils: ^3.0.19

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   args: ^2.4.2
   at_chops: ^2.0.1
-  at_client: ^3.9.0
+  at_client: ^3.9.1
   at_commons: ^5.6.1
   at_cli_commons: ^3.0.1
   at_utils: ^3.0.19

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -85,10 +85,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_client
-      sha256: "3a9b5440faa2d8689714f17d1c3b4a1ef7de63e4ef13634f96b4665300131235"
+      sha256: "6f3597a886549bc0c3d76e7196bc10ba3c6539007d92b748222b5d0b4083e31c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.9.0"
+    version: "3.9.1"
   at_commons:
     dependency: "direct main"
     description:

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -85,10 +85,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_client
-      sha256: "17f92dc153308b7a0809aa52d311d2f85965bfdd94678f4718a6502cbf34e4e3"
+      sha256: "3a9b5440faa2d8689714f17d1c3b4a1ef7de63e4ef13634f96b4665300131235"
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.0"
+    version: "3.9.0"
   at_commons:
     dependency: "direct main"
     description:

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -85,10 +85,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_client
-      sha256: "6f3597a886549bc0c3d76e7196bc10ba3c6539007d92b748222b5d0b4083e31c"
+      sha256: "5259886a09507a439be08bbaa79a360ecd936ac1baa2ae58b72c90357cdb4785"
       url: "https://pub.dev"
     source: hosted
-    version: "3.9.1"
+    version: "3.9.2"
   at_commons:
     dependency: "direct main"
     description:

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   at_onboarding_cli: ^1.14.0
   at_commons: ^5.6.2
   at_cli_commons: ^3.0.1
-  at_client: ^3.9.1
+  at_client: ^3.9.2
   args: 2.7.0
   socket_connector: 2.4.1
   dartssh2: 2.11.0

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   at_onboarding_cli: ^1.14.0
   at_commons: ^5.6.1
   at_cli_commons: ^3.0.1
-  at_client: ^3.8.0
+  at_client: ^3.9.0
   args: 2.7.0
   socket_connector: 2.4.1
   dartssh2: 2.11.0

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   at_onboarding_cli: ^1.14.0
   at_commons: ^5.6.1
   at_cli_commons: ^3.0.1
-  at_client: ^3.9.0
+  at_client: ^3.9.1
   args: 2.7.0
   socket_connector: 2.4.1
   dartssh2: 2.11.0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Closes https://github.com/atsign-foundation/noports/issues/1895

**- What I did**
- Enable `useRequestMutex` flag when creating an AtRpc instance in `noports_core/npa_impl.dart` to allow running multiple npp_atservers (Policy Server)  in parallel under a 'single-reponder' mode. (more context in linked ticket)
- Update pubspec.yaml to consume `at_client v3.9.2` in noports_core, sshnoports, and np_admin

**- How to verify it**
- Tests pass here

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
feat: consume at_client v3.9.2 to enable redundancy support for Policy Servers