### PR TITLE
fix: found and wrapped failed notification with a try block

### DIFF
--- a/packages/dart/noports_core/lib/src/srvd/srvd_impl.dart
+++ b/packages/dart/noports_core/lib/src/srvd/srvd_impl.dart
@@ -167,13 +167,13 @@ class SrvdImpl
   }
 
   Future<void> notificationHandler(AtNotification n) async {
-    if (!wellFormedRequest(n)) {
-      logger.shout('Un-handled notification key: ${n.key}');
-      return;
-    }
-
-    logger.shout('Notification key: ${n.key}');
     try {
+      if (!wellFormedRequest(n)) {
+        logger.shout('Un-handled notification key: ${n.key}');
+        return;
+      }
+
+      logger.shout('Notification key: ${n.key}');
       String topic;
       String messageType;
       try {


### PR DESCRIPTION

**- What I did**
Investigated why srvd was crashing every so often and dropping connections
**- How I did it**
Back trace on carsh dump and put in place a try block to catch malformed notifications
**- How to verify it**
tests complete & local testing
**- Description for the changelog**
prevent crash of srvd on malformed / late notifications
