### PR TITLE
ci: Scope write permission to job rather than workflow

### DIFF
--- a/.github/workflows/npt_flutter_release.yaml
+++ b/.github/workflows/npt_flutter_release.yaml
@@ -7,11 +7,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-windows-desktop:
     runs-on: windows-signer # codesign_windows.sh only works in windows-signer runner
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
https://github.com/atsign-foundation/noports/security/code-scanning/86

**- What I did**

Move scope of write permission from workflow to job

**- How to verify it**

Scorecard should run on merge and close finding referenced above

**- Description for the changelog**

ci: Scope write permission to job rather than workflow
