### PR TITLE
fix: Trust our brew tap when used with brew => 6

### DIFF
--- a/packages/dart/sshnoports/bundles/universal.sh
+++ b/packages/dart/sshnoports/bundles/universal.sh
@@ -1269,6 +1269,14 @@ install_via_brew() {
   fi
 
   brew tap atsign-foundation/homebrew-tap
+
+  # Trust the tap if Homebrew version is 6 or later
+  brew_version=$(brew --version 2>/dev/null | head -n 1 | cut -d' ' -f2 | cut -d'.' -f1 || true)
+  if [ -n "$brew_version" ] && [ "$brew_version" -ge 6 ] 2>/dev/null; then
+    echo "Brew version 6 or later detected ($brew_version). Trusting tap atsign-foundation/homebrew-tap..."
+    brew trust atsign-foundation/homebrew-tap
+  fi
+
   brew install noports
   used_package_manager=true
 }


### PR DESCRIPTION
Fixes #2751 

**- What I did**

* test for brew => 6
  * add trust if recent brew detected

**- How I did it**

agy prompt:

```log
> mac installs using universal.sh to run brew are failing with brew 6 because
  it needs to trust our brew tap. Add a test for which version of brew is
  running, and if it's 6 or later run the commands to trust our tap before
  trying to install from it. Don't run any git commands, I'll do that after
  reviewing the change
```

**- How to verify it**

CI for https://github.com/atsign-foundation/homebrew-tap being modified to follow pattern

**- Description for the changelog**

fix: Trust our brew tap when used with brew => 6
