### PR TITLE
build(deps): Add 7 day cooldown to npm dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,8 @@ updates:
     directory: "/apps/admin/webapp/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
       npm:
         patterns:


### PR DESCRIPTION
Fixes https://github.com/atsign-foundation/operations/issues/334

**- What I did**

Added 7 day cooldown for npm dependencies

**- How to verify it**

Observe latency between npm updates and PRs being raised by Dependabot

**- Description for the changelog**

build(deps): Add 7 day cooldown to npm dependency