### PR TITLE
feat: Update universal.sh to use packages where possible.

### DIFF
--- a/packages/dart/sshnoports/CHANGELOG.md
+++ b/packages/dart/sshnoports/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- pyml disable md034-->
 
+## v5.14.10
+
+* feat: Update universal.sh to use packages where possible.
+
 ## v5.14.9
 
 * build: Ensure noports binary is packaged

--- a/packages/dart/sshnoports/bundles/shell/systemd.nfpm/srvd.service
+++ b/packages/dart/sshnoports/bundles/shell/systemd.nfpm/srvd.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=No Ports Socket Rendezvous Daemon
+Description=NoPorts Socket Rendezvous Daemon
 After=network-online.target
 
 [Install]
@@ -10,6 +10,7 @@ Type=simple
 Restart=always
 RestartSec=3
 
-# The line below runs the srvd service, with the options set above.
-# You can edit this line to further customize the service to your needs.
-ExecStart=/usr/local/bin/srvd -a "$atsign" -i "$internet_address" "$additional_args"
+# The line below runs the srvd service, with the options set in the
+# override.conf file found in /lib/systemd/system/srvd.service.d
+# You can edit that config with: sudo systemctl edit srvd
+ExecStart=/usr/bin/srvd -a "$atsign" -i "$internet_address" "$additional_args"

--- a/packages/dart/sshnoports/bundles/shell/systemd.nfpm/srvd.service.d/override.conf
+++ b/packages/dart/sshnoports/bundles/shell/systemd.nfpm/srvd.service.d/override.conf
@@ -1,0 +1,19 @@
+# Configuration of srvd service
+# This override configuration is a template for the srvd service.
+# You can configure the service by editing the variables below.
+# This ovverride config covers the common configuration options for srvd.
+# To see all available options, run `srvd` with no arguments.
+
+[Service]
+
+# MANDATORY: User to run the daemon as
+User=<username>
+
+# MANDATORY: Srvd atSign
+Environment=atsign="@my_rvd"
+
+# MANDATORY: Public FQDN or IP address of the machine running the srvd
+Environment=internet_address=""
+
+# Any additional command line arguments for srvd
+Environment=additional_args=""

--- a/packages/dart/sshnoports/bundles/shell/systemd.nfpm/sshnpd.service
+++ b/packages/dart/sshnoports/bundles/shell/systemd.nfpm/sshnpd.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Ssh No Ports Daemon
+Description=NoPorts Daemon
 After=network-online.target
 
 [Install]
@@ -11,7 +11,6 @@ Restart=always
 RestartSec=3
 KillMode=process
 
-# The line below runs the sshnpd service, with the options set in
-# /etc/systemd/system/sshnpd.d/override.conf.
-# You can edit that config with: sudo systemctl edit sshnpd
-ExecStart=/usr/local/bin/sshnpd -a "$device_atsign" -m "$manager_atsign" -d "$device_name" "$delegate_policy" "$s" "$u" "$v" "$additional_args"
+# The line below runs the sshnpd service, with the config from
+# /etc/noports/sshnpd.yaml
+ExecStart=/usr/bin/sshnpd

