### PR TITLE
fix: noports desktop switching atsigns refreshes authorisation and policy screen.

### DIFF
--- a/packages/dart/npt_flutter/changelog.md
+++ b/packages/dart/npt_flutter/changelog.md
@@ -7,6 +7,7 @@
 - FIX: Policy Screen layout update for better spacing.
 - FIX: Standardize widget styles, enhance form validation and improve layout consistency across policy forms.
 - FIX: enrollment appName set to `noports` to be consistent with noPorts cli tools.
+- FIX: Policy and Authorization Screen refreshes after switching atsign.
 
 ## 1.7.0+24
 

--- a/packages/dart/npt_flutter/lib/app.dart
+++ b/packages/dart/npt_flutter/lib/app.dart
@@ -7,7 +7,6 @@ import 'package:npt_flutter/features/authorisation/cubit/pending_requests_count_
 import 'package:npt_flutter/features/back_up_key/cubit/backup_key_cubit.dart';
 import 'package:npt_flutter/features/back_up_key/repository/backup_key_repository.dart';
 import 'package:npt_flutter/features/features.dart';
-import 'package:npt_flutter/features/policy/repositories/role_repository.dart';
 import 'package:npt_flutter/features/profile_list/cubit/sync_cubit.dart';
 import 'package:npt_flutter/localization/app_localizations.dart';
 import 'package:npt_flutter/routes.dart';
