### PR TITLE
feat: auto select best RV

### DIFF
--- a/packages/dart/noports_core/lib/src/common/srvd_latency_checker.dart
+++ b/packages/dart/noports_core/lib/src/common/srvd_latency_checker.dart
@@ -66,13 +66,14 @@ class AtLatencyChecker {
       }
     }
 
+    logger.info('Client RV latencies: $clientLatencies');
+    logger.info('Daemon RV latencies: $daemonLatencies');
+
     if (bestRv == null) {
       throw StateError('No reachable RV found');
     }
-    logger.info('Client RV latencies: $clientLatencies');
-    logger.info('Daemon RV latencies: $daemonLatencies');
+
     logger.info('Selecting best RV: $bestRv');
-    
     return bestRv;
   }
 }

--- a/packages/dart/noports_core/lib/src/common/srvd_latency_checker.dart
+++ b/packages/dart/noports_core/lib/src/common/srvd_latency_checker.dart
@@ -1,0 +1,78 @@
+import 'dart:io';
+
+import 'package:at_utils/at_logger.dart';
+
+const Map<String, List<String>> rvServers = {
+  '@rv_ap': ['91.242.241.90', '38.180.106.94'],
+  '@rv_eu': ['195.54.161.125', '38.180.8.69'],
+  '@rv_am': ['185.28.119.179', '38.180.89.181'],
+  '@rv_oc': ['139.99.184.231', '38.180.128.36'],
+};
+
+class AtLatencyChecker {
+  static AtSignLogger logger = AtSignLogger('AtLatencyChecker');
+
+  Future<int> _getLatency(
+    String host, {
+    int port = 443,
+    Duration timeout = const Duration(seconds: 5),
+  }) async {
+    final stopwatch = Stopwatch()..start();
+    try {
+      final socket = await Socket.connect(host, port, timeout: timeout);
+      final latency = stopwatch.elapsedMilliseconds;
+      socket.destroy();
+      return latency;
+    } on SocketException catch (e) {
+      logger.warning('Failed to connect to $host:$port | $e');
+      return -1;
+    } catch (e) {
+      logger.severe('getLatency failed for $host:$port | $e');
+      return -1;
+    } finally {
+      stopwatch.stop();
+    }
+  }
+
+  Future<Map<String, int>> getRvLatencyMap() async {
+    final latencyMap = <String, int>{};
+    for (final rv in rvServers.keys) {
+      int latency = -1;
+      for (final ip in rvServers[rv]!) {
+        latency = await _getLatency(ip);
+        if (latency >= 0) break; // got a response, no need to try the next IP
+      }
+      latencyMap[rv] = latency;
+    }
+    return latencyMap;
+  }
+
+  String getBestRv(
+    Map<String, int> daemonLatencies,
+    Map<String, int> clientLatencies,
+  ) {
+    String? bestRv;
+    double bestAverage = -1;
+
+    for (final rv in daemonLatencies.keys) {
+      final d = daemonLatencies[rv] ?? -1;
+      final c = clientLatencies[rv] ?? -1;
+      if (d == -1 || c == -1) continue; // skip unreachable RVs
+
+      final average = (d + c) / 2;
+      if (bestAverage == -1 || average < bestAverage) {
+        bestAverage = average;
+        bestRv = rv;
+      }
+    }
+
+    if (bestRv == null) {
+      throw StateError('No reachable RV found');
+    }
+    logger.info('Client RV latencies: $clientLatencies');
+    logger.info('Daemon RV latencies: $daemonLatencies');
+    logger.info('Selecting best RV: $bestRv');
+    
+    return bestRv;
+  }
+}

