### PR TITLE
fix: reduce npt control channel heartbeat interval from 30m to 5m

### DIFF
--- a/packages/dart/noports_core/lib/src/common/default_args.dart
+++ b/packages/dart/noports_core/lib/src/common/default_args.dart
@@ -46,7 +46,7 @@ class DefaultArgs {
   /// Heartbeats are an attempt to persuade over-zealous network
   /// intermediaries that the control channel shouldn't be closed due to lack
   /// of activity.
-  static const int controlChannelHeartbeatIntervalMins = 30;
+  static const int controlChannelHeartbeatIntervalMins = 5;
   static const Duration controlChannelHeartbeatInterval = Duration(
     minutes: controlChannelHeartbeatIntervalMins,
   );

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -789,15 +789,15 @@ class SshnpdImpl
       return;
     }
 
-    logger.shout(
-      'relayAtsign ${req.relayAtsign}'
-      ' eventLoggingConfig $elc',
-    );
     if (req.relayAtsign != null && elc != null) {
+      logger.info(
+        'relayAtsign ${req.relayAtsign}'
+        ' eventLoggingConfig $elc',
+      );
       final keyForRelay = AtKey.fromString(
         '${req.relayAtsign}:logging.${req.sessionId}.sessions.${Srvd.namespace}$deviceAtsign',
       )..metadata.namespaceAware = false;
-      logger.shout('Sending session logging config to relay : $keyForRelay');
+      logger.info('Sending session logging config to relay : $keyForRelay');
       await notify(
         keyForRelay,
         jsonEncode(elc!.toJson()),


### PR DESCRIPTION
**- What I did**
Fixes https://github.com/atsign-foundation/noports/issues/2382

**- How I did it**
See commit

**- How to verify it**
- run npt with `-v`, observe message every 5 minutes like this: `Sending heartbeat $heartbeatCounter on control channel`
