### PR TITLE
ci: Add released condition to trigger

### DIFF
--- a/.github/workflows/update_packages.yaml
+++ b/.github/workflows/update_packages.yaml
@@ -2,7 +2,7 @@ name: Update Packages
 
 on:
   release:
-    types: [published, edited]
+    types: [edited, published, released]
 
 permissions: # added using https://github.com/step-security/secure-repo
   contents: read


### PR DESCRIPTION
#2541 didn't fire when v5.14.7 was updated from pre-release to latest :(

**- What I did**

Added `release` to conditions

**- How to verify it**

I'll do the promotion again once merged.

**- Description for the changelog**

ci: Add released condition to trigger