--- a/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
@@ -343,16 +343,12 @@ class SshnpParams extends ClientParamsBase
         (throw ArgumentError('from (clientAtSign) is mandatory'));
 
     if (!(partial.listDevices ?? DefaultSshnpArgs.listDevices)) {
-      // if list-devices is not set, then ensure sshnpdAtSign and srvdAtSign are set
+      // if list-devices is not set, then ensure sshnpdAtSign is set
       partial.sshnpdAtSign ??
           (throw ArgumentError(
             'Option to is mandatory, unless list-devices is passed.',
           ));
-      partial.srvdAtSign ??
-          (throw ArgumentError(
-            'srvdAtSign is mandatory, unless list-devices is passed.',
-          ));
-    }
+      }
 
     String device = partial.device ?? DefaultSshnpArgs.device;
     device = snakifyDeviceName(device);

--- a/packages/dart/noports_core/lib/src/sshnp/util/rv_selector.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/rv_selector.dart
@@ -1,0 +1,35 @@
+import 'package:at_client/at_client.dart';
+import 'package:noports_core/src/sshnp/util/sshnpd_channel/sshnpd_channel.dart';
+import 'package:noports_core/sshnp.dart';
+import 'package:noports_core/src/common/default_args.dart';
+import 'package:noports_core/src/sshnp/util/sshnpd_channel/sshnpd_default_channel.dart';
+import 'package:noports_core/src/common/srvd_latency_checker.dart';
+import 'package:uuid/uuid.dart';
+
+/// Selects the best RV atsign for a given connection.
+///
+/// Measures latency from both the client and the daemon to all known RVs,
+/// then returns the atsign of the RV with the lowest combined average latency.
+///
+/// If [channel] is provided (e.g. reusing an already-created session channel),
+/// it will be used directly. Otherwise a temporary channel is created.
+Future<String> selectBestRv(
+  AtClient atClient,
+  SshnpParams params, {
+  SshnpdChannel? channel,
+}) async {
+  final checker = AtLatencyChecker();
+
+  channel ??= SshnpdDefaultChannel(
+    atClient: atClient,
+    params: params,
+    sessionId: Uuid().v4(),
+    namespace: DefaultArgs.namespace,
+  );
+
+  final clientLatency = await checker.getRvLatencyMap();
+  final deviceLatency = await channel.getRvLatencyDevice();
+  channel = null;
+
+  return checker.getBestRv(deviceLatency, clientLatency);
+}

