### PR TITLE
feat: remove caching of public key client side in npt and sshnp

### DIFF
--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -608,7 +608,7 @@ packages:
       path: "../../../packages/dart/noports_core"
       relative: true
     source: path
-    version: "6.10.5"
+    version: "6.11.0"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/noports_core/CHANGELOG.md
+++ b/packages/dart/noports_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.11.0
+
+- feat: remove persistent caching of public keys
+
 # 6.10.4
 
 - build(deps): take up at_client 3.10.0

--- a/packages/dart/noports_core/lib/src/common/validation_utils.dart
+++ b/packages/dart/noports_core/lib/src/common/validation_utils.dart
@@ -120,14 +120,13 @@ Future<void> verifyEnvelopeSignature(
   AtClient atClient,
   String requestingAtsign,
   AtSignLogger logger,
-  Map envelope, {
-  FileSystem? fs,
-}) async {
+  Map envelope) async {
   final String signature = envelope['signature'];
   Map payload = envelope['payload'];
   final hashingAlgo = HashingAlgoType.values.byName(envelope['hashingAlgo']);
   final signingAlgo = SigningAlgoType.values.byName(envelope['signingAlgo']);
-  final pk = await getLocallyCachedPK(atClient, requestingAtsign, fs: fs);
+  // final pk = await getLocallyCachedPK(atClient, requestingAtsign, fs: fs);
+  final pk = await getRemotePK(atClient: atClient, atSign: requestingAtsign);
   AtSigningVerificationInput input = AtSigningVerificationInput(
     jsonEncode(payload),
     base64Decode(signature),
@@ -178,6 +177,20 @@ Future<void> clearLocallyCachedPKs({
   }
 }
 
+Future<String> getRemotePK({
+  required AtClient atClient,
+  required String atSign,
+}) async {
+  atSign = AtUtils.fixAtSign(atSign);
+  var s = 'public:publickey$atSign';
+  final AtValue av = await atClient.get(AtKey.fromString(s));
+  if (av.value == null) {
+    throw AtPublicKeyNotFoundException('Failed to retrieve $s');
+  }
+  return av.value;
+}
+
+/// Feb 5, 2026 - Decided that we should no longer cache public key locally
 /// If the PK for [atSign] is in the sshnp local cache, then return it.
 /// If it is not, then fetch it via the [atClient], and store it.
 ///
@@ -188,87 +201,87 @@ Future<void> clearLocallyCachedPKs({
 ///   `~/.atsign/sshnp/cached_pks/alice`
 ///
 /// Note that for storage, the leading `@` in the atSign is stripped off.
-Future<String> getLocallyCachedPK(
-  AtClient atClient,
-  String atSign, {
-  FileSystem? fs,
-}) async {
-  atSign = AtUtils.fixAtSign(atSign);
-
-  String? cachedPK = await _fetchFromLocalPKCache(atClient, atSign, fs: fs);
-  if (cachedPK != null) {
-    return cachedPK;
-  }
-
-  var s = 'public:publickey$atSign';
-  final AtValue av = await atClient.get(AtKey.fromString(s));
-  if (av.value == null) {
-    throw AtPublicKeyNotFoundException('Failed to retrieve $s');
-  }
-
-  await _storeToLocalPKCache(av.value, atClient, atSign, fs: fs);
-
-  return av.value;
-}
-
-Future<String?> _fetchFromLocalPKCache(
-  AtClient atClient,
-  String atSign, {
-  FileSystem? fs,
-}) async {
-  String dontAtMe = atSign.substring(1);
-  if (fs != null) {
-    String fn = path.normalize(
-      '${getHomeDirectory()}/.atsign/sshnp/cached_pks/$dontAtMe',
-    );
-    File f = fs.file(fn);
-    if (await f.exists()) {
-      return (await f.readAsString()).trim();
-    } else {
-      return null;
-    }
-  } else {
-    late final AtValue av;
-    try {
-      av = await atClient.get(
-        AtKey.fromString(
-          'local:$dontAtMe.cached_pks.sshnp@${atClient.getCurrentAtSign()!}',
-        ),
-      );
-      return av.value;
-    } on AtKeyNotFoundException catch (_) {
-      return null;
-    }
-  }
-}
-
-Future<bool> _storeToLocalPKCache(
-  String pk,
-  AtClient atClient,
-  String atSign, {
-  FileSystem? fs,
-}) async {
-  String dontAtMe = atSign.substring(1);
-  if (fs != null) {
-    String dirName = path.normalize(
-      '${getHomeDirectory()}/.atsign/sshnp/cached_pks',
-    );
-    String fileName = path.normalize('$dirName/$dontAtMe');
-
-    File f = fs.file(fileName);
-    if (!await f.exists()) {
-      await f.create(recursive: true);
-      await Process.run('chmod', ['-R', 'go-rwx', dirName]);
-    }
-    await f.writeAsString('$pk\n');
-    return true;
-  } else {
-    await atClient.put(
-      AtKey.fromString(
-        'local:$dontAtMe.cached_pks.sshnp@${atClient.getCurrentAtSign()!}',
-      ),
-      pk,
-    );
-    return true;
-  }
-}
+// Future<String> getLocallyCachedPK(
+//   AtClient atClient,
+//   String atSign, {
+//   FileSystem? fs,
+// }) async {
+//   atSign = AtUtils.fixAtSign(atSign);
+//
+//   String? cachedPK = await _fetchFromLocalPKCache(atClient, atSign, fs: fs);
+//   if (cachedPK != null) {
+//     return cachedPK;
+//   }
+//
+//   var s = 'public:publickey$atSign';
+//   final AtValue av = await atClient.get(AtKey.fromString(s));
+//   if (av.value == null) {
+//     throw AtPublicKeyNotFoundException('Failed to retrieve $s');
+//   }
+//
+//   await _storeToLocalPKCache(av.value, atClient, atSign, fs: fs);
+//
+//   return av.value;
+// }
+//
+// Future<String?> _fetchFromLocalPKCache(
+//   AtClient atClient,
+//   String atSign, {
+//   FileSystem? fs,
+// }) async {
+//   String dontAtMe = atSign.substring(1);
+//   if (fs != null) {
+//     String fn = path.normalize(
+//       '${getHomeDirectory()}/.atsign/sshnp/cached_pks/$dontAtMe',
+//     );
+//     File f = fs.file(fn);
+//     if (await f.exists()) {
+//       return (await f.readAsString()).trim();
+//     } else {
+//       return null;
+//     }
+//   } else {
+//     late final AtValue av;
+//     try {
+//       av = await atClient.get(
+//         AtKey.fromString(
+//           'local:$dontAtMe.cached_pks.sshnp@${atClient.getCurrentAtSign()!}',
+//         ),
+//       );
+//       return av.value;
+//     } on AtKeyNotFoundException catch (_) {
+//       return null;
+//     }
+//   }
+// }
+//
+// Future<bool> _storeToLocalPKCache(
+//   String pk,
+//   AtClient atClient,
+//   String atSign, {
+//   FileSystem? fs,
+// }) async {
+//   String dontAtMe = atSign.substring(1);
+//   if (fs != null) {
+//     String dirName = path.normalize(
+//       '${getHomeDirectory()}/.atsign/sshnp/cached_pks',
+//     );
+//     String fileName = path.normalize('$dirName/$dontAtMe');
+//
+//     File f = fs.file(fileName);
+//     if (!await f.exists()) {
+//       await f.create(recursive: true);
+//       await Process.run('chmod', ['-R', 'go-rwx', dirName]);
+//     }
+//     await f.writeAsString('$pk\n');
+//     return true;
+//   } else {
+//     await atClient.put(
+//       AtKey.fromString(
+//         'local:$dontAtMe.cached_pks.sshnp@${atClient.getCurrentAtSign()!}',
+//       ),
+//       pk,
+//     );
+//     return true;
+//   }
+// }

--- a/packages/dart/noports_core/lib/src/sshnp/util/sshnpd_channel/sshnpd_default_channel.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/sshnpd_channel/sshnpd_default_channel.dart
@@ -4,8 +4,6 @@ import 'dart:convert';
 import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
 import 'package:noports_core/events.dart';
-import 'package:meta/meta.dart';
-import 'package:noports_core/src/common/io_types.dart';
 import 'package:noports_core/sshnp_foundation.dart';
 
 class SshnpdDefaultChannel extends SshnpdChannel

--- a/packages/dart/noports_core/lib/src/sshnp/util/sshnpd_channel/sshnpd_default_channel.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/sshnpd_channel/sshnpd_default_channel.dart
@@ -26,10 +26,6 @@ mixin SshnpdDefaultPayloadHandler on SshnpdChannel {
   String? ivD2C;
   String? errorReceived;
 
-  @visibleForTesting
-  // disable publickey cache on windows
-  FileSystem? fs = Platform.isWindows ? null : LocalFileSystem();
-
   @override
   Future<void> initialize() async {
     await super.initialize();
@@ -66,8 +62,7 @@ mixin SshnpdDefaultPayloadHandler on SshnpdChannel {
           atClient,
           params.sshnpdAtSign,
           logger,
-          envelope,
-          fs: fs,
+          envelope
         );
       } catch (e) {
         logger.shout(

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -239,6 +239,8 @@ class SshnpdImpl
 
       if (p.clearCachedPKs) {
         sshnpd.logger.shout('Clearing cached public keys');
+        sshnpd.logger.shout('Note: locally cached public keys are no longer'
+          ' used by sshnpd');
         await clearLocallyCachedPKs(
           logger: sshnpd.logger,
           fs: LocalFileSystem(),

--- a/packages/dart/noports_core/lib/src/version.dart
+++ b/packages/dart/noports_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '6.10.5';
+const packageVersion = '6.11.0';

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: noports_core
 description: Core library code for sshnoports
 homepage: https://docs.atsign.com/
 
-version: 6.10.5
+version: 6.11.0
 
 environment:
   sdk: ^3.8.0

--- a/packages/dart/noports_core/test/sshnp/util/sshnpd_channel/sshnpd_default_channel_test.dart
+++ b/packages/dart/noports_core/test/sshnp/util/sshnpd_channel/sshnpd_default_channel_test.dart
@@ -1,10 +1,8 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
-import 'package:at_cli_commons/at_cli_commons.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:noports_core/sshnp_foundation.dart';
 import 'package:test/test.dart';

--- a/packages/dart/noports_core/test/sshnp/util/sshnpd_channel/sshnpd_default_channel_test.dart
+++ b/packages/dart/noports_core/test/sshnp/util/sshnpd_channel/sshnpd_default_channel_test.dart
@@ -5,13 +5,10 @@ import 'dart:io';
 import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
 import 'package:at_cli_commons/at_cli_commons.dart';
-import 'package:file/memory.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:noports_core/src/common/io_types.dart';
 import 'package:noports_core/sshnp_foundation.dart';
 import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
-import 'package:path/path.dart' as path;
 
 import '../../sshnp_core_constants.dart';
 import '../../sshnp_mocks.dart';
@@ -129,9 +126,6 @@ void main() {
       AtNotification notification = AtNotification.empty()
         ..value = signedPayload;
 
-      // manually disable public key cache
-      stubbedSshnpdDefaultChannel.fs = null;
-
       // Return the testing encryption public key when it's requested
       when(
         () => mockAtClient.get(
@@ -178,29 +172,12 @@ void main() {
       AtNotification notification = AtNotification.empty()
         ..value = signedPayload;
 
-      // manually disable public key cache
-      FileSystem fs = MemoryFileSystem();
-      stubbedSshnpdDefaultChannel.fs = fs;
-
       String? homeDirPath = getHomeDirectory();
 
       if (homeDirPath == null) {
         stderr.writeln('Could not complete test on the current platform.');
         return;
       }
-
-      File cacheFile = fs.file(
-        path.join(
-          homeDirPath,
-          '.atsign',
-          'sshnp',
-          'cached_pks',
-          mockParams.sshnpdAtSign.substring(1),
-        ),
-      );
-
-      await cacheFile.create(recursive: true);
-      await cacheFile.writeAsString(encryptionKeyPair.atPublicKey.publicKey);
 
       Future<SshnpdAck> ack = stubbedSshnpdDefaultChannel.handleSshnpdPayload(
         notification,
@@ -241,9 +218,6 @@ void main() {
 
       AtNotification notification = AtNotification.empty()
         ..value = signedPayload;
-
-      // manually disable public key cache
-      stubbedSshnpdDefaultChannel.fs = null;
 
       // Return the testing encryption public key when it's requested
       when(

--- a/packages/dart/noports_core/test/sshnp/util/sshnpd_channel/sshnpd_default_channel_test.dart
+++ b/packages/dart/noports_core/test/sshnp/util/sshnpd_channel/sshnpd_default_channel_test.dart
@@ -103,7 +103,7 @@ void main() {
       await expectLater(stubbedSshnpdDefaultChannel.initialized, completes);
     }); // test Initialization completes
 
-    test('handleSshnpdPayload - no public key cache', () async {
+    test('handleSshnpdPayload - fetches public key from remote', () async {
       // Create an AtChops instance for testing
       AtEncryptionKeyPair encryptionKeyPair =
           AtChopsUtil.generateAtEncryptionKeyPair();
@@ -130,7 +130,7 @@ void main() {
       when(
         () => mockAtClient.get(
           any<AtKey>(
-            that: predicate((AtKey key) => key.key.contains('cached_pks')),
+            that: predicate((AtKey key) => key.key.contains('publickey')),
           ),
         ),
       ).thenAnswer(
@@ -147,9 +147,9 @@ void main() {
         stubbedSshnpdDefaultChannel.ephemeralPrivateKey,
         TestingKeyPair.private,
       );
-    }); // test handleSshnpdPayload - no public key cache
+    }); // test handleSshnpdPayload - fetches public key from remote
 
-    test('handleSshnpdPayload - with in-memory public key cache', () async {
+    test('handleSshnpdPayload - successful payload handling', () async {
       // Create an AtChops instance for testing
       AtEncryptionKeyPair encryptionKeyPair =
           AtChopsUtil.generateAtEncryptionKeyPair();
@@ -172,12 +172,16 @@ void main() {
       AtNotification notification = AtNotification.empty()
         ..value = signedPayload;
 
-      String? homeDirPath = getHomeDirectory();
-
-      if (homeDirPath == null) {
-        stderr.writeln('Could not complete test on the current platform.');
-        return;
-      }
+      // Return the testing encryption public key when it's requested
+      when(
+        () => mockAtClient.get(
+          any<AtKey>(
+            that: predicate((AtKey key) => key.key.contains('publickey')),
+          ),
+        ),
+      ).thenAnswer(
+        (_) async => AtValue()..value = encryptionKeyPair.atPublicKey.publicKey,
+      );
 
       Future<SshnpdAck> ack = stubbedSshnpdDefaultChannel.handleSshnpdPayload(
         notification,
@@ -189,9 +193,9 @@ void main() {
         stubbedSshnpdDefaultChannel.ephemeralPrivateKey,
         TestingKeyPair.private,
       );
-    }); // test handleSshnpdPayload - with in-memory public key cache
+    }); // test handleSshnpdPayload - successful payload handling
 
-    test('handleSshnpdPayload - bad signature', () async {
+    test('handleSshnpdPayload - rejects invalid signature', () async {
       // Create an AtChops instance for testing
       AtEncryptionKeyPair encryptionKeyPair =
           AtChopsUtil.generateAtEncryptionKeyPair();
@@ -223,7 +227,7 @@ void main() {
       when(
         () => mockAtClient.get(
           any<AtKey>(
-            that: predicate((AtKey key) => key.key.contains('cached_pks')),
+            that: predicate((AtKey key) => key.key.contains('publickey')),
           ),
         ),
       ).thenAnswer(
@@ -237,6 +241,6 @@ void main() {
       await expectLater(ack, completes);
       expect(await ack, SshnpdAck.acknowledgedWithErrors);
       expect(stubbedSshnpdDefaultChannel.ephemeralPrivateKey, null);
-    }); // test handleSshnpdPayload - bad signature
+    }); // test handleSshnpdPayload - rejects invalid signature
   }); // group SshnpDefaultChannel
 }

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -973,7 +973,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.10.5"
+    version: "6.11.0"
   openssh_ed25519:
     dependency: transitive
     description:
@@ -1503,26 +1503,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.26.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.11"
   timing:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -600,7 +600,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.10.5"
+    version: "6.11.0"
   openssh_ed25519:
     dependency: transitive
     description:


### PR DESCRIPTION
closes #2479 

**- What I did**
- Modified `verifyEnvelopeSignature` so that it does not take a `FileSystem? fs` argument anymore
- Commented out functions `_fetchFromLocalPKCache`, `_storeToLocalPKCache`, and `getLocallyCachedPK`
- Created a new function `getRemotePK` that `verifyEnvelopeSignature` now uses

**- How I did it**

**- How to verify it**

I've done a manual test of my branch and found that `npt` and `sshnp` no longer create a cached public key in `~/.atsign/sshnp/cached_pks/` on MacOS

sshnpd does not create a cached public key file at all

**- Description for the changelog**
feat: remove caching of public key client side in npt, sshnp, and sshnpd