### PR TITLE
fix: Ensure SBOM tags are unique

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -216,7 +216,7 @@ jobs:
           COMPONENT_ID: 'Y6pppn8rC4'
           LOCK_FILE: './packages/c/conan.lock'
           COMPONENT_NAME: 'csshnpd'
-          COMPONENT_VERSION: ${{github.ref_name}}
+          COMPONENT_VERSION: ${{github.ref_name}}-gha${{github.run_number}}
           OUTPUT_FILE: 'tarballs/csshnpd-${{github.ref_name}}-sbom.cdx.json'
           AUGMENT: true
           ENRICH: true

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -349,7 +349,7 @@ jobs:
           TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
           COMPONENT_ID: '-93khk8pUi'
           LOCK_FILE: './packages/dart/sshnoports/pubspec.lock'
-          COMPONENT_VERSION: ${{github.ref_name}}
+          COMPONENT_VERSION: ${{github.ref_name}}-gha${{github.run_number}}
           OUTPUT_FILE: 'tarballs/noports_dart-${{github.ref_name}}-sbom.cdx.json'
           AUGMENT: true
           ENRICH: true


### PR DESCRIPTION
Multibuild [failed](https://github.com/atsign-foundation/noports/actions/runs/21322700314/job/61375766927) because sbomify now needs unique tags

**- What I did**

Added GitHub Actions run number to COMPONENT_VERSION

**- How I did it**

Based on https://github.com/atsign-foundation/at_server/pull/2514

**- How to verify it**

Run mulitbuild again for an existing tag

**- Description for the changelog**

fix: Ensure SBOM tags are unique
