### PR TITLE
feat: Add self-hosted runner keepalive workflow

### DIFF
--- a/.github/workflows/self_hosted_keepalive.yaml
+++ b/.github/workflows/self_hosted_keepalive.yaml
@@ -1,4 +1,4 @@
-name: Self Hosted Runner Keepalive
+name: Self Hosted Runner Keepalive 
 
 on:
   schedule:

--- a/.github/workflows/self_hosted_keepalive.yaml
+++ b/.github/workflows/self_hosted_keepalive.yaml
@@ -1,0 +1,19 @@
+name: Self Hosted Runner Keepalive
+
+on:
+  schedule:
+    - cron: '54 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  Keepalive:
+    runs-on: [self-hosted, linux, x64, K8s]
+
+    steps:
+      - name: Runner heartbeat
+        run: |
+          echo "Self Hosted Runner Keepalive - Running"
+          echo "Runner Name: $RUNNER_NAME"

--- a/.github/workflows/self_hosted_keepalive.yaml
+++ b/.github/workflows/self_hosted_keepalive.yaml
@@ -1,9 +1,6 @@
 name: Self Hosted Runner Keepalive 
 
 on:
-  push:
-    branches:
-      - self-hosted-keepalive
   schedule:
     - cron: '54 6 * * 1'
   workflow_dispatch:

--- a/.github/workflows/self_hosted_keepalive.yaml
+++ b/.github/workflows/self_hosted_keepalive.yaml
@@ -1,6 +1,9 @@
 name: Self Hosted Runner Keepalive 
 
 on:
+  push:
+    branches:
+      - self-hosted-keepalive
   schedule:
     - cron: '54 6 * * 1'
   workflow_dispatch:


### PR DESCRIPTION
## Self-Hosted Runner Keepalive

Adds a scheduled GitHub Actions workflow to keep the self-hosted runner active.

- Runs every Monday at 06:54 UTC  
- Executes on `[self-hosted, linux, x64, K8s]`  
- No notifications or monitoring logic included  

This ensures the runner does not go idle due to inactivity.