### PR TITLE
fix: Keep systemd override.conf in place

### DIFF
--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -1102,7 +1102,7 @@ cleanup_old_installation() {
     systemctl stop sshnpd 2>/dev/null || true
     systemctl disable sshnpd 2>/dev/null || true
     mv "/etc/systemd/system/sshnpd.service" "/etc/systemd/system/sshnpd.service.old"
-    [ -d "/etc/systemd/system/sshnpd.service.d" ] && mv "/etc/systemd/system/sshnpd.service.d" "/etc/systemd/system/sshnpd.service.d.old"
+    # We do NOT move the .service.d directory as it's still needed for User= and other overrides
     systemctl daemon-reload
   fi
 }
@@ -1184,6 +1184,20 @@ EOF
   fi
   if [ -n "$d_name" ]; then
     sedi "/^device:/,/^ssh:/s|^\([[:space:]]*name:\)[[:space:]]*$|\1 '$d_name'|" "$yaml_file"
+  fi
+
+  # Comment out the old Environment variables in the override file if they were migrated
+  if [ -f "$override_file" ]; then
+    if grep -q "^Environment=" "$override_file"; then
+      echo "Cleaning up migrated Environment variables from $override_file..."
+      # Add a header note to the [Service] section
+      sedi "s/^\[Service\]/\[Service\]\\
+# NOTE: Environment variables have been commented out below because\\
+# config has been migrated to $yaml_file/" "$override_file"
+
+      # Comment out any active Environment= lines
+      sedi "s/^\(Environment=.*\)/# \1/" "$override_file"
+    fi
   fi
 
   echo "Migration complete."


### PR DESCRIPTION
Script was moving any existing override.conf, which took away the correct `User=` setting

**- What I did**

Script now leaves override.conf in place and adds additional notes about config migration.

**- How I did it**

Gemini CLI:

> when upgrading we should not move the existing override.conf file to a .old directory as an override.conf is still needed to set the user variable

>  the script should put a note in the override.conf explaining that old values have been commented out because config has been migrated to   /etc/noports/sshnpd.yaml

**- How to verify it**

More manual testing on VMs with old setups

**- Description for the changelog**

fix: Keep systemd override.conf in place
