### PR TITLE
fix: srvd.dart respects ENABLE_SNOOP environment variable

### DIFF
--- a/packages/dart/noports_core/lib/src/srvd/build_env.dart
+++ b/packages/dart/noports_core/lib/src/srvd/build_env.dart
@@ -1,6 +1,4 @@
-import 'dart:io';
-
 class BuildEnv {
   static final bool enableSnoop =
-      (Platform.environment['ENABLE_SNOOP'] ?? "false").toLowerCase() == 'true';
+      const bool.fromEnvironment('ENABLE_SNOOP', defaultValue: false);
 }


### PR DESCRIPTION
closes #2316 

**- What I did**
- Replaced `Platform.Environment['ENABLE_SNOOP']` with `bool.fromEnvironment('ENABLE_SNOOP')`

The difference between the two is
- Platform.Environment is for **runtime** OS environment variables
- bool.fromEnvironment is for **compile-time** environment variables

I think in this situation, we would prefer ENABLE_SNOOP to be a **compile-time** environment variable.

**- How I did it**
- Using Claude

Claude says:

```
Platform.environment - When you need dynamic configuration that changes without recompiling (API keys, database URLs, credentials)
bool.fromEnvironment - When you need compile-time decisions that affect which code is included in the final binary (feature flags, build modes)
```

Docs:
- https://api.flutter.dev/flutter/dart-core/bool/bool.fromEnvironment.html
- https://api.dart.dev/dart-io/Platform/environment.html

**- How to verify it**

1. I compile with `ENABLE_SNOOP=true` and I see `-s` in help :)

```bash
➜  bin git:(trunk) ✗ dart compile exe ./srvd.dart -o srvd-with-snoop -D ENABLE_SNOOP=true
Generated: /Users/jeremytubongbanua/GitHub/noports/packages/dart/sshnoports/bin/srvd-with-snoop
➜  bin git:(trunk) ✗ ls
activate_cli.dart       demo_socket_server.dart npt.dart                srvd-with-snoop         sshnpd.dart
demo                    npp_atserver.dart       srv.dart                srvd.dart
demo_socket_client.dart npp_file.dart           srvd                    sshnp.dart
➜  bin git:(trunk) ✗ ./srvd-with-snoop 
Version : 5.13.0 (core: 6.9.0)
-k, --key-file                    atSign's atKeys file if not in ~/.atsign/keys/  Alias: --keyFile
-a, --atsign (mandatory)          atSign for srvd
-m, --manager                     Managers atSign that srvd will accept requests from. Default is any atSign can use srvd
                                  (defaults to "open")
-i, --ip (mandatory)              FQDN/IP address sent to clients
-v, --[no-]verbose                Show more logs (INFO and above)
    --[no-]debug                  Show all logs (FINEST and above)
-s, --[no-]snoop                  Log traffic passing through service
    --root-server                 atDirectory domain. Alias (for backwards compatibility): --root-domain
                                  (defaults to "root.atsign.org")
    --[no-]per-session-storage    Use ephemeral local storage for each session. When true, allows you to run multiple srvds concurrently on the same host,
                                  as the same user. When false, only a single local srvd may run concurrently on the same host as the same user. Alias:
                                  --pss
                                  (defaults to on)
    --[no-]443                    Also bind to port 443, to support clients which want to connect only to port 443 (for ... $reasons)
    --443-bind-port               The actual port to bind to - for example in a docker env you may wish to forward port 443 on the host to a different port
                                  in the container
    --help                        Print usage

Invalid argument(s): Option atsign is mandatory.
➜  bin git:(trunk) ✗ ./srvd-with-snoop -a @tastelessbanana -i vip.ve.atsign.zone -s
Using local storage directory Directory: '/Users/jeremytubongbanua/.atsign/storage/@tastelessbanana/srvd/1763409007476'
^C2025-11-17 14:50:25.295659 : Cleaning up temporary files in Directory: '/Users/jeremytubongbanua/.atsign/storage/@tastelessbanana/srvd/1763409007476'
```

2. I compile without snoop and `-s` is not in `--help` (expected)

```bash
➜  bin git:(trunk) ✗ dart compile exe ./srvd.dart -o srvd-with-no-snoop                  
Generated: /Users/jeremytubongbanua/GitHub/noports/packages/dart/sshnoports/bin/srvd-with-no-snoop
➜  bin git:(trunk) ✗ ./srvd-with-no-snoop 
Version : 5.13.0 (core: 6.9.0)
-k, --key-file                    atSign's atKeys file if not in ~/.atsign/keys/  Alias: --keyFile
-a, --atsign (mandatory)          atSign for srvd
-m, --manager                     Managers atSign that srvd will accept requests from. Default is any atSign can use srvd
                                  (defaults to "open")
-i, --ip (mandatory)              FQDN/IP address sent to clients
-v, --[no-]verbose                Show more logs (INFO and above)
    --[no-]debug                  Show all logs (FINEST and above)
    --root-server                 atDirectory domain. Alias (for backwards compatibility): --root-domain
                                  (defaults to "root.atsign.org")
    --[no-]per-session-storage    Use ephemeral local storage for each session. When true, allows you to run multiple srvds concurrently on the same host,
                                  as the same user. When false, only a single local srvd may run concurrently on the same host as the same user. Alias:
                                  --pss
                                  (defaults to on)
    --[no-]443                    Also bind to port 443, to support clients which want to connect only to port 443 (for ... $reasons)
    --443-bind-port               The actual port to bind to - for example in a docker env you may wish to forward port 443 on the host to a different port
                                  in the container
    --help                        Print usage

Invalid argument(s): Option atsign is mandatory.
```

**- Description for the changelog**
fix: srvd.dart respects ENABLE_SNOOP environment variable
