### PR TITLE
feat: add `--help` flag to srv, and some additional usage info

### DIFF
--- a/packages/dart/sshnoports/bin/srv.dart
+++ b/packages/dart/sshnoports/bin/srv.dart
@@ -51,6 +51,10 @@ Future<void> main(List<String> args) async {
       help: 'The relay auth mode, if required.',
       allowed: RelayAuthMode.values.map((c) => c.name).toList(),
     )
+    ..addFlag('help',
+        defaultsTo: false,
+        negatable: false,
+        help: 'Show usage info')
     ..addFlag('rv-e2ee',
         defaultsTo: false,
         help: 'Whether this rv process will encrypt/decrypt'
@@ -60,6 +64,14 @@ Future<void> main(List<String> args) async {
         negatable: false,
         help: 'Set this flag when we want multiple connections via the rvd');
 
+  void printUsage() {
+    printVersion();
+    stderr.writeln(parser.usage);
+    stderr.writeln('Note: srv is not intended to be directly executed'
+        ' by NoPorts users; srv processes are spawned by the daemon or'
+        ' client programs as required.');
+  }
+
   await runZonedGuarded(() async {
     final SocketConnector sc;
     try {
@@ -68,6 +80,11 @@ Future<void> main(List<String> args) async {
         parsed = parser.parse(args);
       } on FormatException catch (e) {
         throw ArgumentError(e.message);
+      }
+
+      if (parsed.wasParsed('help')) {
+        printUsage();
+        exit(0);
       }
 
       final String streamingHost = parsed['host'];
@@ -186,10 +203,8 @@ Future<void> main(List<String> args) async {
         controlChannelHeartbeat: heartbeat,
       ).run();
     } on ArgumentError catch (e) {
-      printVersion();
-      stderr.writeln(parser.usage);
-      stderr.writeln('\n$e');
-
+      printUsage();
+      stderr.writeln('\n$e\n');
       // We will leave the log file in /tmp since we are exiting abnormally
       exit(1);
     }


### PR DESCRIPTION
**- What I did**
feat: add `--help` flag to srv, and add message explaining that the srv program is not intended to be directly run by NoPorts users. Resolves #2172

**- How I did it**
See commits

**- How to verify it**
Manually verified

```
gary@gkc2025 sshnoports % srv --help
Version : 5.13.0 (core: 6.9.0)
-h, --host (mandatory)    rvd host
-p, --port (mandatory)    rvd port
    --local-port          On the daemon side, this is the local port to connect to. On the client side this is the local port which the srv will bind to so that client-side programs can create sockets to it.
                          (defaults to "22")
    --heartbeat           How frequently to send heartbeats on the connection's control channel. Defaults to 30 minutes (1800 seconds)
                          (defaults to "1800")
    --timeout             How long to keep the SocketConnector open if there have been no connections
                          (defaults to "60")
    --bind-local-port     Client side flag.
    --local-host          Used on daemon side for npt sessions only. The host on the daemon's local network to connect to; defaults to localhost.
                          (defaults to "localhost")
    --[no-]rv-auth        (Legacy) Whether this rv process will authenticate to rvd using legacy "payload" (signed response to implicit challenge) auth.
-a, --relay-auth-mode     The relay auth mode, if required.
                          [payload, escr]
    --help                Show usage info
    --[no-]rv-e2ee        Whether this rv process will encrypt/decrypt all rvd socket traffic
    --multi               Set this flag when we want multiple connections via the rvd
Note: srv is not intended to be directly executed by NoPorts users; srv processes are spawned by the daemon or client programs as required.
```
