### PR TITLE
build(deps): Add cooldown exceptions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+      exclude:
+      - "atsigncompany/*"
     groups:
       docker:
         patterns:
@@ -35,6 +37,8 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+      exclude:
+      - "at_*"
     groups:
       pub:
         patterns:


### PR DESCRIPTION
We don't need cooldowns for stuff we make for ourselves.

**- What I did**

Added exceptions to the cooldowns for our containers and pub packages.

(NB base images now have cooldowns from https://github.com/atsign-foundation/operations/issues/389

**- How I did it**

Wildcard based `exclude:` blocks in YAML (based on files found with a search for [path:**/dependabot.yml cooldown exclude](https://github.com/search?q=path%3A**%2Fdependabot.yml+cooldown+exclude&type=code&ref=advsearch))

**- How to verify it**

:eyes: on Dependabot updates after we've bumped dockerfiles or pub packages.

**- Description for the changelog**

build(deps): Add cooldown exceptions
