### PR TITLE
fix: create default tool tip on tray Icon

### DIFF
--- a/packages/dart/npt_flutter/changelog.md
+++ b/packages/dart/npt_flutter/changelog.md
@@ -1,3 +1,8 @@
+
+FIX: Added a default tool tip to prevent garbled tool tips on the Windows tray Icon
+FEAT: Added auto start of application via URI in configuration of connections
+
+
 ## 1.8.0+25
 
 - FEAT: App now supports IPv6 and IPv4 numeric entries for local and remote host.

--- a/packages/dart/npt_flutter/changelog.md
+++ b/packages/dart/npt_flutter/changelog.md
@@ -1,8 +1,4 @@
 
-FIX: Added a default tool tip to prevent garbled tool tips on the Windows tray Icon
-FEAT: Added auto start of application via URI in configuration of connections
-
-
 ## 1.8.0+25
 
 - FEAT: App now supports IPv6 and IPv4 numeric entries for local and remote host.
@@ -14,6 +10,8 @@ FEAT: Added auto start of application via URI in configuration of connections
 - FIX: enrollment appName set to `noports` to be consistent with noPorts cli tools.
 - FIX: Enrollment Dialog cannot be dismissed once the enrollment process starts
 - FIX: Policy and Authorization Screen refreshes after switching atsign.
+- FIX: Added a default tool tip to prevent garbled tool tips on the Windows tray Icon
+- FEAT: Added auto start of application via URI in configuration of connections
 
 ## 1.7.0+24
 

--- a/packages/dart/npt_flutter/lib/features/tray_manager/cubit/tray_cubit.dart
+++ b/packages/dart/npt_flutter/lib/features/tray_manager/cubit/tray_cubit.dart
@@ -63,7 +63,9 @@ class TrayCubit extends LoggingCubit<TrayState> {
         Platform.isWindows ? Constants.icoIconLight : Constants.pngIconLight,
       Brightness.dark =>
         Platform.isWindows ? Constants.icoIconDark : Constants.pngIconDark,
-    });
+    });   
+    // Set an empty tooltip for the main tray icon to avoid garbage characters
+    await trayManager.setToolTip('NoPorts Desktop');
   }
 
   MenuItem _getMenuItem(TrayAction action, AppLocalizations localizations) {


### PR DESCRIPTION

**- What I did**
Added a default tool tip to prevent garbled tool tips on the Windows tray Icon
**- How I did it**
trayManager.setToolTip 
**- How to verify it**
tested by hand
**- Description for the changelog**
Fix for tool tip on tray icon (on Windows) showing garbled characters, no shows NoPorts DeskTop
