### PR TITLE
deps(noports_core): constrain at_commons to >=5.6.1 < 5.8.0

### DIFF
--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   args: ^2.4.2
   at_chops: ^2.0.1
   at_client: ^3.10.0
-  at_commons: ^5.6.1
+  at_commons: '>=5.6.1 <5.8.0'
   at_cli_commons: ^3.0.1
   at_utils: ^3.0.19
   at_base2e15: ^1.0.0


### PR DESCRIPTION
**- What I did**
 - at_commons 5.8.0 released breaking changes,  [see noports_core tests failing here](https://github.com/atsign-foundation/noports/actions/runs/21042632160/job/60513588662)
 - I will be making changes to fix these breaking changes, for now we're going to constrain at_commons.
 
**- How I did it**
 - added a constraint for at_commons for now `at_commons: '>=5.6.1 < 5.8.0'`
 
**- How to verify it**
 - tests pass
 
**- Description for the changelog**
deps(noports_core): constrain at_commons to >=5.6.1 < 5.8.0