--- a/packages/dart/sshnoports/bundles/shell/systemd.nfpm/sshnpd.service.d/override.conf
+++ b/packages/dart/sshnoports/bundles/shell/systemd.nfpm/sshnpd.service.d/override.conf
@@ -1,0 +1,19 @@
+# Configuration of sshnpd service
+# This override configuration is a template for the sshnpd service.
+# You can configure the service by editing the variables below.
+# This service file covers the common configuration options for sshnpd.
+# To see all available options, run `sshnpd` with no arguments.
+
+[Unit]
+
+# Uncomment the following line to make this unit fail if sshd isn't started first
+; Requisite=sshd.service
+
+# Uncomment the following line to make this unit auto-start sshd if it isn't started
+; Requires=sshd.service
+
+[Service]
+
+# MANDATORY: User to run the daemon as
+# Default value of 1000 (first non root user) should be substituted at install time
+User=1000

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -1116,7 +1116,7 @@ EOF
   p_atsign=""
 
   extract_val() {
-    val=$(grep -h "^Environment=$1=" "$override_file" "$unit_file" 2>/dev/null | tail -n 1 | cut -d= -f2- | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//")
+    val=$(grep -h "^Environment=$1=" "$override_file" "$unit_file" 2>/dev/null | tail -n 1 | cut -d= -f3- | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//")
     echo "$val"
   }
 

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -993,6 +993,18 @@ EOF
   used_package_manager=true
 }
 
+install_via_brew() {
+  echo "Installing noports via brew..."
+  if ! check_cmd brew; then
+    >&2 echo "Error: brew is required for brew installation"
+    exit 1
+  fi
+
+  brew tap atsign-foundation/homebrew-tap
+  brew install noports
+  used_package_manager=true
+}
+
 install_via_apt() {
   echo "Installing noports via apt..."
   if ! check_cmd apt; then
@@ -1039,6 +1051,24 @@ main() {
     install_via_apt
   elif [ "$platform_name" = "linux" ] && is_redhat_like && (check_cmd dnf || check_cmd yum); then
     install_via_rpm
+  elif [ "$platform_name" = "macos" ] && check_cmd brew; then
+    if [ "$quiet" = true ]; then
+      install_via_brew
+    else
+      echo "Homebrew detected."
+      printf "Would you like to install noports via Homebrew? [Y/n] "
+      read -r use_brew
+      case $use_brew in
+      [Nn]*)
+        download_url=$(get_download_url)
+        echo "$download_url" | download_archive
+        unpack_archive
+        ;;
+      *)
+        install_via_brew
+        ;;
+      esac
+    fi
   else
     download_url=$(get_download_url)
     echo "$download_url" | download_archive

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -1019,6 +1019,38 @@ migrate_systemd_config_to_yaml() {
   echo "Migration complete."
 }
 
+remove_old_binaries() {
+  echo "Cleaning up old noports installation..."
+  # List of binaries and scripts to remove from non-package locations
+  binaries="sshnp sshnpd npt srv srvd at_activate noports np_admin npp_atserver npp_atserver npp_file"
+  # We check /usr/local/bin and the user's local bin
+  # Note: Package installs to /usr/bin, so those are safe.
+  for dir in "/usr/local/bin" "$user_home/.local/bin"; do
+    for bin in $binaries; do
+      if [ -f "$dir/$bin" ]; then
+        echo "Removing old binary: $dir/$bin"
+        rm -f "$dir/$bin"
+      fi
+    done
+    # Also remove the wrapper script if it exists
+    if [ -f "$dir/sshnpd.sh" ]; then
+      echo "Removing old script: $dir/sshnpd.sh"
+      rm -f "$dir/sshnpd.sh"
+    fi
+  done
+
+  # If we have an old systemd unit in /etc/systemd/system, it will override the package unit in /lib/systemd/system
+  # So we must remove/rename it after migration is confirmed.
+  if [ -f "/etc/systemd/system/sshnpd.service" ]; then
+    echo "Disabling and removing old systemd unit /etc/systemd/system/sshnpd.service"
+    systemctl stop sshnpd 2>/dev/null || true
+    systemctl disable sshnpd 2>/dev/null || true
+    mv "/etc/systemd/system/sshnpd.service" "/etc/systemd/system/sshnpd.service.old"
+    [ -d "/etc/systemd/system/sshnpd.service.d" ] && mv "/etc/systemd/system/sshnpd.service.d" "/etc/systemd/system/sshnpd.service.d.old"
+    systemctl daemon-reload
+  fi
+}
+
 install_via_rpm() {
   echo "Installing noports via rpm..."
   if ! (check_cmd dnf || check_cmd yum); then
@@ -1051,6 +1083,7 @@ EOF
   if [ -f "/etc/systemd/system/sshnpd.service" ]; then
     migrate_systemd_config_to_yaml
   fi
+  remove_old_binaries
   used_package_manager=true
 }
 
@@ -1097,6 +1130,7 @@ install_via_apt() {
   if [ -f "/etc/systemd/system/sshnpd.service" ]; then
     migrate_systemd_config_to_yaml
   fi
+  remove_old_binaries
   used_package_manager=true
 }
 

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -54,6 +54,7 @@ unset download_url
 local_archive=""
 no_sudo=false
 quiet=false
+used_apt=false
 
 ### Client/ Device Install Variables
 client_atsign=""
@@ -747,13 +748,15 @@ validate_activation() {
 
 # CLIENT INSTALLATION #
 client() {
-  mkdir -p "$bin_path"
+  if [ "$used_apt" = false ]; then
+    mkdir -p "$bin_path"
 
-  # install the binaries
-  "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" sshnp
-  "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" npt
-  "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" srv
-  "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" at_activate
+    # install the binaries
+    "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" sshnp
+    "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" npt
+    "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" srv
+    "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" at_activate
+  fi
 
   # set PATH so it includes user's private bin if it exists
   if [ -d "$user_home/.local/bin" ] ; then
@@ -812,14 +815,18 @@ device() {
     device_install_type=$device_type
   fi
 
-  # install at_activate binary
-  "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" at_activate
+  if [ "$used_apt" = false ]; then
+    # install at_activate binary
+    "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" at_activate
 
-  # install sshnpd binary and capture the installer output
-  install_output=$("$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" "$device_install_type" sshnpd)
+    # install sshnpd binary and capture the installer output
+    install_output=$("$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" "$device_install_type" sshnpd)
 
-  if [ "$verbose" = true ]; then
-    echo "$install_output"
+    if [ "$verbose" = true ]; then
+      echo "$install_output"
+    fi
+  else
+    install_output=""
   fi
 
   # upgrade an existing installation if we find one
@@ -923,6 +930,47 @@ device() {
   fi
 }
 
+is_debian_like() {
+  if [ -f /etc/os-release ]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    case "$ID" in
+    debian | ubuntu | mint | kali | raspbian) return 0 ;;
+    esac
+    case "${ID_LIKE:-}" in
+    *debian* | *ubuntu*) return 0 ;;
+    esac
+  elif [ -f /etc/debian_version ]; then
+    return 0
+  fi
+  return 1
+}
+
+install_via_apt() {
+  echo "Installing noports via apt..."
+  if ! check_cmd sudo; then
+    >&2 echo "Error: sudo is required for apt installation"
+    exit 1
+  fi
+
+  if ! check_cmd curl; then
+    >&2 echo "Error: curl is required for apt installation"
+    exit 1
+  fi
+
+  if ! check_cmd gpg; then
+    echo "gpg not found, installing gnupg..."
+    sudo apt update && sudo apt install -y gnupg
+  fi
+
+  sudo mkdir -p /usr/share/keyrings
+  curl -fsSL https://apt.noports.com/noports.pub.asc | sudo gpg --dearmor -o /usr/share/keyrings/noports-archive-keyring.gpg
+  echo "deb [signed-by=/usr/share/keyrings/noports-archive-keyring.gpg] https://apt.noports.com/ stable main" | sudo tee /etc/apt/sources.list.d/noports.list
+  sudo apt update
+  sudo apt install -y noports
+  used_apt=true
+}
+
 main() {
   trap cleanup EXIT
   set -eu
@@ -934,12 +982,14 @@ main() {
   if [ -n "$local_archive" ]; then
     echo "Using local archive: $local_archive"
     cp "$local_archive" "$archive_path"
+    unpack_archive
+  elif [ "$platform_name" = "linux" ] && is_debian_like && check_cmd apt-get; then
+    install_via_apt
   else
     download_url=$(get_download_url)
     echo "$download_url" | download_archive
+    unpack_archive
   fi
-
-  unpack_archive
 
   get_user_inputs
   case "$install_type" in

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -2,8 +2,8 @@
 
 # SCRIPT METADATA
 # DO NOT MODIFY/DELETE THIS BLOCK
-script_version="3.1.0"
-sshnp_version="5.8.0"
+script_version="3.2.0"
+sshnp_version="5.14.9"
 repo_url="https://github.com/atsign-foundation/sshnoports"
 # END METADATA
 

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -1053,6 +1053,43 @@ cleanup_old_installation() {
     fi
   done
 
+  # Check for local installation in user's home
+  if [ "$user" != "root" ]; then
+    local_bin_dir="$user_home/.local/bin"
+    found_local=false
+    for bin in $binaries; do
+      if [ -f "$local_bin_dir/$bin" ]; then
+        found_local=true
+        break
+      fi
+    done
+
+    if [ "$found_local" = true ]; then
+      if [ "$quiet" = true ]; then
+        echo "Removing local installation from $local_bin_dir..."
+        for bin in $binaries; do
+          rm -f "$local_bin_dir/$bin"
+        done
+        rm -f "$local_bin_dir/sshnpd.sh"
+      else
+        echo "WARNING: A local installation of NoPorts was found in $local_bin_dir"
+        echo "This may conflict with the system-wide installation."
+        printf "Would you like to remove the local installation? [Y/n] "
+        read -r remove_local
+        case $remove_local in
+        [Nn]*) ;;
+        *)
+          echo "Removing local installation..."
+          for bin in $binaries; do
+            rm -f "$local_bin_dir/$bin"
+          done
+          rm -f "$local_bin_dir/sshnpd.sh"
+          ;;
+        esac
+      fi
+    fi
+  fi
+
   # If we have an old systemd unit in /etc/systemd/system, it will override the package unit in /lib/systemd/system
   # Or if we are doing a manual install, we want to move to /lib/systemd/system/ (nfpm style)
   if [ -f "/etc/systemd/system/sshnpd.service" ]; then

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -830,6 +830,12 @@ device() {
       # Manually install the nfpm style systemd unit
       mkdir -p /lib/systemd/system
       cp "$extract_path/sshnp/bundles/shell/systemd.nfpm/sshnpd.service" /lib/systemd/system/sshnpd.service
+      
+      # Install the override file and customize the User
+      mkdir -p /etc/systemd/system/sshnpd.service.d
+      cp "$extract_path/sshnp/bundles/shell/systemd.nfpm/sshnpd.service.d/override.conf" /etc/systemd/system/sshnpd.service.d/override.conf
+      customize_systemd_user
+
       # If we are root, we should also ensure /etc/noports exists and has the config
       mkdir -p /etc/noports
       if [ ! -f /etc/noports/sshnpd.yaml ]; then
@@ -865,7 +871,7 @@ device() {
          if [ "$used_package_manager" = false ]; then
            systemctl daemon-reload
            systemctl restart sshnpd
-           echo "sshnpd restarted. To see logs use: journalctl -u sshnpd -f"
+           print_systemd_summary restart
            return
          fi
        fi
@@ -978,8 +984,7 @@ device() {
       systemctl start sshnpd
     fi
 
-    echo "sshnpd installed with systemd. To see logs use:"
-    echo "  journalctl -u sshnpd -f"
+    print_systemd_summary
     ;;
   tmux | headless)
     shell_script="$bin_path"/sshnpd.sh
@@ -1184,6 +1189,28 @@ EOF
   echo "Migration complete."
 }
 
+customize_systemd_user() {
+  # This covers both sshnpd and srvd as they both have overrides in nfpm
+  for service in "sshnpd" "srvd"; do
+    override_file="/etc/systemd/system/${service}.service.d/override.conf"
+    if [ -f "$override_file" ]; then
+      echo "Customizing systemd user for ${service} in $override_file..."
+      sedi "s/^User=1000$/User=$user/" "$override_file"
+    fi
+  done
+}
+
+print_systemd_summary() {
+  verb="installed with"
+  [ "${1:-}" = "restart" ] && verb="restarted. The service is"
+  echo "sshnpd $verb systemd."
+  echo "The service is configured to run as user: $user"
+  echo "If you wish to change this, run:"
+  echo "  sudo systemctl edit sshnpd"
+  echo "To see logs use:"
+  echo "  journalctl -u sshnpd -f"
+}
+
 install_via_rpm() {
   echo "Installing noports via rpm..."
   if ! (check_cmd dnf || check_cmd yum); then
@@ -1216,7 +1243,9 @@ EOF
   if [ -f "/etc/systemd/system/sshnpd.service" ]; then
     migrate_systemd_config_to_yaml
   fi
+  customize_systemd_user
   cleanup_old_installation
+  print_systemd_summary restart
   used_package_manager=true
 }
 
@@ -1263,7 +1292,9 @@ install_via_apt() {
   if [ -f "/etc/systemd/system/sshnpd.service" ]; then
     migrate_systemd_config_to_yaml
   fi
+  customize_systemd_user
   cleanup_old_installation
+  print_systemd_summary restart
   used_package_manager=true
 }
 

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -54,7 +54,7 @@ unset download_url
 local_archive=""
 no_sudo=false
 quiet=false
-used_apt=false
+used_package_manager=false
 
 ### Client/ Device Install Variables
 client_atsign=""
@@ -748,7 +748,7 @@ validate_activation() {
 
 # CLIENT INSTALLATION #
 client() {
-  if [ "$used_apt" = false ]; then
+  if [ "$used_package_manager" = false ]; then
     mkdir -p "$bin_path"
 
     # install the binaries
@@ -815,7 +815,7 @@ device() {
     device_install_type=$device_type
   fi
 
-  if [ "$used_apt" = false ]; then
+  if [ "$used_package_manager" = false ]; then
     # install at_activate binary
     "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" at_activate
 
@@ -946,6 +946,53 @@ is_debian_like() {
   return 1
 }
 
+is_redhat_like() {
+  if [ -f /etc/os-release ]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    case "$ID" in
+    fedora | rhel | centos | amzn | rocky | almalinux) return 0 ;;
+    esac
+    case "${ID_LIKE:-}" in
+    *fedora* | *rhel* | *centos*) return 0 ;;
+    esac
+  elif [ -f /etc/redhat-release ]; then
+    return 0
+  fi
+  return 1
+}
+
+install_via_rpm() {
+  echo "Installing noports via rpm..."
+  if ! (check_cmd dnf || check_cmd yum); then
+    >&2 echo "Error: dnf or yum is required for rpm installation"
+    exit 1
+  fi
+
+  if ! check_cmd sudo; then
+    >&2 echo "Error: sudo is required for rpm installation"
+    exit 1
+  fi
+
+  # Create the repository file
+  sudo tee /etc/yum.repos.d/noports.repo <<EOF
+[noports]
+name=NoPorts Repository
+baseurl=https://rpm.noports.com/\$basearch/
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://rpm.noports.com/noports.pub.asc
+EOF
+
+  if check_cmd dnf; then
+    sudo dnf install -y noports
+  else
+    sudo yum install -y noports
+  fi
+  used_package_manager=true
+}
+
 install_via_apt() {
   echo "Installing noports via apt..."
   if ! check_cmd apt; then
@@ -973,7 +1020,7 @@ install_via_apt() {
   echo "deb [signed-by=/usr/share/keyrings/noports-archive-keyring.gpg] https://apt.noports.com/ stable main" | sudo tee /etc/apt/sources.list.d/noports.list
   sudo apt update
   sudo apt install -y noports
-  used_apt=true
+  used_package_manager=true
 }
 
 main() {
@@ -990,6 +1037,8 @@ main() {
     unpack_archive
   elif [ "$platform_name" = "linux" ] && is_debian_like && (check_cmd apt || check_cmd apt-get); then
     install_via_apt
+  elif [ "$platform_name" = "linux" ] && is_redhat_like && (check_cmd dnf || check_cmd yum); then
+    install_via_rpm
   else
     download_url=$(get_download_url)
     echo "$download_url" | download_archive

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -223,7 +223,7 @@ parse_env() {
   if is_root; then
     user="$SUDO_USER"
     as_root=true
-    bin_path="/usr/local/bin"
+    bin_path="/usr/bin"
     if [ -z "$user" ]; then
       user="root"
     else
@@ -816,11 +816,29 @@ device() {
   fi
 
   if [ "$used_package_manager" = false ]; then
+    if [ "$device_install_type" = "systemd" ] && [ "$as_root" = true ]; then
+      cleanup_old_installation
+    fi
+
     # install at_activate binary
     "$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" at_activate
 
     # install sshnpd binary and capture the installer output
-    install_output=$("$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" "$device_install_type" sshnpd)
+    # If systemd, we want to use the new style
+    if [ "$device_install_type" = "systemd" ] && [ "$as_root" = true ]; then
+      install_output=$("$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" sshnpd)
+      # Manually install the nfpm style systemd unit
+      mkdir -p /lib/systemd/system
+      cp "$extract_path/sshnp/bundles/shell/systemd.nfpm/sshnpd.service" /lib/systemd/system/sshnpd.service
+      # If we are root, we should also ensure /etc/noports exists and has the config
+      mkdir -p /etc/noports
+      if [ ! -f /etc/noports/sshnpd.yaml ]; then
+        cp "$extract_path/sshnp/bundles/core/config/sshnpd.yaml" /etc/noports/sshnpd.yaml
+      fi
+      migrate_systemd_config_to_yaml
+    else
+      install_output=$("$extract_path"/sshnp/install.sh -b "$bin_path" -u "$user" "$device_install_type" sshnpd)
+    fi
 
     if [ "$verbose" = true ]; then
       echo "$install_output"
@@ -840,12 +858,25 @@ device() {
     fi
     ;;
   systemd)
-    if [ "$is_overrideconf_created" = true ]; then
-      echo "systemd config for sshnpd service already in place"
-      echo "sshnpd systemd upgraded and restarted. To see logs use:"
-      echo "  journalctl -u sshnpd -f"
-      systemctl restart sshnpd
-      return
+    if [ "$as_root" = true ]; then
+       # For systemd nfpm style, we check if it's already enabled/running
+       if systemctl is-enabled sshnpd >/dev/null 2>&1; then
+         echo "sshnpd systemd service is already enabled"
+         if [ "$used_package_manager" = false ]; then
+           systemctl daemon-reload
+           systemctl restart sshnpd
+           echo "sshnpd restarted. To see logs use: journalctl -u sshnpd -f"
+           return
+         fi
+       fi
+    else
+      if [ "$is_overrideconf_created" = true ]; then
+        echo "systemd config for sshnpd service already in place"
+        echo "sshnpd systemd upgraded and restarted. To see logs use:"
+        echo "  journalctl -u sshnpd -f"
+        systemctl restart sshnpd
+        return
+      fi
     fi
     ;;
   tmux | headless)
@@ -854,6 +885,18 @@ device() {
   esac
 
   # Get atSigns for fresh install
+  # We only need to prompt if the config isn't already populated
+  if [ "$device_install_type" = "systemd" ] && [ "$as_root" = true ] && [ -f /etc/noports/sshnpd.yaml ]; then
+     if grep -E "^[[:space:]]+atsign:[[:space:]]*[^[:space:]#]" /etc/noports/sshnpd.yaml >/dev/null; then
+        echo "Configuration already populated in /etc/noports/sshnpd.yaml"
+        # We still might need to ensure activation if it's a new install but config was migrated
+        # Actually validation happens later if client/device_atsign are set.
+        # Let's extract them from YAML if they aren't set
+        [ -z "$device_atsign" ] && device_atsign=$(grep -E "^[[:space:]]+atsign:[[:space:]]*" /etc/noports/sshnpd.yaml | head -n 1 | cut -d: -f2 | sed -e "s/['\"]//g" -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+        [ -z "$client_atsign" ] && client_atsign=$(grep -A 5 "managers:" /etc/noports/sshnpd.yaml | grep "-" | head -n 1 | sed -e "s/['\"]//g" -e 's/^[[:space:]]*-//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+     fi
+  fi
+
   if [ -z "$client_atsign" ]; then
     get_atsign_manually "client"
     client_atsign="$selectedatsign"
@@ -866,6 +909,11 @@ device() {
 
   # Note: policy_atsign is not mandatory so, if none was supplied,
   #       we will not prompt for it
+
+  # For systemd nfpm style, we might already have the name in YAML
+  if [ "$device_install_type" = "systemd" ] && [ "$as_root" = true ] && [ -f /etc/noports/sshnpd.yaml ]; then
+     [ -z "$device_name" ] && device_name=$(grep -E "^[[:space:]]*name:[[:space:]]*" /etc/noports/sshnpd.yaml | head -n 1 | cut -d: -f2 | sed -e "s/['\"]//g" -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+  fi
 
   while [ -z "$device_name" ]; do
     printf "Enter device name: "
@@ -899,16 +947,36 @@ device() {
     echo "sshnpd installed with launchd"
     ;;
   systemd)
-    write_systemd_user "$systemd_config_path" "$user"
-    write_systemd_environment "$systemd_config_path" "manager_atsign" "$(norm_atsign "$client_atsign")"
-    write_systemd_environment "$systemd_config_path" "device_atsign" "$(norm_atsign "$device_atsign")"
-    if [ -n "$policy_atsign" ]; then
-      write_systemd_environment "$systemd_config_path" "delegate_policy" "-p $(norm_atsign "$policy_atsign")"
-    fi
-    write_systemd_environment "$systemd_config_path" "device_name" "$device_name"
+    if [ "$as_root" = true ]; then
+      # Update YAML if we got new inputs
+      yaml_file="/etc/noports/sshnpd.yaml"
+      sedi "s|^\([[:space:]]\{2\}atsign:\)[[:space:]]*.*$|\1 '$(norm_atsign "$device_atsign")'|" "$yaml_file"
+      if [ -n "$client_atsign" ]; then
+        # This is a bit simplistic for managers list, but if it was empty it works
+        if ! grep -A 5 "managers:" "$yaml_file" | grep -q "$(norm_atsign "$client_atsign")"; then
+           sedi "s|^[[:space:]]*#[[:space:]]*- your_atsign_here$|    - '$(norm_atsign "$client_atsign")'|" "$yaml_file"
+        fi
+      fi
+      if [ -n "$policy_atsign" ]; then
+        sedi "s|^\([[:space:]]\{2\}policy:\)[[:space:]]*.*$|\1 '$(norm_atsign "$policy_atsign")'|" "$yaml_file"
+      fi
+      sedi "/^device:/,/^ssh:/s|^\([[:space:]]*name:\)[[:space:]]*.*$|\1 '$device_name'|" "$yaml_file"
 
-    systemctl enable sshnpd
-    systemctl start sshnpd
+      systemctl daemon-reload
+      systemctl enable sshnpd
+      systemctl start sshnpd
+    else
+      write_systemd_user "$systemd_config_path" "$user"
+      write_systemd_environment "$systemd_config_path" "manager_atsign" "$(norm_atsign "$client_atsign")"
+      write_systemd_environment "$systemd_config_path" "device_atsign" "$(norm_atsign "$device_atsign")"
+      if [ -n "$policy_atsign" ]; then
+        write_systemd_environment "$systemd_config_path" "delegate_policy" "-p $(norm_atsign "$policy_atsign")"
+      fi
+      write_systemd_environment "$systemd_config_path" "device_name" "$device_name"
+
+      systemctl enable sshnpd
+      systemctl start sshnpd
+    fi
 
     echo "sshnpd installed with systemd. To see logs use:"
     echo "  journalctl -u sshnpd -f"
@@ -962,15 +1030,72 @@ is_redhat_like() {
   return 1
 }
 
+cleanup_old_installation() {
+  if [ "$as_root" = false ]; then
+    return
+  fi
+  echo "Cleaning up old noports installation..."
+  # List of binaries and scripts to remove from non-package locations
+  binaries="sshnp sshnpd npt srv srvd at_activate noports np_admin npp_atserver npp_file"
+  # We check /usr/local/bin
+  # Note: New install is to /usr/bin, so those are safe.
+  for dir in "/usr/local/bin"; do
+    for bin in $binaries; do
+      if [ -f "$dir/$bin" ]; then
+        echo "Removing old binary: $dir/$bin"
+        rm -f "$dir/$bin"
+      fi
+    done
+    # Also remove the wrapper script if it exists
+    if [ -f "$dir/sshnpd.sh" ]; then
+      echo "Removing old script: $dir/sshnpd.sh"
+      rm -f "$dir/sshnpd.sh"
+    fi
+  done
+
+  # If we have an old systemd unit in /etc/systemd/system, it will override the package unit in /lib/systemd/system
+  # Or if we are doing a manual install, we want to move to /lib/systemd/system/ (nfpm style)
+  if [ -f "/etc/systemd/system/sshnpd.service" ]; then
+    echo "Disabling and removing old systemd unit /etc/systemd/system/sshnpd.service"
+    systemctl stop sshnpd 2>/dev/null || true
+    systemctl disable sshnpd 2>/dev/null || true
+    mv "/etc/systemd/system/sshnpd.service" "/etc/systemd/system/sshnpd.service.old"
+    [ -d "/etc/systemd/system/sshnpd.service.d" ] && mv "/etc/systemd/system/sshnpd.service.d" "/etc/systemd/system/sshnpd.service.d.old"
+    systemctl daemon-reload
+  fi
+}
+
 migrate_systemd_config_to_yaml() {
   yaml_file="/etc/noports/sshnpd.yaml"
+  # If the YAML doesn't exist, we might be in a manual install flow where it's not yet copied.
+  # But for nfpm style, it should be there.
   if [ ! -f "$yaml_file" ]; then
-    echo "Warning: $yaml_file not found. Skipping migration."
-    return
+    echo "Warning: $yaml_file not found. Creating from template if available."
+    mkdir -p /etc/noports
+    if [ -f "$extract_path/sshnp/bundles/core/config/sshnpd.yaml" ]; then
+      cp "$extract_path/sshnp/bundles/core/config/sshnpd.yaml" "$yaml_file"
+    else
+      # Fallback to minimal if template not found in expected extract path
+      cat <<EOF > "$yaml_file"
+atsign:
+  atsign: 
+access:
+  policy: 
+  managers:
+    - 
+device:
+  name: 
+ssh:
+  add-publickeys: true
+  ssh-client: openssh
+  sshd-port: 22
+runtime:
+  verbose: true
+EOF
+    fi
   fi
 
   # Check if atsign is already set
-  # We look for the nested "atsign:" key (indented) followed by any non-whitespace value
   if grep -E "^[[:space:]]+atsign:[[:space:]]*[^[:space:]#]" "$yaml_file" >/dev/null; then
     echo "YAML config $yaml_file appears to be already populated, skipping migration."
     return
@@ -979,8 +1104,11 @@ migrate_systemd_config_to_yaml() {
   echo "Migrating existing systemd configuration to $yaml_file..."
 
   # Extract values from systemd unit and override files
+  # Check /etc/systemd/system/sshnpd.service.old if we just moved it
   unit_file="/etc/systemd/system/sshnpd.service"
+  [ ! -f "$unit_file" ] && [ -f "${unit_file}.old" ] && unit_file="${unit_file}.old"
   override_file="/etc/systemd/system/sshnpd.service.d/override.conf"
+  [ ! -d "$(dirname "$override_file")" ] && [ -d "$(dirname "$override_file").old" ] && override_file="$(dirname "$override_file").old/override.conf"
 
   m_atsign=""
   d_atsign=""
@@ -1019,38 +1147,6 @@ migrate_systemd_config_to_yaml() {
   echo "Migration complete."
 }
 
-remove_old_binaries() {
-  echo "Cleaning up old noports installation..."
-  # List of binaries and scripts to remove from non-package locations
-  binaries="sshnp sshnpd npt srv srvd at_activate noports np_admin npp_atserver npp_atserver npp_file"
-  # We check /usr/local/bin and the user's local bin
-  # Note: Package installs to /usr/bin, so those are safe.
-  for dir in "/usr/local/bin" "$user_home/.local/bin"; do
-    for bin in $binaries; do
-      if [ -f "$dir/$bin" ]; then
-        echo "Removing old binary: $dir/$bin"
-        rm -f "$dir/$bin"
-      fi
-    done
-    # Also remove the wrapper script if it exists
-    if [ -f "$dir/sshnpd.sh" ]; then
-      echo "Removing old script: $dir/sshnpd.sh"
-      rm -f "$dir/sshnpd.sh"
-    fi
-  done
-
-  # If we have an old systemd unit in /etc/systemd/system, it will override the package unit in /lib/systemd/system
-  # So we must remove/rename it after migration is confirmed.
-  if [ -f "/etc/systemd/system/sshnpd.service" ]; then
-    echo "Disabling and removing old systemd unit /etc/systemd/system/sshnpd.service"
-    systemctl stop sshnpd 2>/dev/null || true
-    systemctl disable sshnpd 2>/dev/null || true
-    mv "/etc/systemd/system/sshnpd.service" "/etc/systemd/system/sshnpd.service.old"
-    [ -d "/etc/systemd/system/sshnpd.service.d" ] && mv "/etc/systemd/system/sshnpd.service.d" "/etc/systemd/system/sshnpd.service.d.old"
-    systemctl daemon-reload
-  fi
-}
-
 install_via_rpm() {
   echo "Installing noports via rpm..."
   if ! (check_cmd dnf || check_cmd yum); then
@@ -1083,7 +1179,7 @@ EOF
   if [ -f "/etc/systemd/system/sshnpd.service" ]; then
     migrate_systemd_config_to_yaml
   fi
-  remove_old_binaries
+  cleanup_old_installation
   used_package_manager=true
 }
 
@@ -1130,7 +1226,7 @@ install_via_apt() {
   if [ -f "/etc/systemd/system/sshnpd.service" ]; then
     migrate_systemd_config_to_yaml
   fi
-  remove_old_binaries
+  cleanup_old_installation
   used_package_manager=true
 }
 

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -948,14 +948,19 @@ is_debian_like() {
 
 install_via_apt() {
   echo "Installing noports via apt..."
+  if ! check_cmd apt; then
+    >&2 echo "Error: apt is required for apt installation"
+    exit 1
+  fi
+
   if ! check_cmd sudo; then
     >&2 echo "Error: sudo is required for apt installation"
     exit 1
   fi
 
   if ! check_cmd curl; then
-    >&2 echo "Error: curl is required for apt installation"
-    exit 1
+    echo "curl not found, installing curl..."
+    sudo apt update && sudo apt install -y curl
   fi
 
   if ! check_cmd gpg; then
@@ -983,7 +988,7 @@ main() {
     echo "Using local archive: $local_archive"
     cp "$local_archive" "$archive_path"
     unpack_archive
-  elif [ "$platform_name" = "linux" ] && is_debian_like && check_cmd apt-get; then
+  elif [ "$platform_name" = "linux" ] && is_debian_like && (check_cmd apt || check_cmd apt-get); then
     install_via_apt
   else
     download_url=$(get_download_url)

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -3,7 +3,7 @@
 # SCRIPT METADATA
 # DO NOT MODIFY/DELETE THIS BLOCK
 script_version="3.2.0"
-sshnp_version="5.14.9"
+sshnp_version="5.14.10"
 repo_url="https://github.com/atsign-foundation/sshnoports"
 # END METADATA
 

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -962,6 +962,63 @@ is_redhat_like() {
   return 1
 }
 
+migrate_systemd_config_to_yaml() {
+  yaml_file="/etc/noports/sshnpd.yaml"
+  if [ ! -f "$yaml_file" ]; then
+    echo "Warning: $yaml_file not found. Skipping migration."
+    return
+  fi
+
+  # Check if atsign is already set
+  # We look for the nested "atsign:" key (indented) followed by any non-whitespace value
+  if grep -E "^[[:space:]]+atsign:[[:space:]]*[^[:space:]#]" "$yaml_file" >/dev/null; then
+    echo "YAML config $yaml_file appears to be already populated, skipping migration."
+    return
+  fi
+
+  echo "Migrating existing systemd configuration to $yaml_file..."
+
+  # Extract values from systemd unit and override files
+  unit_file="/etc/systemd/system/sshnpd.service"
+  override_file="/etc/systemd/system/sshnpd.service.d/override.conf"
+
+  m_atsign=""
+  d_atsign=""
+  d_name=""
+  p_atsign=""
+
+  extract_val() {
+    val=$(grep -h "^Environment=$1=" "$override_file" "$unit_file" 2>/dev/null | tail -n 1 | cut -d= -f2- | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//")
+    echo "$val"
+  }
+
+  m_atsign=$(extract_val "manager_atsign")
+  d_atsign=$(extract_val "device_atsign")
+  d_name=$(extract_val "device_name")
+  delegate_policy=$(extract_val "delegate_policy")
+  if [ -n "$delegate_policy" ]; then
+    p_atsign=$(echo "$delegate_policy" | sed 's/-p //')
+  fi
+
+  [ -z "$d_name" ] && d_name="default"
+
+  # Update the template file using sedi
+  if [ -n "$d_atsign" ]; then
+    sedi "s|^\([[:space:]]\{2\}atsign:\)[[:space:]]*$|\1 '$(norm_atsign "$d_atsign")'|" "$yaml_file"
+  fi
+  if [ -n "$p_atsign" ]; then
+    sedi "s|^\([[:space:]]\{2\}policy:\)[[:space:]]*$|\1 '$(norm_atsign "$p_atsign")'|" "$yaml_file"
+  fi
+  if [ -n "$m_atsign" ]; then
+    sedi "s|^[[:space:]]*#[[:space:]]*- your_atsign_here$|    - '$(norm_atsign "$m_atsign")'|" "$yaml_file"
+  fi
+  if [ -n "$d_name" ]; then
+    sedi "/^device:/,/^ssh:/s|^\([[:space:]]*name:\)[[:space:]]*$|\1 '$d_name'|" "$yaml_file"
+  fi
+
+  echo "Migration complete."
+}
+
 install_via_rpm() {
   echo "Installing noports via rpm..."
   if ! (check_cmd dnf || check_cmd yum); then
@@ -989,6 +1046,10 @@ EOF
     sudo dnf install -y noports
   else
     sudo yum install -y noports
+  fi
+
+  if [ -f "/etc/systemd/system/sshnpd.service" ]; then
+    migrate_systemd_config_to_yaml
   fi
   used_package_manager=true
 }
@@ -1032,6 +1093,10 @@ install_via_apt() {
   echo "deb [signed-by=/usr/share/keyrings/noports-archive-keyring.gpg] https://apt.noports.com/ stable main" | sudo tee /etc/apt/sources.list.d/noports.list
   sudo apt update
   sudo apt install -y noports
+
+  if [ -f "/etc/systemd/system/sshnpd.service" ]; then
+    migrate_systemd_config_to_yaml
+  fi
   used_package_manager=true
 }
 

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.14.9';
+const packageVersion = '5.14.10';

--- a/packages/dart/sshnoports/nfpm.yaml
+++ b/packages/dart/sshnoports/nfpm.yaml
@@ -39,10 +39,13 @@ contents:
   - src: ./bundles/shell/systemd.nfpm/srvd.service
     dst: /lib/systemd/system/srvd.service
   - src: ./bundles/shell/systemd.nfpm/srvd.service.d/override.conf
-    dst: /lib/systemd/system/srvd.service.d/override.conf
+    dst: /etc/systemd/system/srvd.service.d/override.conf
     type: config
   - src: ./bundles/shell/systemd.nfpm/sshnpd.service
     dst: /lib/systemd/system/sshnpd.service
+  - src: ./bundles/shell/systemd.nfpm/sshnpd.service.d/override.conf
+    dst: /etc/systemd/system/sshnpd.service.d/override.conf
+    type: config
   - src: ./LICENSE
     dst: /usr/share/doc/noports/copyright
   - src: ./sshnp/at_activate.1.gz

--- a/packages/dart/sshnoports/nfpm.yaml
+++ b/packages/dart/sshnoports/nfpm.yaml
@@ -36,6 +36,11 @@ contents:
   - src: ./bundles/core/config/sshnpd.yaml
     dst: /etc/noports/sshnpd.yaml
     type: config
+  - src: ./bundles/shell/systemd.nfpm/srvd.service
+    dst: /lib/systemd/system/srvd.service
+  - src: ./bundles/shell/systemd.nfpm/srvd.service.d/override.conf
+    dst: /lib/systemd/system/srvd.service.d/override.conf
+    type: config
   - src: ./bundles/shell/systemd.nfpm/sshnpd.service
     dst: /lib/systemd/system/sshnpd.service
   - src: ./LICENSE

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.14.9
+version: 5.14.10
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Fixes #2313 and #2339

**- What I did**

* Use apt where possible (Linux - Debian derivs)
* Use rpm where possible (Linux - RedHat derivs)
* Offer brew where possible (MacOS)
* Migration of systemd config to sshnpd.yaml
* Remove old binaries

**- How I did it**

Gemini CLI prompts:

1. I want to make a series of changes to universal.sh in this repo. Firstly if it finds a debian system or anything else that uses the apt package manager it should install noports using apt with the following sequence of commands rather than downloading the tarball from github:
`sudo mkdir -p /usr/share/keyrings ; curl -fsSL https://apt.noports.com/noports.pub.asc | sudo gpg --dearmor -o /usr/share/keyrings/noports-archive-keyring.gpg ; echo "deb [signed-by=/usr/share/keyrings/noports-archive-keyring.gpg] https://apt.noports.com/ stable main" | sudo tee /etc/apt/sources.list.d/noports.list ; sudo apt update ; sudo apt install -y noports`

2. In the install_via_apt function, rather than erroring if curl isn't found it should try to install curl. The script should also check that apt command is available.

3. similarly if the script finds a redhat derived system it should install the rpm using the repo at https://rpm.noports.com which has its source and install instructions at https://github.com/atsign-foundation/noports-rpm

4. For MacOS installs the universal.sh script should check for whether homebrew is installed and if it is offer to use the homebrew tap at https://github.com/atsign-foundation/homebrew-tap to install noports rather than getting a zip from the GitHub release

5. where we find an existing systemd installation in /etc/systemd/system/ and an upgrade is using apt or rpm to put in place new binaries and systemd units the universal.sh script needs to migrate config from the systemd unit file(s) and any override.conf into /etc/noports/sshnpd.yaml

6. a template sshnpd.yaml is part of the apt or rpm install, so it will always exist. So rather than simply checking whether it exists the script should check to see if it has already been populated. Also because we know there will be a template file there the script should simply modify that rather than creating the sshnpd.yaml from scratch.

7. We can't rely on atsigns having an @ prefix for the population check as it's valid for those variables to start without the preceding @

8. In addition to migrating systemd config for upgrades the script should also remove the old noports binaries so that there's no confusion between old (from previous script installs) and new (from package installs)

9. When universal.sh installs noports binaries it should place them in /usr/bin (like the apt and rpm packages do) rather than /usr/local/bin. It should also make use of the npfm style systemd units rather than the older ones. When performing an upgrade and finding binaries in the old place and/or older systemd units the script should perform similar migration steps to those carried out when upgrading to using a package.

**- How to verify it**

Lots of testing to be done before this is ready for review

**- Description for the changelog**

feat: Update universal.sh to use packages where possible.
