### PR TITLE
fix: In the RelayAuthVerifiers, handle all exceptions the same way, so none are uncaught within an isolate

### DIFF
--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -600,7 +600,7 @@ packages:
       path: "../../../packages/dart/noports_core"
       relative: true
     source: path
-    version: "6.10.2"
+    version: "6.10.3"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/noports_core/CHANGELOG.md
+++ b/packages/dart/noports_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 6.10.3
+
+- fix: In the RelayAuthVerifiers, catch in the same place all the exceptions 
+  which can be thrown during parsing and processing
+
 # 6.10.2
 
 - fix: Require authenticated connection when sshnpd is sending its periodic 

--- a/packages/dart/noports_core/lib/src/srvd/relay_auth_verifiers.dart
+++ b/packages/dart/noports_core/lib/src/srvd/relay_auth_verifiers.dart
@@ -365,91 +365,87 @@ class RelayAuthVerifierESCR implements RelayAuthVerifier {
               buffer.removeRange(0, buffer.indexOf(10) + 1);
               logger.finer('remaining buffer length ${buffer.length}');
 
-              try {
-                /// 2. Receives `${sessionId}:${auth-payload-as-base64}\n` from client
-                final response = String.fromCharCodes(authBuffer).trim();
-                for (final cu in response.codeUnits) {
-                  if (isUnprintable(cu)) {
-                    throw RAVE(
-                      'received unprintable code units',
-                      RAVEReason.malformedChallengeResponse,
-                    );
-                  }
-                }
-                logger.finer('received data: $response');
-
-                bool verified = await verifyChallengeResponse(response);
-
-                if (!verified) {
+              /// 2. Receives `${sessionId}:${auth-payload-as-base64}\n` from client
+              final response = String.fromCharCodes(authBuffer).trim();
+              for (final cu in response.codeUnits) {
+                if (isUnprintable(cu)) {
                   throw RAVE(
-                    '(but verifyChallengeResponse did not throw an exception)',
-                    RAVEReason.signatureVerificationFailed,
+                    'received unprintable code units',
+                    RAVEReason.malformedChallengeResponse,
                   );
                 }
+              }
+              logger.finer('received data: $response');
 
-                if (randomlyFail > 0 && random.nextInt(randomlyFail) == 0) {
-                  throw RAVE(
-                    'Randomly injected failure',
-                    RAVEReason.randomlyInjectedFailure,
-                  );
-                }
+              bool verified = await verifyChallengeResponse(response);
 
-                if (randomlyAddLatency > 0 &&
-                    random.nextInt(randomlyAddLatency) == 0) {
-                  final int l = 100 + random.nextInt(3900);
-                  logger.shout('Injecting random latency of $l ms');
-                  await Future.delayed(Duration(milliseconds: l));
-                }
-
-                logger.info('Verification success');
-
-                /// If all successful
-                /// - send 'ok' to client
-                /// - return (true, dataStream)
-                socket.writeln('ok');
-                await socket.flush();
-
-                authenticated = true;
-                if (!completer.isCompleted) {
-                  completer.complete((true, sc.stream));
-                } else {
-                  if (!sc.isClosed) {
-                    sc.addError(
-                      'Verify succeeded but'
-                      ' completer already completed!!!',
-                    );
-                  }
-                }
-
-                if (buffer.isNotEmpty) {
-                  if (!sc.isClosed) {
-                    try {
-                      sc.add(Uint8List.fromList(buffer));
-                    } catch (err) {
-                      logger.shout('finishing verify: sc.add failed with $err');
-                    }
-                  }
-                }
-              } catch (e) {
-                logger.shout(
-                  'verification FAILED with exception :'
-                  ' $e',
+              if (!verified) {
+                throw RAVE(
+                  '(but verifyChallengeResponse did not throw an exception)',
+                  RAVEReason.signatureVerificationFailed,
                 );
+              }
 
-                if (!completer.isCompleted) {
-                  // TODO Make this a feature flag to see the exception or not
-                  socket.writeln('Socket auth failed');
+              if (randomlyFail > 0 && random.nextInt(randomlyFail) == 0) {
+                throw RAVE(
+                  'Randomly injected failure',
+                  RAVEReason.randomlyInjectedFailure,
+                );
+              }
+
+              if (randomlyAddLatency > 0 &&
+                  random.nextInt(randomlyAddLatency) == 0) {
+                final int l = 100 + random.nextInt(3900);
+                logger.shout('Injecting random latency of $l ms');
+                await Future.delayed(Duration(milliseconds: l));
+              }
+
+              logger.info('Verification success');
+
+              /// If all successful
+              /// - send 'ok' to client
+              /// - return (true, dataStream)
+              socket.writeln('ok');
+              await socket.flush();
+
+              authenticated = true;
+              if (!completer.isCompleted) {
+                completer.complete((true, sc.stream));
+              } else {
+                if (!sc.isClosed) {
+                  sc.addError(
+                    'Verify succeeded but'
+                    ' completer already completed!!!',
+                  );
+                }
+              }
+
+              if (buffer.isNotEmpty) {
+                if (!sc.isClosed) {
                   try {
-                    await socket.flush();
-                    socket.destroy();
-                  } catch (_) {
-                  } finally {
-                    completer.completeError(
-                      'Error during socket authentication: $e',
-                    );
+                    sc.add(Uint8List.fromList(buffer));
+                  } catch (err) {
+                    logger.shout('finishing verify: sc.add failed with $err');
                   }
                 }
               }
+            }
+          }
+        } catch (e) {
+          logger.shout(
+            'verification FAILED with exception :'
+            ' $e',
+          );
+
+          if (!completer.isCompleted) {
+            // TODO Make this a feature flag to see the exception or not
+            socket.writeln('Socket auth failed');
+            try {
+              await socket.flush();
+              socket.destroy();
+            } catch (_) {
+            } finally {
+              completer.completeError('Error during socket authentication: $e');
             }
           }
         } finally {
@@ -550,25 +546,25 @@ class RelayAuthVerifierLegacy implements RelayAuthVerifier {
             }
           }
         } else {
-          if (buffer.length + data.length >
-              RelayAuthVerifier.maxAuthBufferLength) {
-            throw RAVE(
-              'Too much data from client'
-              ' (more than ${RelayAuthVerifier.maxAuthBufferLength} bytes)',
-              RAVEReason.malformedChallengeResponse,
-            );
-          }
-          buffer.addAll(data);
-          if (buffer.contains(10)) {
-            logger.finer('original buffer length ${buffer.length}');
+          try {
+            if (buffer.length + data.length >
+                RelayAuthVerifier.maxAuthBufferLength) {
+              throw RAVE(
+                'Too much data from client'
+                ' (more than ${RelayAuthVerifier.maxAuthBufferLength} bytes)',
+                RAVEReason.malformedChallengeResponse,
+              );
+            }
+            buffer.addAll(data);
+            if (buffer.contains(10)) {
+              logger.finer('original buffer length ${buffer.length}');
 
-            List<int> authBuffer = buffer.sublist(0, buffer.indexOf(10));
-            logger.finer('authBuffer length ${authBuffer.length}');
+              List<int> authBuffer = buffer.sublist(0, buffer.indexOf(10));
+              logger.finer('authBuffer length ${authBuffer.length}');
 
-            buffer.removeRange(0, buffer.indexOf(10) + 1);
-            logger.finer('remaining buffer length ${buffer.length}');
+              buffer.removeRange(0, buffer.indexOf(10) + 1);
+              logger.finer('remaining buffer length ${buffer.length}');
 
-            try {
               final String message;
               try {
                 message = String.fromCharCodes(authBuffer);
@@ -665,18 +661,16 @@ class RelayAuthVerifierLegacy implements RelayAuthVerifier {
                   }
                 }
               }
-            } catch (e) {
-              logger.shout(
-                '$tag :'
-                ' verification FAILED with exception :'
-                ' $e',
-              );
+            }
+          } catch (e) {
+            logger.shout(
+              '$tag :'
+              ' verification FAILED with exception :'
+              ' $e',
+            );
 
-              if (!completer.isCompleted) {
-                completer.completeError(
-                  'Error during socket authentication: $e',
-                );
-              }
+            if (!completer.isCompleted) {
+              completer.completeError('Error during socket authentication: $e');
             }
           }
         }

--- a/packages/dart/noports_core/lib/src/version.dart
+++ b/packages/dart/noports_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '6.10.2';
+const packageVersion = '6.10.3';

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: noports_core
 description: Core library code for sshnoports
 homepage: https://docs.atsign.com/
 
-version: 6.10.2
+version: 6.10.3
 
 environment:
   sdk: ^3.8.0

--- a/packages/dart/noports_core/test/srvd/relay_authentication_escr_test.dart
+++ b/packages/dart/noports_core/test/srvd/relay_authentication_escr_test.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:math';
+import 'dart:typed_data';
 import 'package:at_chops/at_chops.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:noports_core/src/srv/relay_authenticators.dart';
@@ -188,6 +190,52 @@ void main() {
       expect(verifier.atSign, null);
       expect(verifier.sessionId, relaySessionId);
       expect(verifier.isSideA, false);
+    });
+
+    test('too much data', () async {
+      RelayAuthVerifierESCR verifier = RelayAuthVerifierESCR(
+        'too much data',
+        helper,
+      );
+
+      Random r = Random();
+      Uint8List data = Uint8List.fromList(List.generate(
+          RelayAuthVerifier.maxAuthBufferLength + 1, (i) => r.nextInt(256)));
+
+      late Function(Uint8List data) socketOnDataFn;
+      MockSocket mockSocket = MockSocket();
+
+      when (() => mockSocket.flush()).thenAnswer((Invocation i) async {Completer c = Completer(); c.complete(); return c.future;});
+      when(
+            () => mockSocket.listen(
+          any(),
+          onError: any(named: "onError"),
+          onDone: any(named: "onDone"),
+        ),
+      ).thenAnswer((Invocation invocation) {
+        socketOnDataFn = invocation.positionalArguments[0];
+
+        socketOnDataFn(data);
+
+        return MockStreamSubscription<Uint8List>();
+      });
+
+      bool somethingThrown = false;
+      try {
+        await verifier.verifySocketAuth(mockSocket);
+      } catch (e, st) {
+        expect(e.toString(), contains('Error during socket authentication:'
+            ' RelayAuthVerifierException: malformedChallengeResponse :'
+            ' Too much data from client (more than 4096 bytes)'));
+        print('Caught $e as expected\n$st');
+        somethingThrown = true;
+      }
+      expect(somethingThrown, true, reason: 'exception should have been thrown');
+
+
+      expect(verifier.atSign, null);
+      expect(verifier.sessionId, null);
+      expect(verifier.isSideA, null);
     });
   });
 }

