### PR TITLE
fix: policy cache on edit/save

### DIFF
--- a/packages/dart/npt_flutter/lib/features/policy/cubit/policy_cubit.dart
+++ b/packages/dart/npt_flutter/lib/features/policy/cubit/policy_cubit.dart
@@ -26,6 +26,25 @@ class PolicyCubit extends LoggingCubit<PolicyState> {
     }
   }
 
+  Future<void> reloadAndSelectRole(String roleId, AppLocalizations strings) async {
+    emit(const PolicyLoading(operation: 'reloading roles'));
+    try {
+      final List<FetchedRole> roles = await _roleRepository.fetchRoles();
+      final selectedRole = roles.firstWhere(
+        (role) => role.id == roleId,
+        orElse: () => roles.isNotEmpty ? roles.first : throw Exception('No roles found'),
+      );
+      emit(PolicyViewingRole(roles: roles, selectedRole: selectedRole));
+    } catch (e) {
+      emit(
+        PolicyError(
+          strings.rolesLoadingFailedWithDetails(e.toString()),
+          operation: 'reloadAndSelectRole',
+        ),
+      );
+    }
+  }
+
   Future<void> updateExistingRole(
     FetchedRole role,
     AppLocalizations strings,

--- a/packages/dart/npt_flutter/lib/features/policy/repositories/role_repository.dart
+++ b/packages/dart/npt_flutter/lib/features/policy/repositories/role_repository.dart
@@ -59,8 +59,8 @@ class RoleRepository {
     return roles;
   }
 
-  Future<bool> putNewRole(final RoleInProgress roleInProgress) async {
-    
+  Future<String?> putNewRole(final RoleInProgress roleInProgress) async {
+
     final AtClient atClient = AtClientManager.getInstance().atClient;
     String? currentAtSign = atClient.getCurrentAtSign();
 
@@ -68,7 +68,7 @@ class RoleRepository {
       App.log(
         '[ERROR] updateExistingRole: Current atSign is null'.loggable,
       );
-      return false;
+      return null;
     }
 
     // ensure currentAtSign starts with '@'
@@ -112,10 +112,10 @@ class RoleRepository {
           );
         }
       }
-      return success;
+      return success ? newId.toString() : null;
     } catch (e) {
       App.log('[ERROR] updateExistingRole: Failed to update role: $e'.loggable);
-      return false;
+      return null;
     }
 
   }

--- a/packages/dart/npt_flutter/lib/features/policy/view/policy_view.dart
+++ b/packages/dart/npt_flutter/lib/features/policy/view/policy_view.dart
@@ -152,14 +152,14 @@ class PolicyContent extends StatelessWidget {
       create: (context) {
         final cubit = PolicyFormCubit(
           context.read<RoleRepository>(),
-          onSuccess: (message) {
+          onSuccess: (message, roleId) {
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
                 content: Text(message),
                 backgroundColor: AppColor.primaryColor,
               ),
             );
-            context.read<PolicyCubit>().cancelEditing();
+            context.read<PolicyCubit>().reloadAndSelectRole(roleId, strings);
           },
           onDeleted: () {
             ScaffoldMessenger.of(context).showSnackBar(

--- a/packages/dart/npt_flutter/lib/features/policy_form/cubit/policy_form_cubit.dart
+++ b/packages/dart/npt_flutter/lib/features/policy_form/cubit/policy_form_cubit.dart
@@ -9,7 +9,7 @@ part 'policy_form_state.dart';
 
 class PolicyFormCubit extends LoggingCubit<PolicyFormState> {
   final RoleRepository _roleRepository;
-  final void Function(String message)? onSuccess;
+  final void Function(String message, String roleId)? onSuccess;
   final void Function()? onDeleted;
 
   PolicyFormCubit(this._roleRepository, {this.onSuccess, this.onDeleted})
@@ -111,7 +111,7 @@ class PolicyFormCubit extends LoggingCubit<PolicyFormState> {
         if (isClosed) return;
 
         if (success) {
-          onSuccess?.call('Role saved successfully');
+          onSuccess?.call('Role saved successfully', currentState.currentRole.id);
           if (!isClosed) {
             emit(const PolicyFormLoading());
           }
@@ -140,14 +140,14 @@ class PolicyFormCubit extends LoggingCubit<PolicyFormState> {
       emit(currentState.copyWith(isSaving: true));
 
       try {
-        final success = await _roleRepository.putNewRole(
+        final newRoleId = await _roleRepository.putNewRole(
           currentState.roleInProgress,
         );
 
         if (isClosed) return;
 
-        if (success) {
-          onSuccess?.call('Role created successfully');
+        if (newRoleId != null) {
+          onSuccess?.call('Role created successfully', newRoleId);
           if (!isClosed) {
             emit(const PolicyFormLoading());
           }

--- a/packages/dart/npt_flutter/pubspec.yaml
+++ b/packages/dart/npt_flutter/pubspec.yaml
@@ -16,13 +16,13 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.6.4+23
+version: 1.7.0+24
 msix_config:
   display_name: "NoPorts Desktop"
   publisher_display_name: Atsign Inc
   identity_name: TheCompany.NoPortsDesktop
   publisher: CN=BBFE1D0B-F713-4C7F-B375-5EA851CBB1FF
-  msix_version: 1.6.4.0
+  msix_version: 1.7.0.0
   logo_path: "assets/logo.png"
   capabilities: internetClient
   store: true


### PR DESCRIPTION
closes #2285 

**- What I did**
- Fixed Policy form so you don't have to refresh to get the latest data

**- How I did it**
Using Claude

- Policy cubit has new `reloadAndSelectRole` function which is meant to be used in onSuccess.
- When editing an existing role, `reloadAndSelectRole` is called on the existing role's id
- When creating a new role, `putNewRole` is called and returns the roleId so that when a new role is created, we can call `reloadAndSelectRole` to select that newly created role.
- When we delete a role, no role is selected in the main view

**- How to verify it**
Cases that were tested

1. Editing an existing role
2. Creating a new role
3. Deleting a role

In the first two cases, they will go to the current role and have updated cache.
In third case, no role will be selected

**- Description for the changelog**
fix: policy cache on edit/save
