### PR TITLE
fix(actions): explicitly declare wix versions

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -147,9 +147,9 @@ jobs:
           WINDOWS_SIGNTOOL_ARGS: ${{ secrets.WINDOWS_SIGNTOOL_ARGS }}
           WINDOWS_SIGNTOOL_PATH: ${{ secrets.WINDOWS_SIGNTOOL_PATH }}
         run: |
-          dotnet tool install --global wix
-          wix extension add -g WixToolset.Util.wixext
-          wix extension add -g WixToolset.UI.wixext
+          dotnet tool install --global wix --version 6.0.2
+          wix extension add -g WixToolset.Util.wixext/6.0.2
+          wix extension add -g WixToolset.UI.wixext/6.0.2
           mkdir bin
           cp ../../packages/dart/sshnoports/sshnp/{sshnpd,at_activate,sshnp,npp_atserver,npp_file,npt,srv,sshnpdService}.exe ./bin/
           cp ../../packages/dart/sshnoports/bundles/core/config/sshnpd.yaml ./bin/


### PR DESCRIPTION
**- What I did**
 - #2496 

**- How I did it**
 - pinned wix and the extentions to the stable release to avoid pulling the latest pre-release from WIX v7.0.0-rc1

**- How to verify it**
 - ran multibuild on this branch 
 -  https://github.com/atsign-foundation/noports/actions/runs/22154282032/job/64053760719 

**- Description for the changelog**
fix(actions): explicitly declare wix versions