--- a/packages/dart/noports_core/test/srvd/relay_authentication_legacy_test.dart
+++ b/packages/dart/noports_core/test/srvd/relay_authentication_legacy_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 import 'dart:typed_data';
 import 'package:at_chops/at_chops.dart';
 import 'package:mocktail/mocktail.dart';
@@ -18,6 +19,54 @@ void main() {
 
       atChops = AtChopsImpl(AtChopsKeys.create(encryptionKeyPair, null));
     });
+
+    test('too much data', () async {
+      String rvdSessionNonce = DateTime.now().toIso8601String();
+      Map payload = {
+        'sessionId': Uuid().v4().toString(),
+        'rvdNonce': rvdSessionNonce,
+      };
+
+      RelayAuthVerifierLegacy sa = RelayAuthVerifierLegacy(
+        atChops.atChopsKeys.atEncryptionKeyPair!.atPublicKey.publicKey,
+        'some other payload',
+        rvdSessionNonce,
+        'legacy_test_overflow',
+        '@alice',
+        payload['sessionId'],
+      );
+
+      Random r = Random();
+      Uint8List data = Uint8List.fromList(List.generate(
+          RelayAuthVerifier.maxAuthBufferLength + 1, (i) => r.nextInt(256)));
+
+      late Function(Uint8List data) socketOnDataFn;
+      MockSocket mockSocket = MockSocket();
+
+      when(
+            () => mockSocket.listen(
+          any(),
+          onError: any(named: "onError"),
+          onDone: any(named: "onDone"),
+        ),
+      ).thenAnswer((Invocation invocation) {
+        socketOnDataFn = invocation.positionalArguments[0];
+
+        socketOnDataFn(data);
+
+        return MockStreamSubscription<Uint8List>();
+      });
+
+      bool somethingThrown = false;
+      try {
+        await sa.verifySocketAuth(mockSocket);
+      } catch (e) {
+        print('Caught $e as expected');
+        somethingThrown = true;
+      }
+      expect(somethingThrown, true);
+    });
+
     test('signature verification success', () async {
       String rvdSessionNonce = DateTime.now().toIso8601String();
       Map payload = {'sessionId': Uuid().v4(), 'rvdNonce': rvdSessionNonce};

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -973,7 +973,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.10.2"
+    version: "6.10.3"
   openssh_ed25519:
     dependency: transitive
     description:
@@ -1503,26 +1503,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.26.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.11"
   timing:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.14.2';
+const packageVersion = '5.14.3';

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -584,7 +584,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.10.2"
+    version: "6.10.3"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.14.2
+version: 5.14.3
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
**- What I did**
- In the RelayAuthVerifier implementations, moved some processing in the `verifySocketAuth` function so it's inside the try-catch block responsible for transmitting the errors to the stream
- Added some tests

**- How I did it**
See commits

**- How to verify it**
- Manually verified, running srvd's locally and sending lots of data to them via netcat:
```while true
do
echo -n 0
done | nc 127.0.0.1 443
```
- **running latest live srvd**: unhandled exception, isolate terminates, subsequent connections not handled
```
build/sshnp/srvd -a @relay -i 127.0.0.1 --443 \   
  --root-domain vip.ve.atsign.zone
Using local storage directory Directory: '/Users/gary/.atsign/storage/@relay/srvd/1767614747684'
Unhandled exception:
RelayAuthVerifierException: malformedChallengeResponse : Too much data from client (more than 4096 bytes)
#0      RelayAuthVerifierESCR.verifySocketAuth.<anonymous closure> (package:noports_core/src/srvd/relay_auth_verifiers.dart:352)
<asynchronous suspension>
```
- **running srvd from branch**: exception handled, isolate does not terminate, subsequent connections handled normally
```
SHOUT|2026-01-05 12:06:50.368252| RelayAuthVerifierESCR (to port 443 from host InternetAddress('127.0.0.1', IPv4) port 59975) |verification FAILED with exception : RelayAuthVerifierException: malformedChallengeResponse : Too much data from client (more than 4096 bytes) 
SHOUT|2026-01-05 12:06:52.340855| RelayAuthVerifierESCR (to port 443 from host InternetAddress('127.0.0.1', IPv4) port 59986) |verification FAILED with exception : RelayAuthVerifierException: malformedChallengeResponse : Too much data from client (more than 4096 bytes) 
SHOUT|2026-01-05 12:06:53.763145| RelayAuthVerifierESCR (to port 443 from host InternetAddress('127.0.0.1', IPv4) port 59987) |verification FAILED with exception : RelayAuthVerifierException: malformedChallengeResponse : Too much data from client (more than 4096 bytes)
```
