### PR TITLE
feat: npt, srv, srvd, sshnp, sshnpd --version

### DIFF
--- a/packages/dart/noports_core/lib/src/srvd/srvd_params.dart
+++ b/packages/dart/noports_core/lib/src/srvd/srvd_params.dart
@@ -179,6 +179,12 @@ class SrvdParams {
       negatable: false,
       help: 'Print usage',
     );
+    parser.addFlag(
+      'version',
+      defaultsTo: false,
+      negatable: false,
+      help: 'Print version',
+    );
     return parser;
   }
 }

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd.dart
@@ -109,6 +109,7 @@ abstract class Sshnpd {
     FutureOr<AtClient> Function(SshnpdParams)? atClientGenerator,
     void Function(Object, StackTrace)? usageCallback,
     void Function()? helpCallback,
+    void Function()? versionCallback,
     required String version,
     Future<void> Function(AtNotification)? notifPreProcessor,
   }) async {
@@ -118,6 +119,7 @@ abstract class Sshnpd {
       atClientGenerator: atClientGenerator,
       usageCallback: usageCallback,
       helpCallback: helpCallback,
+      versionCallback: versionCallback,
       version: version,
       notifPreProcessor: notifPreProcessor,
     );

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_config.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_config.dart
@@ -347,6 +347,15 @@ enum SshnpdOption<V> implements OptionDefinition<V> {
       helpText: 'Show usage',
       group: runtimeGroup,
     ),
+  ),
+
+  version(
+    FlagOption(
+      argName: 'version',
+      defaultsTo: false,
+      helpText: 'Show version',
+      group: runtimeGroup,
+    ),
   );
 
   const SshnpdOption(this.option);

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -180,13 +180,14 @@ class SshnpdImpl
     FutureOr<AtClient> Function(SshnpdParams)? atClientGenerator,
     void Function(Object, StackTrace)? usageCallback,
     void Function()? helpCallback,
+    void Function()? versionCallback,
     required String version,
     Future<void> Function(AtNotification)? notifPreProcessor,
   }) async {
     try {
       SshnpdParams p;
       try {
-        p = await SshnpdParams.fromArgs(args, helpCallback: helpCallback);
+        p = await SshnpdParams.fromArgs(args, helpCallback: helpCallback, versionCallback: versionCallback);
       } on FormatException catch (e) {
         throw ArgumentError(e.message);
       }

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_params.dart
@@ -64,6 +64,7 @@ class SshnpdParams {
   static Future<SshnpdParams> fromArgs(
     List<String> args, {
     void Function()? helpCallback,
+    void Function()? versionCallback,
   }) async {
     // Arg check
     final Configuration c = Configuration<SshnpdOption>.resolveNoExcept(
@@ -71,6 +72,10 @@ class SshnpdParams {
       args: args,
       configBroker: SshnpdConfigBroker(),
     );
+
+    if (c.value(SshnpdOption.version)) {
+      versionCallback?.call();
+    }
 
     if (c.value(SshnpdOption.help)) {
       helpCallback?.call();

--- a/packages/dart/sshnoports/bin/npt.dart
+++ b/packages/dart/sshnoports/bin/npt.dart
@@ -180,6 +180,8 @@ void main(List<String> args) async {
       );
       parser.addFlag('help',
           defaultsTo: false, negatable: false, help: 'Print usage');
+      parser.addFlag('version',
+          defaultsTo: false, negatable: false, help: 'Print version');
 
       parser.addFlag(
         'ipv4',
@@ -287,6 +289,11 @@ void main(List<String> args) async {
 
       // Parse Args
       ArgResults parsedArgs = parser.parse(args);
+
+      if (parsedArgs['version'] == true) {
+        printVersion();
+        exit(0);
+      }
 
       if (parsedArgs['help'] == true) {
         print(parser.usage);

--- a/packages/dart/sshnoports/bin/srv.dart
+++ b/packages/dart/sshnoports/bin/srv.dart
@@ -55,6 +55,10 @@ Future<void> main(List<String> args) async {
         defaultsTo: false,
         negatable: false,
         help: 'Show usage info')
+    ..addFlag('version',
+        defaultsTo: false,
+        negatable: false,
+        help: 'Show version info')
     ..addFlag('rv-e2ee',
         defaultsTo: false,
         help: 'Whether this rv process will encrypt/decrypt'
@@ -80,6 +84,11 @@ Future<void> main(List<String> args) async {
         parsed = parser.parse(args);
       } on FormatException catch (e) {
         throw ArgumentError(e.message);
+      }
+
+      if (parsed.wasParsed('version')) {
+        printVersion();
+        exit(0);
       }
 
       if (parsed.wasParsed('help')) {

--- a/packages/dart/sshnoports/bin/srvd.dart
+++ b/packages/dart/sshnoports/bin/srvd.dart
@@ -23,6 +23,11 @@ void main(List<String> args) async {
     exit(0);
   }
 
+  if (r.wasParsed('version')) {
+    printVersion();
+    exit(0);
+  }
+
   if (r.wasParsed('help')) {
     printVersion();
     stderr.writeln(SrvdParams.parser.usage);

--- a/packages/dart/sshnoports/bin/sshnp.dart
+++ b/packages/dart/sshnoports/bin/sshnp.dart
@@ -86,6 +86,12 @@ void main(List<String> args) async {
     exit(exitCode);
   }
 
+  // Manually check if the version flag is set and print version
+  if (args.contains('--version')) {
+    printVersion();
+    exitProgram();
+  }
+
   // Manually check if the help flag is set and print usage
   Set<String> helpSet = SshnpArg.fromName('help').aliasList.toSet();
   if (args.toSet().intersection(helpSet).isNotEmpty) {

--- a/packages/dart/sshnoports/bin/sshnpd.dart
+++ b/packages/dart/sshnoports/bin/sshnpd.dart
@@ -35,6 +35,10 @@ void main(List<String> args) async {
         stderr.writeln(SshnpdOption.usage);
         exit(0);
       },
+      versionCallback: () {
+        printVersion();
+        exit(0);
+      },
       version: packageVersion,
     );
   } on ArgumentError catch (_) {


### PR DESCRIPTION
**- What I did**

- Added a `--version` flag to our NoPorts binaries (npt, srv, srvd, sshnp, sshnpd)

**- How I did it**

**- How to verify it**

<img width="891" height="458" alt="image" src="https://github.com/user-attachments/assets/4d570c4c-54a7-4d0c-a175-ecdf843c6860" />

**- Description for the changelog**
feat: npt, srv, srvd, sshnp, sshnpd --version
