### PR TITLE
feat: noPorts desktop allow IPv6 numeric entries

### DIFF
--- a/packages/dart/npt_flutter/changelog.md
+++ b/packages/dart/npt_flutter/changelog.md
@@ -1,10 +1,14 @@
+## 1.8.0+25
+
+- FEAT: App no supports IPv6 and IPv4 numeric entries for local and remote host.
+
 ## 1.7.0+24
 
 - FEAT: App now supports use of atDirectories other than root.atsign.org
 - FEAT: App now supports use of atServer proxy services
-- FIX: When policy rules are updated in the app, they are now picked up by 
+- FIX: When policy rules are updated in the app, they are now picked up by
   the policy service in near-real-time
-- FIX: Policy info being displayed on the policy view is now auto-refreshed 
+- FIX: Policy info being displayed on the policy view is now auto-refreshed
   after an edit has been saved.
 
 ## 1.6.4+23

--- a/packages/dart/npt_flutter/changelog.md
+++ b/packages/dart/npt_flutter/changelog.md
@@ -1,6 +1,6 @@
 ## 1.8.0+25
 
-- FEAT: App no supports IPv6 and IPv4 numeric entries for local and remote host.
+- FEAT: App now supports IPv6 and IPv4 numeric entries for local and remote host.
 
 ## 1.7.0+24
 

--- a/packages/dart/npt_flutter/lib/features/profile_form/widgets/profile_local_host_text_field.dart
+++ b/packages/dart/npt_flutter/lib/features/profile_form/widgets/profile_local_host_text_field.dart
@@ -3,7 +3,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:npt_flutter/features/profile/profile.dart';
 import 'package:npt_flutter/localization/app_localizations.dart';
 import 'package:npt_flutter/styles/sizes.dart';
-import 'package:npt_flutter/util/constants.dart';
 import 'package:npt_flutter/util/form_validator.dart';
 
 class ProfileLocalHostTextField extends StatelessWidget {
@@ -22,16 +21,14 @@ class ProfileLocalHostTextField extends StatelessWidget {
           style: Theme.of(context).textTheme.bodySmall,
         ),
         gapH14,
-        BlocSelector<ProfileBloc, ProfileState, String>(
+        BlocSelector<ProfileBloc, ProfileState, String?>(
           selector: (ProfileState state) {
             if (state is ProfileLoadedState) return state.profile.localHost;
-            return StringConst.localhost;
-          },
-          builder: (BuildContext context, String state) {
-            // If state is null, it is set to the default value of 'localhost'.
-            // This prevents the TextFormField from being empty initially for profile created before localHost was field was added.
 
-            // state ??= StringConst.localhost;
+            return null;
+          },
+          builder: (BuildContext context, String? state) {
+            if (state == null) return gap0;
             return SizedBox(
               height: Sizes.p100,
               width: Sizes.p300,

--- a/packages/dart/npt_flutter/lib/util/form_validator.dart
+++ b/packages/dart/npt_flutter/lib/util/form_validator.dart
@@ -1,5 +1,7 @@
 // This file contains the form validation logic for the app. It is used to validate the input fields in the app.
 
+import 'dart:io';
+
 import 'package:npt_flutter/app.dart';
 import 'package:npt_flutter/localization/app_localizations.dart';
 
@@ -92,9 +94,11 @@ class FormValidator {
     final strings = AppLocalizations.of(App.navState.currentContext!)!;
     String valid =
         r'^(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)$';
+
     if (value?.isEmpty ?? true) {
       return strings.validationErrorEmptyField;
-    } else if (!value!.contains(RegExp(valid))) {
+    } else if (!value!.contains(RegExp(valid)) &&
+        InternetAddress.tryParse(value) == null) {
       return strings.validationErrorHostField;
     }
     return null;

--- a/packages/dart/npt_flutter/macos/Podfile.lock
+++ b/packages/dart/npt_flutter/macos/Podfile.lock
@@ -83,13 +83,13 @@ SPEC CHECKSUMS:
   file_picker: e716a70a9fe5fd9e09ebc922d7541464289443af
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   package_info_plus: 12f1c5c2cfe8727ca46cbd0b26677728972d9a5b
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  path_provider_foundation: 0b743cbb62d8e47eab856f09262bb8c1ddcfe6ba
   screen_retriever_macos: 776e0fa5d42c6163d2bf772d22478df4b302b161
   share_plus: 1fa619de8392a4398bfaf176d441853922614e89
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
   tray_manager: 9064e219c56d75c476e46b9a21182087930baf90
-  url_launcher_macos: c82c93949963e55b228a30115bd219499a6fe404
-  webview_flutter_wkwebview: a4af96a051138e28e29f60101d094683b9f82188
+  url_launcher_macos: 175a54c831f4375a6cf895875f716ee5af3888ce
+  webview_flutter_wkwebview: 29eb20d43355b48fe7d07113835b9128f84e3af4
   window_manager: 3a1844359a6295ab1e47659b1a777e36773cd6e8
 
 PODFILE CHECKSUM: 9ebaf0ce3d369aaa26a9ea0e159195ed94724cf3

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_client
-      sha256: "6f3597a886549bc0c3d76e7196bc10ba3c6539007d92b748222b5d0b4083e31c"
+      sha256: "5259886a09507a439be08bbaa79a360ecd936ac1baa2ae58b72c90357cdb4785"
       url: "https://pub.dev"
     source: hosted
-    version: "3.9.1"
+    version: "3.9.2"
   at_client_mobile:
     dependency: "direct main"
     description:
@@ -1503,26 +1503,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:

--- a/packages/dart/npt_flutter/pubspec.yaml
+++ b/packages/dart/npt_flutter/pubspec.yaml
@@ -16,13 +16,13 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.7.0+24
+version: 1.8.0+25
 msix_config:
   display_name: "NoPorts Desktop"
   publisher_display_name: Atsign Inc
   identity_name: TheCompany.NoPortsDesktop
   publisher: CN=BBFE1D0B-F713-4C7F-B375-5EA851CBB1FF
-  msix_version: 1.7.0.0
+  msix_version: 1.8.0.0
   logo_path: "assets/logo.png"
   capabilities: internetClient
   store: true


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Updated form validation to accept IPv6 values and
- Updated localhost form field to rebuild form field when localhost value after profile loaded state

**- How I did it**

**- How to verify it**
Verified by connecting to @kimdimick remote device with IPv6 enabled.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
