### PR TITLE
feat: add `debug` flag to noports daemon

### DIFF
--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_config.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_config.dart
@@ -324,7 +324,17 @@ enum SshnpdOption<V> implements OptionDefinition<V> {
       configKey: '/runtime/verbose',
       argAbbrev: 'v',
       defaultsTo: false,
-      helpText: 'More logging',
+      helpText: 'More logging (INFO and above)',
+      group: runtimeGroup,
+    ),
+  ),
+
+  debug(
+    FlagOption(
+      argName: 'debug',
+      configKey: '/runtime/debug',
+      defaultsTo: false,
+      helpText: 'All logging (FINEST and above)',
       group: runtimeGroup,
     ),
   ),

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -197,7 +197,9 @@ class SshnpdImpl
       }
 
       AtSignLogger.root_level = 'SEVERE';
-      if (p.verbose) {
+      if (p.debug) {
+        AtSignLogger.root_level = 'FINEST';
+      } else if (p.verbose) {
         AtSignLogger.root_level = 'INFO';
       }
 
@@ -228,7 +230,10 @@ class SshnpdImpl
         notifPreProcessor: notifPreProcessor,
       );
 
-      if (p.verbose) {
+      if (p.debug) {
+        sshnpd.logger.logger.level = Level.FINEST;
+      }
+      else if (p.verbose) {
         sshnpd.logger.logger.level = Level.INFO;
       }
 

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
@@ -16,6 +16,7 @@ class SshnpdParams {
   final String passPhrase;
   final String deviceAtsign;
   final bool verbose;
+  final bool debug;
   final bool makeDeviceInfoVisible;
   final bool addSshPublicKeys;
   final SupportedSshClient sshClient;
@@ -40,6 +41,7 @@ class SshnpdParams {
     required this.passPhrase,
     required this.deviceAtsign,
     required this.verbose,
+    required this.debug,
     required this.makeDeviceInfoVisible,
     required this.addSshPublicKeys,
     required this.sshClient,
@@ -139,6 +141,7 @@ class SshnpdParams {
       passPhrase: c.optionalValue(SshnpdOption.passPhrase) ?? "",
       deviceAtsign: deviceAtsign,
       verbose: c.value(SshnpdOption.verbose),
+      debug: c.value(SshnpdOption.debug),
       makeDeviceInfoVisible: makeDeviceInfoVisible,
       addSshPublicKeys: c.value(SshnpdOption.addSshPublicKey),
       sshClient: c.value(SshnpdOption.sshClient),


### PR DESCRIPTION
**- What I did**
feat: add `debug` flag to noports daemon so you can see all log messages including FINEST and FINER to assist in diagnosing new issues.

**- How I did it**
See commits
