### PR TITLE
ci: Add trigger for homebrew-tap

### DIFF
--- a/.github/workflows/update_packages.yaml
+++ b/.github/workflows/update_packages.yaml
@@ -11,6 +11,17 @@ jobs:
   Dispatch:
     runs-on: ubuntu-slim
     steps:
+      - name: homebrew-tap trigger
+        if: github.event.release.prerelease == false && startsWith(github.ref_name, 'v')
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          token: ${{ secrets.MY_GITHUB_TOKEN }}
+          repository: atsign-foundation/homebrew-tap
+          event-type: new-release
+          client-payload: >
+            {
+              "version": "${{ github.event.release.tag_name }}"
+            }
       - name: noports-apt trigger
         if: github.event.release.prerelease == false && startsWith(github.ref_name, 'v')
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1


### PR DESCRIPTION
Progresses #2313 

**- What I did**

Added a trigger for homebrew-tap

**- How I did it**

Based on existing triggers

**- How to verify it**

I'll cut a v5.14.9 release then promote once build is complete

**- Description for the changelog**

ci: Add trigger for homebrew-tap