@@ -44,9 +43,7 @@ class App extends StatelessWidget {
         RepositoryProvider<BackUpKeyRepository>(
           create: (_) => BackUpKeyRepository(),
         ),
-        RepositoryProvider<RoleRepository>(
-          create: (_) => RoleRepository(),
-        ),
+        RepositoryProvider<RoleRepository>(create: (_) => RoleRepository()),
       ],
       child: MultiBlocProvider(
         providers: [
@@ -109,6 +106,9 @@ class App extends StatelessWidget {
           BlocProvider<SyncCubit>(create: (_) => SyncCubit()),
           // A cubit which tracks if the atkey is backed up
           BlocProvider<BackupKeyCubit>(create: (ctx) => BackupKeyCubit()),
+          BlocProvider<PolicyCubit>(
+            create: (ctx) => PolicyCubit(ctx.read<RoleRepository>()),
+          ),
         ],
         child: BlocSelector<SettingsBloc, SettingsState, Language?>(
           selector: (state) {

--- a/packages/dart/npt_flutter/lib/features/authorisation/view/authorisation_view.dart
+++ b/packages/dart/npt_flutter/lib/features/authorisation/view/authorisation_view.dart
@@ -1,11 +1,13 @@
 import 'package:at_client_mobile/at_client_mobile.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:npt_flutter/features/onboarding/cubit/onboarding_cubit.dart';
 
 class AuthorisationView extends StatelessWidget {
   const AuthorisationView({super.key});
   @override
   Widget build(BuildContext context) {
+    final atSign = context.watch<OnboardingCubit>().getAtSign();
     return Padding(
       padding: const EdgeInsets.all(64.0),
       child: Container(
@@ -14,6 +16,8 @@ class AuthorisationView extends StatelessWidget {
           borderRadius: BorderRadius.circular(8),
         ),
         child: AuthorisationHub(
+          // Ensure a unique key so that the AuthorisationHub is rebuilt when switching atsigns
+          key: ValueKey('authorization_hub_$atSign'),
           service: context.watch<AuthorisationService>(),
           themeData: Theme.of(context).copyWith(
             colorScheme: Theme.of(context).colorScheme.copyWith(

--- a/packages/dart/npt_flutter/lib/features/onboarding/util/post_onboard.dart
+++ b/packages/dart/npt_flutter/lib/features/onboarding/util/post_onboard.dart
@@ -5,20 +5,16 @@ import 'package:npt_flutter/features/features.dart';
 
 Future<void> postOnboard(String atSign, String rootDomain) async {
   App.log("setting all application state after onboarding".loggable);
-  App.navState.currentContext?.read<OnboardingCubit>().setState(
+  final context = App.navState.currentContext;
+  context?.read<OnboardingCubit>().setState(
     atSign: atSign,
     rootDomain: rootDomain,
     status: OnboardingStatus.onboarded,
   );
   // Start loading application data in the background as soon as we have an atClient
-  App.navState.currentContext?.read<FavoriteBloc>().add(
-    const FavoriteLoadEvent(),
-  );
-  App.navState.currentContext?.read<ProfileListBloc>().add(
-    const ProfileListLoadEvent(),
-  );
-  App.navState.currentContext?.read<SettingsBloc>().add(
-    const SettingsLoadEvent(),
-  );
-  App.navState.currentContext?.read<AuthorisationService>().init();
+  context?.read<FavoriteBloc>().add(const FavoriteLoadEvent());
+  context?.read<ProfileListBloc>().add(const ProfileListLoadEvent());
+  context?.read<SettingsBloc>().add(const SettingsLoadEvent());
+  context?.read<AuthorisationService>().init();
+  await context?.read<PolicyCubit>().loadRoles(strings);
 }

--- a/packages/dart/npt_flutter/lib/features/onboarding/util/pre_offboard.dart
+++ b/packages/dart/npt_flutter/lib/features/onboarding/util/pre_offboard.dart
@@ -7,19 +7,19 @@ import 'package:npt_flutter/features/features.dart';
 // Returns: a boolean, true = success, false = failed
 Future<bool> preSignout() async {
   App.log("Resetting all application state before signout".loggable);
+  final context = App.navState.currentContext;
   // We need to do the following before "signing out"
   // - Wipe all application state
-  App.navState.currentContext?.read<ProfilesRunningCubit>().stopAllAndClear();
-  App.navState.currentContext?.read<ProfileCacheCubit>().clear();
-  App.navState.currentContext?.read<ProfilesSelectedCubit>().deselectAll();
-  App.navState.currentContext?.read<FavoriteBloc>().clearAll();
-  App.navState.currentContext?.read<ProfileListBloc>().clearAll();
-  App.navState.currentContext?.read<SettingsBloc>().clear();
-  App.navState.currentContext?.read<OnboardingCubit>().setStatus(
-    OnboardingStatus.offboarded,
-  );
+  context?.read<ProfilesRunningCubit>().stopAllAndClear();
+  context?.read<ProfileCacheCubit>().clear();
+  context?.read<ProfilesSelectedCubit>().deselectAll();
+  context?.read<FavoriteBloc>().clearAll();
+  context?.read<ProfileListBloc>().clearAll();
+  context?.read<SettingsBloc>().clear();
+  context?.read<OnboardingCubit>().setStatus(OnboardingStatus.offboarded);
   // - Reset the tray icon
-  App.navState.currentContext?.read<TrayCubit>().initialize();
-  await App.navState.currentContext?.read<AuthorisationService>().dispose();
+  context?.read<TrayCubit>().initialize();
+  await context?.read<AuthorisationService>().dispose();
+
   return true;
 }

--- a/packages/dart/npt_flutter/lib/features/policy/view/policy_view.dart
+++ b/packages/dart/npt_flutter/lib/features/policy/view/policy_view.dart
@@ -18,11 +18,10 @@ class PolicyView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final strings = AppLocalizations.of(context)!;
-    return BlocProvider(
-      create: (context) =>
-          PolicyCubit(context.read<RoleRepository>())..loadRoles(strings),
-      child: PolicyContent(atSign: atSign),
+    return BlocBuilder<PolicyCubit, PolicyState>(
+      builder: (context, state) {
+        return PolicyContent(atSign: atSign);
+      },
     );
   }
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Made Policy and Authorization Screen refreshes after switching atsign.
**- How I did it**
Updated `post_onboarding.dart` and made `PolicyCubit` global so it can be updated outside of the Policy Screen.
**- How to verify it**

1. Run app, 
2. Navigate to the policy screen, switch atSign and the policy screen will refresh without having to leave the screen.
3. Navigate to the Authenticator screen, switch atSign and the Authenticator screen will refresh without having to leave the screen.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
