### PR TITLE
build: add another copy of windows msi into release tarball, without the version number in the filename

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -227,6 +227,7 @@ jobs:
           source ../codesign_windows.sh
           sign_file "build/NoPorts.msi"
           cp build/NoPorts.msi ../../packages/dart/sshnoports/tarball/NoPorts-${VERSION}-x64.msi
+          cp build/NoPorts.msi ../../packages/dart/sshnoports/tarball/NoPorts-x64.msi
       - name: Copy additional bundle items to build
         run: |
           cp -r bundles/core/* sshnp/


### PR DESCRIPTION
**- What I did**
build: multibuild: copy the windows msi into the released assets without a version number as well as with a version number as it currently does

**- How I did it**

**- How to verify it**
Running a [multibuild](https://github.com/atsign-foundation/noports/actions/runs/22905022551) against this branch to verify
