### PR TITLE
feat: Container detection, Use tarball for headless install

### DIFF
--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -92,6 +92,14 @@ is_systemd_available() {
   [ -d /run/systemd/system ]
 }
 
+is_container() {
+  [ -f /.dockerenv ] || \
+    [ -f /.dockerinit ] || \
+    [ -f /run/.containerenv ] || \
+    [ -n "${container:-}" ] || \
+    { [ -f /proc/1/cgroup ] && grep -q -E 'docker|kubepods|containerd|lxc' /proc/1/cgroup; }
+}
+
 check_quiet() {
   for arg in "$@"; do
     if [ "$arg" = "-q" ] || [ "$arg" = "--quiet" ]; then
@@ -783,6 +791,11 @@ client() {
 
 # DEVICE INSTALLATION #
 device() {
+  if is_container; then
+    >&2 echo "Error: Device installation cannot succeed inside a container because"
+    >&2 echo "there is no init process to run the daemon."
+    exit 1
+  fi
   unset device_install_type
   if [ -z "$device_type" ]; then
     if is_darwin; then

--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -1339,9 +1339,9 @@ main() {
     echo "Using local archive: $local_archive"
     cp "$local_archive" "$archive_path"
     unpack_archive
-  elif ! $no_sudo && [ "$platform_name" = "linux" ] && is_debian_like && (check_cmd apt || check_cmd apt-get); then
+  elif [ "${device_type:-}" != "headless" ] && ! $no_sudo && [ "$platform_name" = "linux" ] && is_debian_like && (check_cmd apt || check_cmd apt-get); then
     install_via_apt
-  elif ! $no_sudo && [ "$platform_name" = "linux" ] && is_redhat_like && (check_cmd dnf || check_cmd yum); then
+  elif [ "${device_type:-}" != "headless" ] && ! $no_sudo && [ "$platform_name" = "linux" ] && is_redhat_like && (check_cmd dnf || check_cmd yum); then
     install_via_rpm
   elif [ "$platform_name" = "macos" ] && check_cmd brew; then
     if [ "$quiet" = true ]; then


### PR DESCRIPTION
Fixes #2686 and #2687

**- What I did**

* Detect if running in a container when installing a device and exit with error message
* Install from tarball if headless install is defined (as scripts aren't in apt/yum packages) 

**- How I did it**

`agy` prompts:

```txt
People have been trying to install NoPorts into containers using the
universal.sh script, which fails because there isn't an init process to run
the daemon. So the script should detect whether it's running in a container,
warn that a device installation cannot succeed, and then exit.
Modify the script, but do not run any git commands.

the container check should only happen when the script gets to the device
install section, as a client install would be fine in a container.
```

```txt
some time ago universal.sh was adapted to prefer installation from apt/yum
packages, with the assumption that services would be run using systemd.
Those packages don't work for a headless install, as they don't have the
shell/headless bundle in them (which is in the NoPorts tarball).
Change the script logic so that if a headless install is specified then the
tarball is used to source the relevant scripts.
```

**- How to verify it**

Run `universal.sh` in a container and select device install type:

```log
Error: Device installation cannot succeed inside a container because
there is no init process to run the daemon.
```

**- Description for the changelog**

feat: Container detection, Use tarball for headless install
