### PR TITLE
feat(cd): add npp to build

### DIFF
--- a/.github/workflows/dockerhub_sshnpd.yml
+++ b/.github/workflows/dockerhub_sshnpd.yml
@@ -21,6 +21,7 @@ jobs:
           - sshnpd
           - activate_sshnpd
           - sshnp_sshnpd
+          - npp_sshnpd
           - npt_sshnpd
           - sshnpd-slim
           - srvd
@@ -31,6 +32,8 @@ jobs:
             dockerfile: ./packages/dart/sshnoports/tools/Dockerfile.activate
           - name: sshnp_sshnpd
             dockerfile: ./packages/dart/sshnoports/tools/Dockerfile.sshnp
+          - name: npp_sshnpd
+            dockerfile: ./packages/dart/sshnoports/tools/Dockerfile.npp
           - name: npt_sshnpd
             dockerfile: ./packages/dart/sshnoports/tools/Dockerfile.npt
           - name: sshnpd-slim
@@ -123,6 +126,7 @@ jobs:
           - name: sshnpd
           - name: activate_sshnpd
           - name: sshnp_sshnpd
+          - name: npp_sshnpd
           - name: npt_sshnpd
           - name: sshnpd-slim
           - name: srvd

--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -109,7 +109,7 @@ jobs:
             platform: "windows"
     env:
       ARCH: ${{ matrix.arch }}
-      BINS: "at_activate noports npevents npp_atserver npp_file npt srv sshnp sshnpd"
+      BINS: "at_activate noports npevents npp npp_atserver npp_file npt srv sshnp sshnpd"
       CROSS: ${{ matrix.cross }}
       EXT: ${{ matrix.ext }}
       VERSION: ${{ needs.verify_tags.outputs.version }}
@@ -219,7 +219,7 @@ jobs:
           wix extension add -g WixToolset.Util.wixext/6.0.2
           wix extension add -g WixToolset.UI.wixext/6.0.2
           mkdir bin
-          cp ../../packages/dart/sshnoports/sshnp/{sshnpd,at_activate,sshnp,npp_atserver,npp_file,npt,srv,sshnpdService}.exe ./bin/
+          cp ../../packages/dart/sshnoports/sshnp/{sshnpd,at_activate,sshnp,npp,npp_atserver,npp_file,npt,srv,sshnpdService}.exe ./bin/
           cp ../../packages/dart/sshnoports/bundles/core/config/sshnpd.yaml ./bin/
           wix build -ext WixToolset.Util.wixext -ext WixToolset.UI.wixext \
               -arch x64 -o build/NoPorts.msi noports.wxs

--- a/.github/workflows/promote_canary.yml
+++ b/.github/workflows/promote_canary.yml
@@ -13,6 +13,7 @@ on:
           - sshnpd
           - activate_sshnpd
           - sshnp_sshnpd
+          - npp_sshnpd
           - npt_sshnpd
           - sshnpd-slim
           - srvd
@@ -66,6 +67,7 @@ jobs:
           - name: sshnpd
           - name: activate_sshnpd
           - name: sshnp_sshnpd
+          - name: npp_sshnpd
           - name: npt_sshnpd
           - name: sshnpd-slim
           - name: srvd

--- a/packages/dart/sshnoports/nfpm.yaml
+++ b/packages/dart/sshnoports/nfpm.yaml
@@ -19,6 +19,8 @@ contents:
     dst: /usr/bin/noports
   - src: ./sshnp/np_admin
     dst: /usr/bin/np_admin
+  - src: ./sshnp/npp
+    dst: /usr/bin/npp
   - src: ./sshnp/npp_atserver
     dst: /usr/bin/npp_atserver
   - src: ./sshnp/npp_file
@@ -54,6 +56,8 @@ contents:
     dst: /usr/share/man/man1/noports.1.gz
   - src: ./sshnp/np_admin.1.gz
     dst: /usr/share/man/man1/np_admin.1.gz
+  - src: ./sshnp/npp.1.gz
+    dst: /usr/share/man/man1/npp.1.gz
   - src: ./sshnp/npp_atserver.1.gz
     dst: /usr/share/man/man1/npp_atserver.1.gz
   - src: ./sshnp/npp_file.1.gz

