### PR TITLE
fix(windows): high cpu usage in windows service

### DIFF
--- a/packages/csharp/WindowsBinaryService/Binary.cs
+++ b/packages/csharp/WindowsBinaryService/Binary.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Text;
 using System.Threading.Channels;
+using System.Threading.Tasks;
 
 namespace WindowsBinaryService
 {
@@ -86,7 +87,7 @@ namespace WindowsBinaryService
 		}
 
 		// Debounces logs by grouping based on time.
-		private void LogDebouncer()
+		private async Task LogDebouncer()
 		{
 			// How much time must elapse between reads before a flush is allowed to happen
 			var minReadTimeSpan = TimeSpan.FromMilliseconds(500); 
@@ -104,7 +105,15 @@ namespace WindowsBinaryService
 				// - We have read logs into the buffer AND either of the two are true:
 				//   - maxFlushTimeSpan has passed
 				//   - there was nothing to read during the last attempt
-				do 
+
+				if(!await r.WaitToReadAsync())
+				{
+                    logger.LogWarning($"{logBuffer}");
+                    logBuffer.Clear();
+					break;
+                }
+
+                do 
 
 				{ 
 					didReadLine = r.TryRead(out var line);


### PR DESCRIPTION
**- What I did**
 - Added an async await for data to enter the output buffer
 - will now hand control back to the event loop during infinite logging loop
 - resolves #2312 
 
**- How I did it**

**- How to verify it**
 - [use noports.msi from the multibuild artifacts](https://github.com/atsign-foundation/noports/actions/runs/19906203337#artifacts)
 
**- Description for the changelog**
fix(windows): high cpu usage in windows service
