### PR TITLE
fix: Ensure correct token permission for signing images

### DIFF
--- a/.github/workflows/promote_canary.yml
+++ b/.github/workflows/promote_canary.yml
@@ -24,6 +24,8 @@ jobs:
   single:
     if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write # for creating OIDC tokens for signing.
     steps:
       - name: Install cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
@@ -56,6 +58,8 @@ jobs:
   multi:
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write # for creating OIDC tokens for signing.
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Promote Canary workflows (e.g. https://github.com/atsign-foundation/noports/actions/runs/21041289413) have been failing to sign images

**- What I did**

Added write permission for `id-token` to each job

**- How I did it**

Copied from dockerhub_sshnpd workflow

**- How to verify it**

We need to promote v5.14.5, so that will exercise the workflow

**- Description for the changelog**

fix: Ensure correct token permission for signing images