--- a/packages/dart/noports_core/lib/src/sshnp/util/sshnpd_channel/sshnpd_channel.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/sshnpd_channel/sshnpd_channel.dart
@@ -319,19 +319,21 @@ abstract class SshnpdChannel
   Future<Map<String, int>> getRvLatencyDevice() async {
     final completer = Completer<Map<String, int>>();
     late StreamSubscription<AtNotification> subscription;
-    subscription = subscribe(
-      regex: 'rv_latency.${params.device}.${DefaultArgs.namespace}',
-      shouldDecrypt: true,
-    ).listen((notification) {
-      logger.info(
-        'Received rv_latencies from device ${notification.from} : ${notification.key} : ${notification.value}',
-      );
-      if (notification.from == params.sshnpdAtSign && !completer.isCompleted) {
-        final Map<String, dynamic> raw = jsonDecode(notification.value ?? '{}');
-        completer.complete(Map<String, int>.from(raw));
-        subscription.cancel();
-      }
-    });
+    subscription =
+        subscribe(
+          regex: 'rv_latency.${params.device}.${DefaultArgs.namespace}',
+          shouldDecrypt: true,
+        ).listen((notification) {
+          logger.info('Received rv_latencies from device: ${notification.value}');
+          if (notification.from == params.sshnpdAtSign &&
+              !completer.isCompleted) {
+            final Map<String, dynamic> raw = jsonDecode(
+              notification.value ?? '{}',
+            );
+            completer.complete(Map<String, int>.from(raw));
+            subscription.cancel();
+          }
+        });
 
     /// Send a latency check notification
     await notify(

--- a/packages/dart/noports_core/lib/src/sshnp/util/sshnpd_channel/sshnpd_channel.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/sshnpd_channel/sshnpd_channel.dart
@@ -316,6 +316,40 @@ abstract class SshnpdChannel
     return completer.future;
   }
 
+  Future<Map<String, int>> getRvLatencyDevice() async {
+    final completer = Completer<Map<String, int>>();
+    late StreamSubscription<AtNotification> subscription;
+    subscription = subscribe(
+      regex: 'rv_latency.${params.device}.${DefaultArgs.namespace}',
+      shouldDecrypt: true,
+    ).listen((notification) {
+      logger.info(
+        'Received rv_latencies from device ${notification.from} : ${notification.key} : ${notification.value}',
+      );
+      if (notification.from == params.sshnpdAtSign && !completer.isCompleted) {
+        final Map<String, dynamic> raw = jsonDecode(notification.value ?? '{}');
+        completer.complete(Map<String, int>.from(raw));
+        subscription.cancel();
+      }
+    });
+
+    /// Send a latency check notification
+    await notify(
+      AtKey()
+        ..key = 'latency_check.${params.device}'
+        ..namespace = DefaultArgs.namespace
+        ..sharedBy = params.clientAtSign
+        ..sharedWith = params.sshnpdAtSign
+        ..metadata = (Metadata()..ttl = 10000),
+      'latency_check',
+      checkForFinalDeliveryStatus: false,
+      waitForFinalDeliveryStatus: false,
+      ttln: Duration(minutes: 1),
+    );
+
+    return completer.future;
+  }
+
   /// List all available devices from the daemon.
   /// Returns a [SSHPNPDeviceList] object which contains a map of device names
   /// and corresponding info, and a list of active devices (devices which also

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -14,6 +14,7 @@ import 'package:meta/meta.dart';
 import 'package:noports_core/src/common/features.dart';
 import 'package:noports_core/src/common/handle_server_events.dart';
 import 'package:noports_core/src/common/openssh_binary_path.dart';
+import 'package:noports_core/src/common/srvd_latency_checker.dart';
 import 'package:noports_core/src/events/noports_event_types.dart';
 import 'package:noports_core/src/srv/relay_authenticators.dart';
 import 'package:noports_core/src/srv/srv.dart';
@@ -188,7 +189,12 @@ class SshnpdImpl
     try {
       SshnpdParams p;
       try {
-        p = await SshnpdParams.fromArgs(args, helpCallback: helpCallback, versionCallback: versionCallback, doctorCallback: doctorCallback);
+        p = await SshnpdParams.fromArgs(
+          args,
+          helpCallback: helpCallback,
+          versionCallback: versionCallback,
+          doctorCallback: doctorCallback,
+        );
       } on FormatException catch (e) {
         throw ArgumentError(e.message);
       }
@@ -240,8 +246,10 @@ class SshnpdImpl
 
       if (p.clearCachedPKs) {
         sshnpd.logger.shout('Clearing cached public keys');
-        sshnpd.logger.shout('Note: locally cached public keys are no longer'
-          ' used by sshnpd');
+        sshnpd.logger.shout(
+          'Note: locally cached public keys are no longer'
+          ' used by sshnpd',
+        );
         await clearLocallyCachedPKs(
           logger: sshnpd.logger,
           fs: LocalFileSystem(),
@@ -430,6 +438,14 @@ class SshnpdImpl
           _handleNptRequestNotification(notification, auth);
           break;
 
+        case 'latency_check':
+          logger.info(
+            '$messageType received from ${notification.from}'
+            ' ( ${notification.value})',
+          );
+          await _handleLatencyCheckRequest(notification);
+          break;
+
         default:
           logger.warning(
             'unknown "$messageType" request received from ${notification.from}'
@@ -592,12 +608,30 @@ class SshnpdImpl
       ..metadata = (Metadata()
         ..isPublic = false
         ..isEncrypted = true
-        ..ttl =
-            10000 // allow only ten seconds before this record expires
+        ..ttl = 10000
         ..namespaceAware = true);
 
     /// send a heartbeat back
     unawaited(_notify(atKey: atKey, value: jsonEncode(pingResponse)));
+  }
+
+  Future<void> _handleLatencyCheckRequest(AtNotification notification) async {
+    final rvLatencyMap = await AtLatencyChecker().getRvLatencyMap();
+    logger.finer('Got latency map: $rvLatencyMap');
+
+    var atKey = AtKey()
+      ..key = 'rv_latency.$device'
+      ..sharedBy = deviceAtsign
+      ..sharedWith = notification.from
+      ..namespace = DefaultArgs.namespace
+      ..metadata = (Metadata()
+        ..isPublic = false
+        ..isEncrypted = true
+        ..ttl =
+            10000 // allow only ten seconds before this record expires
+        ..namespaceAware = true);
+
+    await _notify(atKey: atKey, value: jsonEncode(rvLatencyMap));
   }
 
   Future<void> _handlePublicKeyNotification(AtNotification notification) async {

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -608,7 +608,8 @@ class SshnpdImpl
       ..metadata = (Metadata()
         ..isPublic = false
         ..isEncrypted = true
-        ..ttl = 10000
+        ..ttl =
+            10000 // allow only ten seconds before this record expires
         ..namespaceAware = true);
 
     /// send a heartbeat back

--- a/packages/dart/noports_core/lib/sshnp_foundation.dart
+++ b/packages/dart/noports_core/lib/sshnp_foundation.dart
@@ -18,6 +18,7 @@ export 'src/sshnp/models/sshnp_device_list.dart';
 // Sshnp Utils
 export 'src/sshnp/util/sshnpd_channel/sshnpd_channel.dart';
 export 'src/sshnp/util/sshnpd_channel/sshnpd_default_channel.dart';
+export 'src/sshnp/util/rv_selector.dart';
 
 export 'src/sshnp/util/srvd_channel/srvd_channel.dart';
 export 'src/sshnp/util/srvd_channel/srvd_dart_channel.dart';

--- a/packages/dart/sshnoports/lib/src/create_sshnp.dart
+++ b/packages/dart/sshnoports/lib/src/create_sshnp.dart
@@ -22,6 +22,11 @@ Future<Sshnp> createSshnp(
     throw ArgumentError(
         'atClient must be provided or atClientGenerator must be provided');
   }
+  if (params.srvdAtSign.isEmpty) {
+    // if srvdAtSign is not provided, auto select the best rv
+    final bestRv = await selectBestRv(atClient, params);
+    params = SshnpParams.merge(params, SshnpPartialParams(srvdAtSign: bestRv));
+  }
 
   switch (sshClient) {
     case SupportedSshClient.openssh:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Closes **https://github.com/atsign-foundation/noports/issues/294**

**- What I did**
- Allow noports to auto-select best RV when not provided through args

**- How I did it**
- Introduced `LatencyChecker` uses hard-coded RV IPs to create a dummy socket and calculate client/device latencies to all available RVs.
- Client sends a notification to the device requesting its latencies to all available RVs. 
- Then the client does the same calculation of RV latencies.
- Then selects the RV with the best average of client latency and device latency.

**- How to verify it**
- Tests pass here
- Manually: try running sshnp without the `-r` param and noports should pick up the best RV automatically
- Example from my testing:
For a device running in San Jose and the client running in India:
``` 
INFO|2026-03-31 17:33:24.708027|AtLatencyChecker|Client RV latencies: {@rv_ap: 47, @rv_eu: 241, @rv_am: 216, @rv_oc: 137} 
INFO|2026-03-31 17:33:24.708042|AtLatencyChecker|Daemon RV latencies: {@rv_ap: 179, @rv_eu: 145, @rv_am: 30, @rv_oc: 164} 
INFO|2026-03-31 17:33:24.708050|AtLatencyChecker|Selecting best RV: @rv_ap 
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
feat: auto select best RV