### PR TITLE
ci: Use Atsign fork of gChat action

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -462,7 +462,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Google Chat Notification
-        uses: Co-qn/google-chat-notification@3691ccf4763537d6e544bc6cdcccc1965799d056 # v1
+        uses: atsign-company/google-chat-notification@69f3920c9c9372c296112b25eaea0bddab9ee115 # v2.0.1
         with:
           name:
             SSH no ports binaries build by GitHub Action ${{ github.run_number


### PR DESCRIPTION
Progresses https://github.com/atsign-foundation/operations/issues/404

**- What I did**

Replaced Co-qn action (Node 16) with Atsign fork (Node 24)

**- How I did it**

Based on [self test workflow](https://github.com/atsign-company/google-chat-notification/actions/workflows/selftest.yml) in the fork repo

**- How to verify it**

:eyes: workflow logs

**- Description for the changelog**

ci: Use Atsign fork of gChat action
