### PR TITLE
fix: Tool Tray behavior fixed on Windows and settings window now opens when click from tool tray

### DIFF
--- a/packages/dart/npt_flutter/changelog.md
+++ b/packages/dart/npt_flutter/changelog.md
@@ -12,6 +12,9 @@
 - FIX: Policy and Authorization Screen refreshes after switching atsign.
 - FIX: Added a default tool tip to prevent garbled tool tips on the Windows tray Icon
 - FEAT: Added auto start of application via URI in configuration of connections
+- FIX: On Windows the tool tray now has Icons to indicate status (Windows cannot do color in tool tray)
+- FIX: In the tool tray now when you click settings you get to the app and the settings page
+- FEAT: On Windows clicking the tool tray Icon for a favourite will open the app and connect, if already connected will simply disconnect 
 
 ## 1.7.0+24
 

--- a/packages/dart/npt_flutter/lib/features/favorite/models/favorite.dart
+++ b/packages/dart/npt_flutter/lib/features/favorite/models/favorite.dart
@@ -65,8 +65,7 @@ sealed class Favorite<T extends Loggable> extends Loggable {
 
 @JsonSerializable()
 class FavoriteProfile extends Favorite<ProfileState> {
-  const FavoriteProfile({required super.uuid})
-    : super(type: FavoriteType.profile);
+  const FavoriteProfile({required super.uuid}) : super(type: FavoriteType.profile);
 
   @override
   List<Object?> get props => [uuid];
@@ -76,8 +75,7 @@ class FavoriteProfile extends Favorite<ProfileState> {
     return 'FavoriteProfile(uuid: $uuid)';
   }
 
-  factory FavoriteProfile.fromJson(Map<String, dynamic> json) =>
-      _$FavoriteProfileFromJson(json);
+  factory FavoriteProfile.fromJson(Map<String, dynamic> json) => _$FavoriteProfileFromJson(json);
 
   @override
   Map<String, dynamic> toJson() {
@@ -109,10 +107,9 @@ class FavoriteProfile extends Favorite<ProfileState> {
     return switch (state) {
       ProfileLoaded _ || ProfileFailedSave _ => ProfileStatus.off.message,
       ProfileStarting _ => ProfileStatus.starting.message,
-      ProfileStarted _ =>
-        '${ProfileStatus.on.message} - ${(state as ProfileLoadedState).profile.localPort}]',
+      ProfileStarted _ => '${ProfileStatus.on.message} - [${(state as ProfileLoadedState).profile.localPort}]',
       ProfileStopping _ => ProfileStatus.stopping.message,
-      ProfileInitial _ || ProfileLoading _ => ProfileStatus.loading.message,
+      ProfileInitial _ || ProfileLoading _ => ProfileStatus.off.message, // Show as disconnected during initialization
       ProfileFailedStart _ => ProfileStatus.failedToStart.message,
       ProfileFailedLoad _ => ProfileStatus.failedToLoad.message,
     };

--- a/packages/dart/npt_flutter/lib/features/tray_manager/cubit/tray_cubit.dart
+++ b/packages/dart/npt_flutter/lib/features/tray_manager/cubit/tray_cubit.dart
@@ -160,7 +160,24 @@ class TrayCubit extends LoggingCubit<TrayState> {
               statusIcon = ProfileStatus.off.emoji;
             }
             var label = '$statusIcon $displayName';
-            return MenuItem(label: label, toolTip: status, onClick: (_) => fav.toggle());
+            return MenuItem(
+              label: label,
+              toolTip: status,
+              onClick: (_) {
+                // Check if we're currently disconnected before toggling
+                final isDisconnected = status == null || 
+                    status == ProfileStatus.off.message ||
+                    status == ProfileStatus.failedToStart.message ||
+                    status == ProfileStatus.failedToLoad.message;
+                
+                fav.toggle();
+                
+                // Show the main window on Windows only when initiating a connection
+                if (Platform.isWindows && isDisconnected) {
+                  windowManager.show();
+                }
+              },
+            );
           }),
     );
 

--- a/packages/dart/npt_flutter/lib/features/tray_manager/cubit/tray_cubit.dart
+++ b/packages/dart/npt_flutter/lib/features/tray_manager/cubit/tray_cubit.dart
@@ -8,6 +8,7 @@ import 'package:npt_flutter/features/favorite/favorite.dart';
 import 'package:npt_flutter/features/onboarding/onboarding.dart';
 import 'package:npt_flutter/features/profile/profile.dart';
 import 'package:npt_flutter/features/profile_list/profile_list.dart';
+import 'package:npt_flutter/home_wrapper_widget.dart';
 import 'package:npt_flutter/localization/app_localizations.dart';
 import 'package:npt_flutter/routes.dart';
 import 'package:npt_flutter/util/constants.dart';
@@ -36,9 +37,7 @@ class TrayCubit extends LoggingCubit<TrayState> {
     if (state is! TrayInitial || localizations == null) return;
     var context = App.navState.currentContext;
     if (context == null) return;
-    var showSettings =
-        context.read<OnboardingCubit>().getStatus() ==
-        OnboardingStatus.onboarded;
+    var showSettings = context.read<OnboardingCubit>().getStatus() == OnboardingStatus.onboarded;
 
     await reloadIcon();
 
@@ -46,8 +45,7 @@ class TrayCubit extends LoggingCubit<TrayState> {
       Menu(
         items: [
           _getMenuItem(TrayAction.showDashboard, localizations),
-          if (showSettings)
-            _getMenuItem(TrayAction.showSettings, localizations),
+          if (showSettings) _getMenuItem(TrayAction.showSettings, localizations),
           _getMenuItem(TrayAction.quitApp, localizations),
         ],
       ),
@@ -56,36 +54,23 @@ class TrayCubit extends LoggingCubit<TrayState> {
   }
 
   Future<void> reloadIcon() async {
-    final brightness =
-        WidgetsBinding.instance.platformDispatcher.platformBrightness;
+    final brightness = WidgetsBinding.instance.platformDispatcher.platformBrightness;
     await trayManager.setIcon(switch (brightness) {
-      Brightness.light =>
-        Platform.isWindows ? Constants.icoIconLight : Constants.pngIconLight,
-      Brightness.dark =>
-        Platform.isWindows ? Constants.icoIconDark : Constants.pngIconDark,
-    });   
+      Brightness.light => Platform.isWindows ? Constants.icoIconLight : Constants.pngIconLight,
+      Brightness.dark => Platform.isWindows ? Constants.icoIconDark : Constants.pngIconDark,
+    });
     // Set an empty tooltip for the main tray icon to avoid garbage characters
     await trayManager.setToolTip('NoPorts Desktop');
   }
 
   MenuItem _getMenuItem(TrayAction action, AppLocalizations localizations) {
     final (label, callback) = _getAction(action, localizations);
-    return MenuItem(
-      key: _$TrayActionEnumMap[action],
-      label: label,
-      onClick: callback,
-    );
+    return MenuItem(key: _$TrayActionEnumMap[action], label: label, onClick: callback);
   }
 
-  (String, void Function(MenuItem)) _getAction(
-    TrayAction action,
-    AppLocalizations localizations,
-  ) {
+  (String, void Function(MenuItem)) _getAction(TrayAction action, AppLocalizations localizations) {
     return switch (action) {
-      TrayAction.showDashboard => (
-        localizations.showWindow,
-        (_) => windowManager.show(inactive: true),
-      ),
+      TrayAction.showDashboard => (localizations.showWindow, (_) => windowManager.show(inactive: true)),
       TrayAction.showSettings => (
         localizations.settings,
         (_) => windowManager.show(inactive: true).then((_) {
@@ -94,10 +79,8 @@ class TrayCubit extends LoggingCubit<TrayState> {
           if (context.mounted) {
             var cubit = context.read<OnboardingCubit>();
             if (cubit.getStatus() != OnboardingStatus.onboarded) return;
-            Navigator.of(context).pushNamedAndRemoveUntil(
-              HomeRoutes.settings,
-              (route) => route.isFirst,
-            );
+            // Use the wrapper navigator which has the settings route
+            wrapperNav.currentState?.pushNamedAndRemoveUntil(HomeRoutes.settings, (route) => route.isFirst);
           }
         }),
       ),
@@ -141,31 +124,28 @@ class TrayCubit extends LoggingCubit<TrayState> {
     /// Generate the new menu based on current state
     var favMenuItems = await Future.wait(
       favoriteState.favorites
-          .where(
-            (fav) => fav.isLoadedInProfiles(
-              (profileListState as ProfileListLoaded).profiles,
-            ),
-          )
+          .where((fav) => fav.isLoadedInProfiles((profileListState as ProfileListLoaded).profiles))
           .map((fav) async {
             /// Make sure to call [e.displayName] and [e.isRunning] only once to
             /// ensure good performance - these getters call a bunch of nested
             /// information from elsewhere in the app state
 
             var displayName =
-                (profileState != null &&
-                    profileState is ProfileLoadedState &&
-                    profileState.uuid == fav.uuid)
+                (profileState != null && profileState is ProfileLoadedState && profileState.uuid == fav.uuid)
                 ? profileState.profile.displayName
                 : await fav.displayName;
 
             final status = fav.status;
 
             final String statusIcon;
-            if (status == ProfileStatus.off.message) {
+            if (status == null) {
+              // Status is not available yet - default to disconnected
+              statusIcon = ProfileStatus.off.emoji;
+            } else if (status == ProfileStatus.off.message) {
               statusIcon = ProfileStatus.off.emoji;
             } else if (status == ProfileStatus.starting.message) {
               statusIcon = ProfileStatus.starting.emoji;
-            } else if (status?.contains(ProfileStatus.on.message) ?? false) {
+            } else if (status.contains(ProfileStatus.on.message)) {
               statusIcon = ProfileStatus.on.emoji;
             } else if (status == ProfileStatus.stopping.message) {
               statusIcon = ProfileStatus.stopping.emoji;
@@ -176,14 +156,11 @@ class TrayCubit extends LoggingCubit<TrayState> {
             } else if (status == ProfileStatus.failedToLoad.message) {
               statusIcon = ProfileStatus.failedToLoad.emoji;
             } else {
-              statusIcon = '';
+              // Unknown status - default to disconnected
+              statusIcon = ProfileStatus.off.emoji;
             }
             var label = '$statusIcon $displayName';
-            return MenuItem(
-              label: label,
-              toolTip: status,
-              onClick: (_) => fav.toggle(),
-            );
+            return MenuItem(label: label, toolTip: status, onClick: (_) => fav.toggle());
           }),
     );
 
@@ -198,8 +175,7 @@ class TrayCubit extends LoggingCubit<TrayState> {
           ...favMenuItems,
           MenuItem.separator(),
           _getMenuItem(TrayAction.showDashboard, localizations),
-          if (showSettings)
-            _getMenuItem(TrayAction.showSettings, localizations),
+          if (showSettings) _getMenuItem(TrayAction.showSettings, localizations),
           _getMenuItem(TrayAction.quitApp, localizations),
         ],
       ),

--- a/packages/dart/npt_flutter/lib/util/profile_status.dart
+++ b/packages/dart/npt_flutter/lib/util/profile_status.dart
@@ -1,15 +1,9 @@
+import 'dart:io';
+
 import 'package:npt_flutter/app.dart';
 import 'package:npt_flutter/localization/app_localizations.dart';
 
-enum ProfileStatus {
-  off,
-  starting,
-  on,
-  stopping,
-  loading,
-  failedToStart,
-  failedToLoad,
-}
+enum ProfileStatus { off, starting, on, stopping, loading, failedToStart, failedToLoad }
 
 extension ProfileStatusExtension on ProfileStatus {
   String get message {
@@ -33,6 +27,27 @@ extension ProfileStatusExtension on ProfileStatus {
   }
 
   String get emoji {
+    // Windows system tray doesn't support colored emojis, use distinct text symbols instead
+    if (Platform.isWindows) {
+      switch (this) {
+        case ProfileStatus.off:
+          return '○'; // White circle (disconnected)
+        case ProfileStatus.starting:
+          return '◔'; // Circle with upper right quadrant black (starting)
+        case ProfileStatus.on:
+          return '✓'; // Check mark (connected)
+        case ProfileStatus.stopping:
+          return '◑'; // Circle with left half black (stopping)
+        case ProfileStatus.loading:
+          return '◐'; // Circle with right half black (loading)
+        case ProfileStatus.failedToStart:
+          return '⚠'; // Warning sign (failed to start)
+        case ProfileStatus.failedToLoad:
+          return '!'; // Exclamation mark (failed to load)
+      }
+    }
+
+    // macOS and Linux support colored emojis
     switch (this) {
       case ProfileStatus.off:
         return '⚪';


### PR DESCRIPTION

**- What I did**
Worked on these bugs
https://github.com/atsign-foundation/noports/issues/2399
https://github.com/atsign-foundation/noports/issues/2407

**- How I did it**
Migrated to Icons for Windows as Colors/Emjois are not supported on Windows Tool Tray menus
Fixed minor issue with the Settings tool tray so it pops to the right panel in the app

**- How to verify it**
Ran tests locally on Win and Mac

**- Description for the changelog**
- FIX: On Windows the tool tray now has Icons to indicate status (Windows cannot do color in tool tray)
- FIX: In the tool tray now when you click settings you get to the app and the settings page
- FEAT: On Windows clicking the tool tray Icon for a favourite will open the app and connect, if already connected will simply disconnect 