--- a/packages/dart/sshnoports/tools/Dockerfile.npp
+++ b/packages/dart/sshnoports/tools/Dockerfile.npp
@@ -1,0 +1,39 @@
+# Dockerfile.npp
+# Build image for a containerized call of the npp binary
+FROM dart:3.11.1@sha256:e3ea62cbe54470e5cc4c31cbc85693aa9b0b01723521baf0be634ea3597e1f5d AS buildimage
+ENV PACKAGEDIR=packages/dart/sshnoports
+ENV BINARYDIR=/usr/local/at
+SHELL ["/bin/bash", "-c"]
+WORKDIR /app
+COPY . .
+RUN \
+  set -eux ; \
+  mkdir -p ${BINARYDIR} ; \
+  cd ${PACKAGEDIR}; \
+  dart pub get --enforce-lockfile; \
+  dart run build_runner build --delete-conflicting-outputs ; \
+  dart compile exe bin/npp.dart -o ${BINARYDIR}/npp
+
+# Second stage of build FROM debian-slim
+FROM debian:stable-20260223-slim@sha256:85dfcffff3c1e193877f143d05eaba8ae7f3f95cb0a32e0bc04a448077e1ac69
+ENV USER=atsign
+ENV HOMEDIR=/${USER}
+ENV BINARYDIR=/usr/local/at
+ENV USER_ID=1024
+ENV GROUP_ID=1024
+
+COPY --from=buildimage --chown=${USER}:${USER} /usr/local/at/npp /usr/local/at/
+WORKDIR ${HOMEDIR}
+
+RUN \
+  set -eux ; \
+  apt-get update ; \
+  apt-get install -y adduser sudo ; \
+  addgroup --gid ${GROUP_ID} ${USER} ; \
+  useradd --system --uid ${USER_ID} --gid ${GROUP_ID} --shell /bin/bash --home ${HOMEDIR} ${USER} ; \
+  mkdir -p ${HOMEDIR}/.atsign/keys ; \
+  chown -R ${USER}:${USER} ${HOMEDIR} ; \
+  usermod -aG sudo ${USER} ;
+
+USER ${USER}
+ENTRYPOINT [ "/usr/local/at/npp" ]


### PR DESCRIPTION
**- What I did**
- **NEW** Dockerfile.npp
- Updated `multibuild.yaml`
- Updated `dockerhub_sshnpd.yaml`
- Updated `promote_canary.yaml`
- Updated `nfpm.yaml`

**- How I did it**
- Using Codex

**- How to verify it**

### 1. Verifying `Dockerfile.npp`

Docker commands I ran
```
sudo docker build -f packages/dart/sshnoports/tools/Dockerfile.npp . -t atsigncompany/npp:latest
sudo docker run \
  -v /Users/jeremytubongbanua/.atsign/keys:/atsign/.atsign/keys \
  -it \
  atsigncompany/npp:latest \
  -a @policy_jttest -v
```

Output logs
```
INFO|2026-03-09 22:45:38.977477|AtLookup|Creating new connection
INFO|2026-03-09 22:45:39.180261|AtLookup|New connection created OK
INFO|2026-03-09 22:45:39.269074|AtLookup|auth success
INFO|2026-03-09 22:45:39.269290|AtClientManager|setCurrentAtSign called with atSign @policy_jttest
INFO|2026-03-09 22:45:39.269387|AtClientManager|Switching atSigns from null to @policy_jttest
INFO|2026-03-09 22:45:39.279119|AtClientCommitLogCompaction (@policy_jttest)|Starting commit log compaction job running for every 11 minute(s)
INFO|2026-03-09 22:45:39.280206|AtClientManager|setCurrentAtSign complete
INFO|2026-03-09 22:45:39.283506|npp|Using persistence method: "atserver"
INFO|2026-03-09 22:45:39.283595|AtLookup|Creating new connection
INFO|2026-03-09 22:45:39.485163|AtLookup|New connection created OK
INFO|2026-03-09 22:45:39.564679|AtLookup|auth success
INFO|2026-03-09 22:45:39.610240|npp|Found 0 policy AtKeys from atServer
INFO|2026-03-09 22:45:39.610365|npp|Loaded 0 Clients into cache
INFO|2026-03-09 22:45:39.610416|npp|Loaded 0 ClientGroups into cache
INFO|2026-03-09 22:45:39.610451|npp|Loaded 0 ClientGroupMembers into cache
INFO|2026-03-09 22:45:39.610501|npp|Loaded 0 Daemons into cache
INFO|2026-03-09 22:45:39.610522|npp|Loaded 0 Services into cache
INFO|2026-03-09 22:45:39.610551|npp|Loaded 0 ServiceACLs into cache
INFO|2026-03-09 22:45:39.610593|npp|Successfully loaded policy cache from atServer
INFO|2026-03-09 22:45:39.610856|AtRpc|allowList is {}; allowAll is true
```

