### PR TITLE
build(deps): take up at_client 3.10.0 which includes enhancements to Monitor (notifications listener) reliability

### DIFF
--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -94,10 +94,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_client
-      sha256: "5259886a09507a439be08bbaa79a360ecd936ac1baa2ae58b72c90357cdb4785"
+      sha256: "0b2a044859a212d7c4e6bc5c9686b1b395e014d37b4d6c50e04d1d5d23a3e3e2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.9.2"
+    version: "3.10.0"
   at_commons:
     dependency: transitive
     description:

--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -600,7 +600,7 @@ packages:
       path: "../../../packages/dart/noports_core"
       relative: true
     source: path
-    version: "6.10.3"
+    version: "6.10.4"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/apps/admin/admin_api/pubspec.yaml
+++ b/apps/admin/admin_api/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 # Add regular dependencies here.
 dependencies:
   alfred: 1.1.2+1
-  at_client: ^3.9.2
+  at_client: ^3.10.0
   json_annotation: 4.9.0
   at_cli_commons: ^3.0.1
   args: 2.7.0

--- a/packages/dart/noports_core/CHANGELOG.md
+++ b/packages/dart/noports_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.10.4
+
+- build(deps): take up at_client 3.10.0
+
 # 6.10.3
 
 - fix: In the RelayAuthVerifiers, catch in the same place all the exceptions 

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -232,8 +232,7 @@ class SshnpdImpl
 
       if (p.debug) {
         sshnpd.logger.logger.level = Level.FINEST;
-      }
-      else if (p.verbose) {
+      } else if (p.verbose) {
         sshnpd.logger.logger.level = Level.INFO;
       }
 
@@ -272,7 +271,7 @@ class SshnpdImpl
     await _shareUsername();
 
     logger.info('Starting heartbeat');
-    startHeartbeat();
+    startHeartbeats();
 
     handlePublicKeyChangedEvent(atClient, deviceAtsign);
 
@@ -304,37 +303,38 @@ class SshnpdImpl
       (_) async => await _sendHeartbeatToPolicy(),
     );
 
-    logger.info('Done');
+    logger.info('Daemon is running');
   }
 
