### PR TITLE
ci: Ensure cosign binary is in place

### DIFF
--- a/.github/workflows/promote_canary.yml
+++ b/.github/workflows/promote_canary.yml
@@ -25,6 +25,8 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-24.04
     steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Login to Docker Hub
@@ -64,6 +66,8 @@ jobs:
           - name: sshnpd-slim
           - name: srvd
     steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Login to Docker Hub


### PR DESCRIPTION
Canary promotions runs (e.g. [this one](https://github.com/atsign-foundation/noports/actions/runs/19241415157/job/55004782338)) have been failing:

```log
cosign: command not found
```

**- What I did**

Added cosign action

**- How I did it**

Based on other workflows

**- How to verify it**

Re-run action(s)

**- Description for the changelog**

https://github.com/atsign-foundation/noports/actions/runs/19241415157/job/55004782338
