### PR TITLE
ci: Codesign most deeply nested binary first and add np_admin

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -253,7 +253,7 @@ jobs:
           security import $CERT_PATH -k $KEYCHAIN_PATH -P "$MACOS_CODESIGN_CERT_PASSWORD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:apple,:,codesign: -s -k "$MACOS_KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           # codesign
-          DBINS="${BINS} srvd debug/srvd"
+          DBINS="debug/srvd ${BINS} np_admin srvd"
           for BINARY in ${DBINS}; do \
             /usr/bin/codesign \
               --force \

--- a/packages/dart/sshnoports/CHANGELOG.md
+++ b/packages/dart/sshnoports/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 <!-- pyml disable md034-->
 
+## v5.14.13
+
+* feat: sshnpd doctor by @LilianGRD
+* ci: Codesign most deeply nested binary first and add np_admin
+
 ## v5.14.12
 
 * feat: npp.dart

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.14.12';
+const packageVersion = '5.14.13';

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.14.12
+version: 5.14.13
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Fixes #2604

**- What I did**

Added `np_admin` to list of binaries to be signed.

**- How I did it**

Thanks @cconstab for sluething out the problem

**- How to verify it**

Notarization working on workflow_dispatch run of workflow run https://github.com/atsign-foundation/noports/actions/runs/23004321280/job/66796813900

**- Description for the changelog**

ci: Codesign most deeply nested binary first and add np_admin