-  void startHeartbeat() {
-    bool lastHeartbeatOk = true;
+  /// 1. Periodically send a 'noop' on the main atLookUp connection, so that
+  /// the connection is kept alive in normal conditions.
+  /// 2. Listen for notification listener currentState changes and log a
+  /// message when it changes
+  void startHeartbeats() {
+    // 1. keep-alive on the main atLookUp connection
     Timer.periodic(Duration(seconds: 90), (timer) async {
-      String? resp;
       try {
-        resp = await atClient.getRemoteSecondary()?.atLookUp.executeCommand(
+        await atClient.getRemoteSecondary()?.atLookUp.executeCommand(
           'noop:0\n',
           auth: true,
         );
       } catch (_) {}
-      if (resp == null || !resp.startsWith('data:ok')) {
-        if (lastHeartbeatOk) {
-          logger.shout('connection lost');
-        }
-        lastHeartbeatOk = false;
-      } else {
-        if (!lastHeartbeatOk) {
-          logger.shout('connection available');
-        }
-        lastHeartbeatOk = true;
+    });
+
+    // 2. Log a message when notification listener state changes
+    NotificationListenerState? lastState;
+    atClient.notificationService.currentListenerStateStream.listen((nls) {
+      if (nls != lastState) {
+        logger.shout('Notification listener state changed to $nls');
+        lastState = nls;
       }
     });
   }
 
   /// Notification handler for requests from clients
   Future<void> clientRequestNotificationHandler(
-      AtNotification notification,
-      ) async {
+    AtNotification notification,
+  ) async {
     try {
       try {
         if (notifPreProcessor != null) {
@@ -343,7 +343,7 @@ class SshnpdImpl
       } catch (e) {
         logger.shout(
           'Notification pre-processing failed with $e\n'
-              'Notification: $notification',
+          'Notification: $notification',
         );
         return;
       }
@@ -351,11 +351,11 @@ class SshnpdImpl
       String messageType = notification.key
           .replaceAll('${notification.to}:', '')
           .replaceAll(
-        '.$device.${DefaultArgs.namespace}${notification.from}',
-        '',
-      )
-      // convert to lower case as the latest AtClient converts notification
-      // keys to lower case when received
+            '.$device.${DefaultArgs.namespace}${notification.from}',
+            '',
+          )
+          // convert to lower case as the latest AtClient converts notification
+          // keys to lower case when received
           .toLowerCase();
 
       NPAAuthCheckResponse auth = await authCheck(notification);
@@ -738,14 +738,14 @@ class SshnpdImpl
     // Check if this *client* is allowed connections to the requested host / port
     if (!_permittedToOpen(auth.permitOpen, req)) {
       await _logEvent(
-          SessionEvent.denied(
-            sessionId: req.sessionId,
-            authInfo: NPAAuthCheckResponse(
-              authorized: false,
-              message: 'POLICY denied request',
-              permitOpen: auth.permitOpen,
-            ).toJson(),
-          )
+        SessionEvent.denied(
+          sessionId: req.sessionId,
+          authInfo: NPAAuthCheckResponse(
+            authorized: false,
+            message: 'POLICY denied request',
+            permitOpen: auth.permitOpen,
+          ).toJson(),
+        ),
       );
 
       // Notify noports client that this session is NOT connected
@@ -883,7 +883,7 @@ class SshnpdImpl
         d2cBundle = await genBundle(encKeyType, req.clientEphemeralPK);
       }
     }
-      if (inline) {
+    if (inline) {
       SocketConnector sc = await Srv.dart(
         req.rvdHost,
         req.rvdPort,
@@ -1036,14 +1036,14 @@ class SshnpdImpl
     // Check if this *client* is allowed connections to the requested host / port
     if (!_permittedToOpen(auth.permitOpen, req)) {
       await _logEvent(
-          SessionEvent.denied(
-            sessionId: req.sessionId,
-            authInfo: NPAAuthCheckResponse(
-              authorized: false,
-              message: 'POLICY denied request',
-              permitOpen: auth.permitOpen,
-            ).toJson(),
-          )
+        SessionEvent.denied(
+          sessionId: req.sessionId,
+          authInfo: NPAAuthCheckResponse(
+            authorized: false,
+            message: 'POLICY denied request',
+            permitOpen: auth.permitOpen,
+          ).toJson(),
+        ),
       );
 
       // Notify noports client that this session is NOT connected
@@ -1391,7 +1391,9 @@ class SshnpdImpl
           sessionId: sessionId,
         );
       } else {
-        await _logEvent(SessionEvent.daemonConnecting(sessionId: req.sessionId));
+        await _logEvent(
+          SessionEvent.daemonConnecting(sessionId: req.sessionId),
+        );
 
         /// Notify sshnp that the connection has been made
         await _notify(

--- a/packages/dart/noports_core/lib/src/version.dart
+++ b/packages/dart/noports_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '6.10.3';
+const packageVersion = '6.10.4';

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   args: ^2.4.2
   at_chops: ^2.0.1
-  at_client: ^3.9.2
+  at_client: ^3.10.0
   at_commons: ^5.6.1
   at_cli_commons: ^3.0.1
   at_utils: ^3.0.19
@@ -33,11 +33,6 @@ dependencies:
   yaml: ^3.1.3
 
 dependency_overrides:
-  at_client:
-    git:
-      url: https://github.com/atsign-foundation/at_client_sdk
-      path: packages/at_client
-      ref: gkc-notif-service-connection-reliability
   archive: ^4.0.7
   dartssh2:
     git:

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: noports_core
 description: Core library code for sshnoports
 homepage: https://docs.atsign.com/
 
-version: 6.10.3
+version: 6.10.4
 
 environment:
   sdk: ^3.8.0
@@ -33,6 +33,11 @@ dependencies:
   yaml: ^3.1.3
 
 dependency_overrides:
+  at_client:
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk
+      path: packages/at_client
+      ref: gkc-notif-service-connection-reliability
   archive: ^4.0.7
   dartssh2:
     git:

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_client
-      sha256: "5259886a09507a439be08bbaa79a360ecd936ac1baa2ae58b72c90357cdb4785"
+      sha256: "0b2a044859a212d7c4e6bc5c9686b1b395e014d37b4d6c50e04d1d5d23a3e3e2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.9.2"
+    version: "3.10.0"
   at_client_mobile:
     dependency: "direct main"
     description:

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -973,7 +973,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.10.3"
+    version: "6.10.4"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/npt_flutter/test/features/profile/repository/profile_repository_test.mocks.dart
+++ b/packages/dart/npt_flutter/test/features/profile/repository/profile_repository_test.mocks.dart
@@ -218,9 +218,16 @@ class MockAtClient extends _i1.Mock implements _i2.AtClient {
           as _i6.Future<_i3.AtResponse>);
 
   @override
-  _i6.Future<bool> putMeta(_i2.AtKey? key) =>
+  _i6.Future<bool> putMeta(
+    _i2.AtKey? key, {
+    _i2.PutRequestOptions? putRequestOptions,
+  }) =>
       (super.noSuchMethod(
-            Invocation.method(#putMeta, [key]),
+            Invocation.method(
+              #putMeta,
+              [key],
+              {#putRequestOptions: putRequestOptions},
+            ),
             returnValue: _i6.Future<bool>.value(false),
           )
           as _i6.Future<bool>);

--- a/packages/dart/sshnoports/lib/src/create_at_client_cli.dart
+++ b/packages/dart/sshnoports/lib/src/create_at_client_cli.dart
@@ -23,6 +23,7 @@ Future<AtClient> createAtClientCli({
     ..hiveStoragePath = storagePath
     ..namespace = namespace
     ..downloadPath = path.normalize('$storagePath/downloads')
+    // ignore: deprecated_member_use
     ..isLocalStoreRequired = true
     ..commitLogPath = path.normalize('$storagePath/commitLog')
     ..fetchOfflineNotifications = false

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.14.3';
+const packageVersion = '5.14.4';

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "0eb33edbbe99a02e73b8bbeb6f2b65972023d902117ee8d1bf0ea1a79f83aa7b"
+      sha256: "5b7468c326d2f8a4f630056404ca0d291ade42918f4a3c6233618e724f39da8e"
       url: "https://pub.dev"
     source: hosted
-    version: "90.0.0"
+    version: "92.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "711e3a890bb529bf55f07d73b8706f4b7504ad77e90d2f205626b116c048583f"
+      sha256: "70e4b1ef8003c64793a9e268a551a82869a8a96f39deb73dea28084b0e8bf75e"
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.0"
+    version: "9.0.0"
   archive:
     dependency: "direct overridden"
     description:
@@ -86,7 +86,7 @@ packages:
     description:
       path: "packages/at_client"
       ref: gkc-notif-service-connection-reliability
-      resolved-ref: "743d62336cc0be0bd0a712bd143f58a86e8aafaa"
+      resolved-ref: "239448da572704507c9744c3a590c96008d428b7"
       url: "https://github.com/atsign-foundation/at_client_sdk"
     source: git
     version: "3.10.0"
@@ -94,10 +94,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_commons
-      sha256: bd6ba59a7b23fd04d2fcda30be14c314cd8635ad3e0f5b1e917825563f0bcddd
+      sha256: "5592ccf18bd673f3f68e13a75a8f5a9934ea516e1ef2f6b22fb9f620f071ff74"
       url: "https://pub.dev"
     source: hosted
-    version: "5.6.2"
+    version: "5.7.0"
   at_lookup:
     dependency: transitive
     description:
@@ -110,10 +110,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_onboarding_cli
-      sha256: "1d44901cf534050834a70452bcf1b700253491016d9608c7dbfb1817ea2e3f80"
+      sha256: "9e8317662dffb447e5dd41e82d5825eea0d44460e01c106570902224a97abd44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.1"
+    version: "1.14.2"
   at_persistence_secondary_server:
     dependency: transitive
     description:
@@ -134,10 +134,10 @@ packages:
     dependency: transitive
     description:
       name: at_server_status
-      sha256: caffbc483f3c8d7606fa8a6767ade941e6fccf017765c3c1d436b2f2eaf2d156
+      sha256: bbce2d6226b5a381a5462ba99afc6e6d677043263a4eb659a731d0f51465bc54
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   at_utf7:
     dependency: transitive
     description:
@@ -166,10 +166,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: dfb67ccc9a78c642193e0c2d94cb9e48c2c818b3178a86097d644acdcde6a8d9
+      sha256: c1668065e9ba04752570ad7e038288559d1e2ca5c6d0131c0f5f55e39e777413
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.0.3"
   build_config:
     dependency: transitive
     description:
@@ -182,10 +182,10 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
+      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.4"
+    version: "4.1.1"
   build_runner:
     dependency: "direct dev"
     description:
@@ -214,10 +214,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: a30f0a0e38671e89a492c44d005b5545b830a961575bbd8336d42869ff71066d
+      sha256: "426cf75afdb23aa74bd4e471704de3f9393f3c7b04c1e2d9c6f1073ae0b8b139"
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.0"
+    version: "8.12.1"
   chalkdart:
     dependency: "direct main"
     description:
@@ -262,10 +262,10 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "11654819532ba94c34de52ff5feb52bd81cba1de00ef2ed622fd50295f9d4243"
+      sha256: "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d"
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.0"
+    version: "4.11.1"
   collection:
     dependency: transitive
     description:
@@ -310,18 +310,18 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   cryptography:
     dependency: transitive
     description:
       name: cryptography
-      sha256: d146b76d33d94548cf035233fbc2f4338c1242fa119013bead807d033fc4ae05
+      sha256: "3eda3029d34ec9095a27a198ac9785630fe525c0eb6a49f3d575272f8e792ef0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.0"
+    version: "2.9.0"
   crypton:
     dependency: transitive
     description:
@@ -334,18 +334,18 @@ packages:
     dependency: transitive
     description:
       name: dart_periphery
-      sha256: b9fe42da5c26c2f79afc077160e8a4917e3c45c4a8d56a1ef7ac29c3e972eb55
+      sha256: "1c933dae787d65e6e66ee89db4a58ed74dc9213b83cea10c344585a256ca498a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.12"
+    version: "0.9.20"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: c87dfe3d56f183ffe9106a18aebc6db431fc7c98c31a54b952a77f3d54a85697
+      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
   dartssh2:
     dependency: "direct main"
     description:
@@ -391,10 +391,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      sha256: d07d37192dbf97461359c1518788f203b0c9102cfd2c35a716b823741219542c
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   file:
     dependency: transitive
     description:
@@ -447,10 +447,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -471,10 +471,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: f31d52537dc417fdcde36088fdf11d191026fd5e4fae742491ebd40e5a8bea7d
+      sha256: "492bd52f6c4fbb6ee41f781ff27765ce5f627910e1e0cbecfa3d9add5562604c"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.0"
+    version: "4.7.2"
   internet_connection_checker:
     dependency: transitive
     description:
@@ -495,10 +495,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -527,10 +527,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   meta:
     dependency: transitive
     description:
@@ -754,14 +754,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
-  sprintf:
-    dependency: transitive
-    description:
-      name: sprintf
-      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.0"
   stack_trace:
     dependency: transitive
     description:
@@ -806,26 +798,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "77cc98ea27006c84e71a7356cf3daf9ddbde2d91d84f77dbfe64cf0e4d9611ae"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.28.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: f1072617a6657e5fc09662e721307f7fb009b4ed89b19f47175d11d5254a62d4
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.14"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:
@@ -838,10 +830,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
+      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.1"
+    version: "4.5.2"
   version:
     dependency: transitive
     description:
@@ -862,10 +854,10 @@ packages:
     dependency: transitive
     description:
       name: watcher
-      sha256: "592ab6e2892f67760543fb712ff0177f4ec76c031f02f5b4ff8d3fc5eb9fb61a"
+      sha256: "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.4"
+    version: "1.2.1"
   web:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -84,11 +84,10 @@ packages:
   at_client:
     dependency: "direct main"
     description:
-      path: "packages/at_client"
-      ref: gkc-notif-service-connection-reliability
-      resolved-ref: "239448da572704507c9744c3a590c96008d428b7"
-      url: "https://github.com/atsign-foundation/at_client_sdk"
-    source: git
+      name: at_client
+      sha256: "0b2a044859a212d7c4e6bc5c9686b1b395e014d37b4d6c50e04d1d5d23a3e3e2"
+      url: "https://pub.dev"
+    source: hosted
     version: "3.10.0"
   at_commons:
     dependency: "direct main"

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -84,11 +84,12 @@ packages:
   at_client:
     dependency: "direct main"
     description:
-      name: at_client
-      sha256: "5259886a09507a439be08bbaa79a360ecd936ac1baa2ae58b72c90357cdb4785"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.9.2"
+      path: "packages/at_client"
+      ref: gkc-notif-service-connection-reliability
+      resolved-ref: "743d62336cc0be0bd0a712bd143f58a86e8aafaa"
+      url: "https://github.com/atsign-foundation/at_client_sdk"
+    source: git
+    version: "3.10.0"
   at_commons:
     dependency: "direct main"
     description:
@@ -584,7 +585,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.10.3"
+    version: "6.10.4"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   at_onboarding_cli: ^1.14.1
   at_commons: ^5.6.2
   at_cli_commons: ^3.0.1
-  at_client: ^3.9.2
+  at_client: ^3.10.0
   args: 2.7.0
   socket_connector: 2.4.1
   dartssh2: 2.11.0
@@ -24,11 +24,6 @@ dependencies:
   config: ^0.8.3
 
 dependency_overrides:
-  at_client:
-    git:
-      url: https://github.com/atsign-foundation/at_client_sdk
-      path: packages/at_client
-      ref: gkc-notif-service-connection-reliability
   archive: ^4.0.7
   dartssh2:
     git:

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.14.3
+version: 5.14.4
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -24,6 +24,11 @@ dependencies:
   config: ^0.8.3
 
 dependency_overrides:
+  at_client:
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk
+      path: packages/at_client
+      ref: gkc-notif-service-connection-reliability
   archive: ^4.0.7
   dartssh2:
     git:


### PR DESCRIPTION
Fixes https://github.com/atsign-foundation/noports/issues/2379

**- What I did**
build(deps): take up at_client 3.10.0 which includes enhancements to Monitor (notifications listener) reliability

**- How I did it**
See commits

**- How to verify it**
- Extensively tested by @gkc, @cconstab and @kimdimick 
