### PR TITLE
ci: Use more recent MacOS runners

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -54,13 +54,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-13
+          - os: macos-15-intel
             output-name: sshnpd-macos-x64
             ext: ""
             bundle: "shell"
             compiler: "clang"
             flags: "-Wno-error -pthread"
-          - os: macos-14
+          - os: macos-latest
             output-name: sshnpd-macos-arm64
             ext: ""
             bundle: "shell"


### PR DESCRIPTION
MacOS parts of c1.0.18 release [failed to build](https://github.com/atsign-foundation/noports/actions/runs/24403094347) due to runner types being deprecated.

**- What I did**

Updated to newer runners.

**- How I did it**

Based on runners used in Dart multibuild.

**- How to verify it**

Re-release c1.0.18

**- Description for the changelog**

ci: Use more recent MacOS runners