### PR TITLE
fix: always do policy check even if policy atSign is same as client atSign

### DIFF
--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -393,13 +393,6 @@ class SshnpdImpl with AtClientBindings, ApkamSigning implements Sshnpd {
         permitOpen: ['*:*'],
       );
     }
-    if (policyManagerAtsign == client) {
-      return NPAAuthCheckResponse(
-        authorized: true,
-        message: '$client is the policy manager',
-        permitOpen: ['*:*'],
-      );
-    }
 
     if (authChecker != null) {
       late NPAAuthCheckResponse resp;


### PR DESCRIPTION
**- What I did**
fix: when the client's atSign is the same as the atSign of the policy service the daemon is using, the daemon no longer skips the policy check. Resolves #2253

**- How I did it**
See commits

**- How to verify it**
Manually verified
