### PR TITLE
build(deps): Use GitHub releases for zlib tarball

### DIFF
--- a/tools/static-openssh/static-openssh.sh
+++ b/tools/static-openssh/static-openssh.sh
@@ -24,7 +24,7 @@ mkdir -p "$root" "$build" "$dist"
 if [ ! -f "build/zlib-$ZLIB_VERSION/minigzip" ]; then
 echo "---- Building ZLIB -----"
 if [ ! -f "$dist/zlib-$ZLIB_VERSION.tar.gz" ]; then
-curl --output $dist/zlib-$ZLIB_VERSION.tar.gz --location https://zlib.net/fossils/zlib-$ZLIB_VERSION.tar.gz
+curl --output $dist/zlib-$ZLIB_VERSION.tar.gz --location https://github.com/madler/zlib/releases/download/v$ZLIB_VERSION/zlib-$ZLIB_VERSION.tar.gz
 gzip -dc $dist/zlib-*.tar.gz |(cd "$build" && tar xf -)
 fi
 cd "$build"/zlib-*


### PR DESCRIPTION
Use of 'fossils' introduced by #2516 seems to have made actions flaky. I suspect that 'fossils' isn't behind a CDN and frequently returns an error response to curl rather than the correct tarball.

**- What I did**

Changed URL to download tarball from GitHub releases

**- How I did it**

Copied URL from latest release and s/1.3.2/$ZLIB_VERSION/

**- How to verify it**

Docker build will run on merge.

**- Description for the changelog**

build(deps): Use GitHub releases for zlib tarball
