### PR TITLE
ci: Complete ps1 removal

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -324,7 +324,7 @@ jobs:
   github-release:
     name: >-
       Upload artifacts and generate SBOMs and checksums for provenance
-    needs: [main_build, other_build, web_build, universal_sh, universal_ps1]
+    needs: [main_build, other_build, web_build, universal_sh]
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
@@ -357,7 +357,6 @@ jobs:
         run: |
           cd tarballs
           mv */*.sh .
-          mv */*.ps1 .
           mv */*.tgz .
           mv */*.zip .
           rm -Rf -- */


### PR DESCRIPTION
#2303 removed the ps1 job, but didn't change the things that depended on it this is causing the multibuild workflow to [fail](https://github.com/atsign-foundation/noports/actions/runs/19356795834)

**- What I did**

Removed remenants of ps1

**- How I did it**

Search of workflow for ps1

**- How to verify it**

Multibuild should run OK on merge

**- Description for the changelog**

ci: Complete ps1 removal