### 2. Verifying `multibuild.yaml`

https://github.com/atsign-foundation/noports/actions/runs/22878512449

<img width="637" height="466" alt="image" src="https://github.com/user-attachments/assets/93fbb0b0-c2dd-4702-bc26-ef2fddfda453" />

### 3. Verifying `dockerhub_sshnpd.yaml`

https://github.com/atsign-foundation/noports/actions/runs/22878533715

Then I pulled and ran the Docker image

Pulling:

```bash
❯ sudo docker pull atsigncompany/npp_sshnpd:dev_env-jt-npp-build-gha595

dev_env-jt-npp-build-gha595: Pulling from atsigncompany/npp_sshnpd
12c19d266eed: Already exists
6f4504d52265: Pull complete
97b6469c10d3: Pull complete
28cfc3b56e2e: Pull complete
Digest: sha256:69d52e9d03cc5a4198a990f89c2d55907483f69bac38974dc626f81fdddcb6c5
Status: Downloaded newer image for atsigncompany/npp_sshnpd:dev_env-jt-npp-build-gha595
docker.io/atsigncompany/npp_sshnpd:dev_env-jt-npp-build-gha595

~ took 2s
```

Running:

```bash
❯ sudo docker run -it -v ~/.atsign/keys/:/atsign/.atsign/keys/ -t atsigncompany/npp_sshnpd:dev_env-jt-npp-build-gha595 . -a @policy_jttest -v
Password:
INFO|2026-03-10 13:48:28.455187|AtLookup|Creating new connection
INFO|2026-03-10 13:48:28.837258|AtLookup|New connection created OK
INFO|2026-03-10 13:48:28.984234|AtLookup|auth success
INFO|2026-03-10 13:48:28.984457|AtClientManager|setCurrentAtSign called with atSign @policy_jttest
INFO|2026-03-10 13:48:28.984574|AtClientManager|Switching atSigns from null to @policy_jttest
INFO|2026-03-10 13:48:28.994492|AtClientCommitLogCompaction (@policy_jttest)|Starting commit log compaction job running for every 11 minute(s)
INFO|2026-03-10 13:48:28.996028|AtClientManager|setCurrentAtSign complete
INFO|2026-03-10 13:48:28.997849|npp|Using persistence method: "atserver"
INFO|2026-03-10 13:48:28.997918|AtLookup|Creating new connection
INFO|2026-03-10 13:48:29.309874|AtLookup|New connection created OK
INFO|2026-03-10 13:48:29.464718|AtLookup|auth success
INFO|2026-03-10 13:48:29.526648|npp|Found 0 policy AtKeys from atServer
INFO|2026-03-10 13:48:29.526799|npp|Loaded 0 Clients into cache
INFO|2026-03-10 13:48:29.526910|npp|Loaded 0 ClientGroups into cache
INFO|2026-03-10 13:48:29.526933|npp|Loaded 0 ClientGroupMembers into cache
INFO|2026-03-10 13:48:29.527065|npp|Loaded 0 Daemons into cache
INFO|2026-03-10 13:48:29.527108|npp|Loaded 0 Services into cache
INFO|2026-03-10 13:48:29.527128|npp|Loaded 0 ServiceACLs into cache
INFO|2026-03-10 13:48:29.527179|npp|Successfully loaded policy cache from atServer
```

### 4. `nfpm.yaml`

### 5. `promote_canary.yaml`

Since `dockerhub_sshnpd.yaml` is working, I plan to test `promote_canary.yaml`'s workflow once this is merged to trunk

**- Description for the changelog**
feat(cd): add npp to build
