### PR TITLE
chore: update noports_core to 6.10.5 and dart run melos bootstrap

### DIFF
--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -600,7 +600,7 @@ packages:
       path: "../../../packages/dart/noports_core"
       relative: true
     source: path
-    version: "6.10.4"
+    version: "6.10.5"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/noports_core/lib/src/events/event_models.g.dart
+++ b/packages/dart/noports_core/lib/src/events/event_models.g.dart
@@ -8,7 +8,7 @@ part of 'event_models.dart';
 
 AtEventConfig _$AtEventConfigFromJson(Map<String, dynamic> json) =>
     AtEventConfig(
-      atSign: (json['atSign'] as String).toAtsign(),
+      atSign: json['atSign'] as Atsign,
       topic: json['topic'] as String,
       ttln: (json['ttln'] as num).toInt(),
     );

--- a/packages/dart/noports_core/lib/src/version.dart
+++ b/packages/dart/noports_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '6.10.4';
+const packageVersion = '6.10.5';

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: noports_core
 description: Core library code for sshnoports
 homepage: https://docs.atsign.com/
 
-version: 6.10.4
+version: 6.10.5
 
 environment:
   sdk: ^3.8.0

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -126,10 +126,10 @@ packages:
     dependency: transitive
     description:
       name: at_commons
-      sha256: bd6ba59a7b23fd04d2fcda30be14c314cd8635ad3e0f5b1e917825563f0bcddd
+      sha256: a8a07fff913a36524b95757ff72fcde448ae461b1647c8e8aee3276395452ae7
       url: "https://pub.dev"
     source: hosted
-    version: "5.6.2"
+    version: "5.8.0"
   at_contact:
     dependency: "direct main"
     description:
@@ -973,7 +973,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.10.4"
+    version: "6.10.5"
   openssh_ed25519:
     dependency: transitive
     description:
@@ -1503,26 +1503,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -584,7 +584,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.10.4"
+    version: "6.10.5"
   openssh_ed25519:
     dependency: transitive
     description:


### PR DESCRIPTION
**- What I did**
- Updated `noports_core`'s `pubspec.yaml` to `6.10.5`
- Ran `dart run melos bootstrap` in `./`

**- How I did it**
- See changes

**- How to verify it**


**- Description for the changelog**
chore: update noports_core to 6.10.5 and dart run melos bootstrap