### PR TITLE
ci: Workflow to keep windows-signer self hosted runner alive

### DIFF
--- a/.github/workflows/signer-keepalive.yml
+++ b/.github/workflows/signer-keepalive.yml
@@ -1,0 +1,21 @@
+name: Windows Signer Keepalive
+# Workflow to regularly exercise windows-signer self hosted runner to avoid
+# time out after two weeks
+
+on:
+  schedule:
+    # 0654 each Monday
+    - cron: '54 6 * * 1'
+  workflow_dispatch:
+
+permissions: # added using https://github.com/step-security/secure-repo
+  contents: read
+
+jobs:
+  run-script:
+    runs-on: windows-signer
+    
+    steps:
+      - name: Run trivial script
+        run: |
+          echo "Windows Signer Keepalive"


### PR DESCRIPTION
Closes #2416

**- What I did**

New workflow to exercise the `windows-signer` self hosted runner weekly

**- How to verify it**

Will run manually using workflow-dispatch once merged

**- Description for the changelog**

ci: Workflow to keep windows-signer self hosted runner alive
