### PR TITLE
build(deps): Add 7 day cooldown for all package ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:
@@ -18,6 +20,8 @@ updates:
       - "/tests/end2end_tests/image/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
       docker:
         patterns:
@@ -29,6 +33,8 @@ updates:
       - "/apps/admin/admin_api/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
       pub:
         patterns:


### PR DESCRIPTION
Progresses https://github.com/atsign-foundation/operations/issues/375

**- What I did**

Added cooldown block to each dependency

**- How I did it**

Copied from npm

**- How to verify it**

:eyes: on future Dependabot bumps

**- Description for the changelog**

build(deps): Add 7 day cooldown for all package ecosystems
