### PR TITLE
feat: prepare for v5.14.12 release

### DIFF
--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -600,7 +600,7 @@ packages:
       path: "../../../packages/dart/noports_core"
       relative: true
     source: path
-    version: "6.11.0"
+    version: "6.12.0"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/noports_core/CHANGELOG.md
+++ b/packages/dart/noports_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.12.0
+
+- feat: npp policy next iteration
+
 # 6.11.0
 
 - feat: remove persistent caching of public keys

--- a/packages/dart/noports_core/lib/src/version.dart
+++ b/packages/dart/noports_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '6.11.0';
+const packageVersion = '6.12.0';

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: noports_core
 description: Core library code for sshnoports
 homepage: https://docs.atsign.com/
 
-version: 6.11.0
+version: 6.12.0
 
 environment:
   sdk: ^3.8.0

--- a/packages/dart/sshnoports/CHANGELOG.md
+++ b/packages/dart/sshnoports/CHANGELOG.md
@@ -7,6 +7,10 @@
 * feat: npp.dart
 * feat: npp_client.dart
 
+## v5.14.11
+
+* build: add another copy of windows msi, without the version number in the filename
+
 ## v5.14.10
 
 * feat: Update universal.sh to use packages where possible.

--- a/packages/dart/sshnoports/CHANGELOG.md
+++ b/packages/dart/sshnoports/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 <!-- pyml disable md034-->
 
+## v5.14.12
+
+* feat: npp.dart
+* feat: npp_client.dart
+
 ## v5.14.10
 
 * feat: Update universal.sh to use packages where possible.

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.14.10';
+const packageVersion = '5.14.12';

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -600,7 +600,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.11.0"
+    version: "6.12.0"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.14.10
+version: 5.14.12
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
**- What I did**

In noports_core:
- updated sshnoports `pubspec.yaml`
- updated sshnoports `CHANGELOG.md`
- ran `dart run build_runner build`

In sshnoports:
- updated `pubspec.yaml`
- updated `CHANGELOG.md`
- ran `dart run build_runner build`

Ran
- `dart pub get` in `apps/admin/admin_api`

**- How I did it**

**- How to verify it**
- see changes

**- Description for the changelog**
feat: prepare for v5.14.12 release