### PR TITLE
fix: Remove unecessary condition for native build packaging

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -83,8 +83,7 @@ jobs:
           mkdir tarball
           mv build/sshnpd .
           mv build/at_activate .
-      - if: ${{ matrix.os == 'macOS-13' || matrix.os == 'macos-14'}}
-        name: Zip the build
+      - name: Zip the build
         run: zip tarball/${{ matrix.output-name }}.zip sshnpd at_activate
       - name: Upload archives
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0


### PR DESCRIPTION
c1.0.18 build still [failing](https://github.com/atsign-foundation/noports/actions/runs/24404110886)

**- What I did**

Removed if statement that was referencing older runner types (as it's not needed now)

**- How to verify it**

Re-release c1.0.18

**- Description for the changelog**

fix: Remove unecessary condition for native build packaging
