### PR TITLE
fix: have desktop app emit notifications with same namespaces as the np_admin service does

### DIFF
--- a/packages/dart/noports_core/lib/src/admin/impl.dart
+++ b/packages/dart/noports_core/lib/src/admin/impl.dart
@@ -22,17 +22,17 @@ class PolicyServiceWithAtClient extends PolicyServiceInMem
     atClient.notificationService
         .subscribe(regex: r'.*\.groups\.policy\.sshnp', shouldDecrypt: true)
         .listen((AtNotification n) {
-      String groupId = n.key.split(':')[1].split('.').first;
-      logger.info(
-        'Received ${n.operation} notification for group ${n.key} - ID is $groupId',
-      );
-      if (n.operation == 'delete') {
-        groups.remove(groupId);
-      } else {
-        UserGroup g = UserGroup.fromJson(jsonDecode(n.value!));
-        groups[groupId] = g;
-      }
-    });
+          String groupId = n.key.split(':')[1].split('.').first;
+          logger.info(
+            'Received ${n.operation} notification for group ${n.key} - ID is $groupId',
+          );
+          if (n.operation == 'delete') {
+            groups.remove(groupId);
+          } else {
+            UserGroup g = UserGroup.fromJson(jsonDecode(n.value!));
+            groups[groupId] = g;
+          }
+        });
 
     subscribe(regex: r'.*\.logs\.policy\.sshnp', shouldDecrypt: true).listen((
       AtNotification n,
@@ -118,13 +118,12 @@ class PolicyServiceWithAtClient extends PolicyServiceInMem
       jsonEncode(group),
       putRequestOptions: PutRequestOptions()..useRemoteAtServer = true,
     );
+    AtKey notifKey = AtKey.fromString(
+      '${atClient.getCurrentAtSign()}:${_groupAtKey(group.id!)}',
+    );
+    logger.info('[INFO] updateUserGroup: Sending notification $notifKey');
     await atClient.notificationService.notify(
-      NotificationParams.forUpdate(
-        AtKey.fromString(
-          '${atClient.getCurrentAtSign()}:${_groupAtKey(group.id!)}',
-        ),
-        value: jsonEncode(group),
-      ),
+      NotificationParams.forUpdate(notifKey, value: jsonEncode(group)),
     );
     groups[group.id!] = group;
   }
@@ -185,8 +184,8 @@ class PolicyServiceInMem implements PolicyService {
       'type': 'PolicyCheck',
       'daemon': pe['daemon'],
       'deviceName': pe['payload']['request']['payload']['daemonDeviceName'],
-      'deviceGroupName': pe['payload']['request']['payload']
-          ['daemonDeviceGroupName'],
+      'deviceGroupName':
+          pe['payload']['request']['payload']['daemonDeviceGroupName'],
       'user': pe['payload']['request']['payload']['clientAtsign'],
       'authorized': pe['payload']['response']['payload']['authorized'],
       'message': pe['payload']['response']['payload']['message'],

--- a/packages/dart/npt_flutter/lib/features/policy/repositories/role_repository.dart
+++ b/packages/dart/npt_flutter/lib/features/policy/repositories/role_repository.dart
@@ -94,9 +94,14 @@ class RoleRepository {
 
       if (success) {
         try {
+          AtKey notifKey = AtKey.fromString('$currentAtSign:$atKeyStr');
+          notifKey.metadata.namespaceAware = false;
+          App.log(
+              '[INFO] putNewRole: Sending UPDATE notification $notifKey'
+                  .loggable);
           await atClient.notificationService.notify(
             NotificationParams.forUpdate(
-              AtKey.fromString('$currentAtSign:$atKeyStr'),
+              notifKey,
               value: jsonEncode(newRole),
             ),
           );
@@ -151,9 +156,14 @@ class RoleRepository {
 
       if (success) {
         try {
+          AtKey notifKey = AtKey.fromString('$currentAtSign:$atKeyStr');
+          notifKey.metadata.namespaceAware = false;
+          App.log(
+              '[INFO] updateExistingRole: Sending UPDATE notification $notifKey'
+                  .loggable);
           await atClient.notificationService.notify(
             NotificationParams.forUpdate(
-              AtKey.fromString('$currentAtSign:$atKeyStr'),
+              notifKey,
               value: jsonEncode(role),
             ),
           );
@@ -202,9 +212,14 @@ class RoleRepository {
       );
       if (success) {
         try {
+          AtKey notifKey = AtKey.fromString('$currentAtSign:$atKeyStr');
+          notifKey.metadata.namespaceAware = false;
+          App.log(
+              '[INFO] deleteRole: Sending DELETE notification $notifKey'
+                  .loggable);
           await atClient.notificationService.notify(
             NotificationParams.forDelete(
-              AtKey.fromString('$currentAtSign:$atKeyStr'),
+              notifKey,
             ),
           );
         } catch (notifyError) {

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -175,10 +175,10 @@ packages:
     description:
       path: "packages/at_onboarding_flutter"
       ref: at_onboarding_flutter_layers
-      resolved-ref: "1e244eb5f522d31d9d0eb3c67990d7d6bd612446"
+      resolved-ref: f7f022a2d4b145f4d8b35c07f5a5cb2085551d86
       url: "https://github.com/atsign-foundation/at_widgets"
     source: git
-    version: "6.1.10"
+    version: "6.1.10+20251107"
   at_persistence_secondary_server:
     dependency: transitive
     description:


### PR DESCRIPTION
**- What I did**
- Fixes https://github.com/atsign-foundation/noports/issues/2281
- fix: have desktop app emit notifications with same namespaces as the np_admin service does

**- How I did it**
fix: in npt_flutter: use `namespaceAware: false` for the notifications which are sent when a policy rule is added / updated / deleted

**- How to verify it**
- Have manually verified
- np_admin emits notifications like: `@policy:1.groups.policy.sshnp@policy`
- desktop used to emit notifications like: `@policy:1.groups.policy.sshnp.noports@policy`
- Now desktop emits notifications like `@policy:1.groups.policy.sshnp@policy`
