### PR TITLE
fix: Fix bug where sshnpd could become unresponsive when using proxy service

### DIFF
--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -600,7 +600,7 @@ packages:
       path: "../../../packages/dart/noports_core"
       relative: true
     source: path
-    version: "6.10.1"
+    version: "6.10.2"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/noports_core/CHANGELOG.md
+++ b/packages/dart/noports_core/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 6.10.2
+
+- fix: Require authenticated connection when sshnpd is sending its periodic 
+  "am I alive" heartbeat. This forces issuing of a `from:` request, which in 
+  turn means that a connection via a proxy service is made successfully. 
+  Also, reduce frequency of this heartbeat from every 15 seconds to every 90 
+  seconds.
+
 # 6.10.1
 
 fix: remove late from `AtEventConfig? elc` in NPAImpl

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -309,11 +309,12 @@ class SshnpdImpl
 
   void startHeartbeat() {
     bool lastHeartbeatOk = true;
-    Timer.periodic(Duration(seconds: 15), (timer) async {
+    Timer.periodic(Duration(seconds: 90), (timer) async {
       String? resp;
       try {
         resp = await atClient.getRemoteSecondary()?.atLookUp.executeCommand(
           'noop:0\n',
+          auth: true,
         );
       } catch (_) {}
       if (resp == null || !resp.startsWith('data:ok')) {

--- a/packages/dart/noports_core/lib/src/version.dart
+++ b/packages/dart/noports_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '6.10.1';
+const packageVersion = '6.10.2';

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: noports_core
 description: Core library code for sshnoports
 homepage: https://docs.atsign.com/
 
-version: 6.10.1
+version: 6.10.2
 
 environment:
   sdk: ^3.8.0

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -973,7 +973,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.10.1"
+    version: "6.10.2"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.14.1';
+const packageVersion = '5.14.2';

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -584,7 +584,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.10.1"
+    version: "6.10.2"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.14.1
+version: 5.14.2
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
**- What I did**
fix: Fix bug where sshnpd could become unresponsive when using proxy service

**- How I did it**
- Require authenticated connection when sshnpd is sending its periodic "am I alive" heartbeat. This forces issuing of a `from:` request, which in turn means that a connection via a proxy service is made successfully. Also, reduce frequency of this heartbeat from every 15 seconds to every 90 seconds.

**- How to verify it**
- Tests pass
- Note that I am running a version from this branch on a VPS and will leave it running there for a few days so I can be approximately 100% confident the issue has been resolved

**- Additional context**
- Explanation: After some time - multiple hours - a situation could occur where
  - AtLookUp's socket connection would be invalid when the heartbeat was being sent
  - which would trigger recreation of the socket
  - and immediate sending of the `noop` heartbeat without requiring authentication
  - ... which would time out because no `from:` would have been issued
  - and the proxy service requires a `from:` in order to establish a connection to the relevant atServer
  - This situation would persist unless we got a new session request at exactly the right time, such that **_it_** triggered the creation of a new socket rather than the heartbeat timer
- Future work required: I believe we should introduce a `to:` verb into atProtocol, such that all connections can issue `to:@alice` when they connect, without side effects, and proxy services and the like can therefore immediately establish the onward connection. I will make an ADR ticket for this proposal.