### PR TITLE
test(npe2e): support running e2e packs against a local atStack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Keeps the Docker build context lean for builds that use the repo root as
+# their context (COPY . .):
+#   - the npe2e image builds (tests/npe2e/tools/dockerfiles/Dockerfile.*.current)
+#   - the published sshnpd image (packages/dart/sshnoports/tools/Dockerfile.*,
+#     built with `context: .` in .github/workflows/dockerhub_sshnpd.yml)
+#
+# Only non-source artefacts are excluded. The Dart image builds still get
+# everything they compile: packages/dart/{sshnoports,noports_core}, the repo's
+# pubspec.lock files (required by `dart pub get --enforce-lockfile`), and
+# tools/static-openssh.
+
+# melos writes host-absolute dependency paths into pubspec_overrides.yaml; those
+# paths don't exist inside the container and break `dart pub get`. The file is
+# gitignored, so it is absent on a clean CI checkout (this line is a no-op there)
+# and only matters on a developer's machine that has run `melos bootstrap`.
+**/pubspec_overrides.yaml
+
+# VCS metadata and generated/local build state
+.git
+.github
+**/.dart_tool/
+**/build/
+
+# Repo areas that no image build compiles
+tests/
+apps/
+docs/
+images/
+
+# npe2e test output written at the repo root
+npe2e_core_tests/
+npe2e_*/
+
+# logs and editor scratch
+**/*.log
+**/*.swp

--- a/tests/npe2e/README.md
+++ b/tests/npe2e/README.md
@@ -1,0 +1,156 @@
+# npe2e
+
+End-to-end tests for NoPorts. The harness compiles the current binaries, builds
+daemon Docker images (Dart and C, `current` plus a few released versions),
+enrols APKAM keys for the client and daemon atSigns, starts each daemon in its
+own container, then runs the client (`npt` / `sshnp`) on the host against those
+containerised daemons through a relay (`srvd`).
+
+In CI these run against the public atDirectory (`root.atsign.org`). This README
+covers running them **locally against a local atStack** — the usual reason being
+to test an atServer that has not been released to production yet.
+
+There are three test packs, each with its own entrypoint under `bin/`:
+
+| Pack | Entrypoint |
+| --- | --- |
+| core | `bin/core_tests.dart` |
+| relay | `bin/relay_tests.dart` |
+| policy | `bin/policy_tests.dart` |
+
+The examples below use the core pack; the others take the same arguments.
+
+## Prerequisites
+
+- Docker (Docker Desktop on macOS).
+- The Dart SDK.
+- `expect`, `ssh-keygen`, `git`, `chmod`, `sh` on `PATH` (the harness checks
+  these on startup).
+
+## Running against a local atStack
+
+### 1. Point the test domain at your machine
+
+Add the domain your local atStack uses to `/etc/hosts`, mapped to loopback:
+
+```
+127.0.0.1 vip.ve.atsign.zone
+```
+
+Your host processes now resolve `vip.ve.atsign.zone` to your local atStack. The
+containerised daemons are handled separately — see step 4.
+
+### 2. Start your local atStack
+
+Bring up your atDirectory and the atServers for the client, daemon and relay
+atSigns, all on the domain from step 1. The atDirectory must listen on port 64,
+and the atServers and atDirectory must bind `0.0.0.0` (not `127.0.0.1` only), or
+the containers won't be able to reach them (see step 4).
+
+### 3. The Docker build context (`.dockerignore`)
+
+The daemon images build with the repo root as their context. The repo-root
+`.dockerignore` keeps `melos`-managed `pubspec_overrides.yaml` files out of that
+context: those pin dependencies to host-absolute paths that don't exist inside
+the container, so without this the in-container `dart pub get` fails. The file
+is committed and is a no-op on a clean CI checkout (the overrides are
+gitignored), so there's nothing to do here — just don't delete it.
+
+### 4. Container-to-host networking (automatic)
+
+A container can't inherit your `/etc/hosts`, and `127.0.0.1` inside a container
+is the container itself, not your host. So the harness reads your `/etc/hosts`
+and, for every `127.0.0.1 *.atsign.zone` entry, injects
+`--add-host <name>:host-gateway` into each daemon container. `host-gateway` is
+Docker's route back to the host, so the containerised daemons resolve the test
+domains to your machine. This is automatic; there are no flags for it. It is
+scoped to `*.atsign.zone` names, so unrelated `/etc/hosts` entries and
+deliberate black-holes such as `127.1.1.1 unreachable.atsign.zone` are left
+alone.
+
+### 5. Start the relay (`srvd`)
+
+The tests need a rendezvous relay running as the relay atSign. Two things
+matter for a local run:
+
+- **Advertise a host-resolvable name.** Use `-i vip.ve.atsign.zone`, not
+  `-i 127.0.0.1`. `srvd` binds its rendezvous ports to `0.0.0.0` and only
+  *advertises* the `-i` value to clients, so the name just has to resolve to
+  your host on both sides — the host client resolves it via `/etc/hosts`, the
+  container daemon resolves it via the injected `--add-host` from step 4. With
+  `-i 127.0.0.1` the container would dial its own loopback and time out.
+- **Drop `--443` for local runs.** It needs a privileged port (so `sudo`), and
+  the packs don't require it.
+
+```
+srvd -a @relay -i vip.ve.atsign.zone -v --root-domain vip.ve.atsign.zone
+```
+
+Wait for `monitor started` in its output before running the pack.
+
+### 6. Run the pack
+
+```
+dart run tests/npe2e/bin/core_tests.dart \
+  --client-atsign @client \
+  --daemon-atsign @service \
+  --relay-atsign @relay \
+  --root-domain vip.ve.atsign.zone \
+  --base-directory npe2e_core_tests \
+  --batch-size 5
+```
+
+## Re-running on the same commit
+
+`--test-run-id` defaults to the short git commit hash, so re-runs on the same
+commit reuse `<base-directory>/<testRunId>/` and the daemon container names
+(which embed the testRunId). Two bits of state carry over between runs on the
+same commit:
+
+- `at_activate enroll` fails if the APKAM keys already exist in the run
+  directory, so delete it:
+
+  ```
+  rm -rf npe2e_core_tests/<testRunId>
+  ```
+
+- the daemon containers aren't removed when the harness exits, so the next run
+  hits a `container name ... already in use` conflict. Remove them first:
+
+  ```
+  docker rm -f $(docker ps -aq --filter name=npe2e) 2>/dev/null
+  ```
+
+Either clear both, or pass a fresh `--test-run-id`.
+
+## Arguments
+
+| Argument | Default | Notes |
+| --- | --- | --- |
+| `--client-atsign` | (required) | Client atSign used in tests |
+| `--daemon-atsign` | (required) | Daemon atSign used in tests |
+| `--relay-atsign` | (required) | Relay atSign used in tests |
+| `--root-domain` | `root.atsign.org:64` | atDirectory host:port; set to your local domain |
+| `--base-directory` | `npe2e_core` | Where run artefacts (binaries, keys, logs) are written |
+| `--client-versions` | `d:v5.9.4,d:v5.11.2,d:v5.13.0,d:current` | Comma-separated `language:version` |
+| `--daemon-versions` | `d:v5.9.4,d:v5.11.2,d:v5.13.0,d:current,c:current` | Comma-separated `language:version` |
+| `--batch-size` | `4` | Tests run concurrently per batch |
+| `--max-retries` | `3` | Retries for a failing test |
+| `--test-timeout-seconds` | `300` | Per-test timeout before fail/retry |
+| `--test-run-id` | short git hash | Overrides the run directory name |
+| `--verbose` | `false` | More logging |
+
+## Troubleshooting
+
+- **`error from sender: lstat ... permission denied` during an image build.** A
+  path in the repo has no read/traverse permission and is leaking into the build
+  context. The `.dockerignore` trims the context to source; make sure any scratch
+  in your working tree is readable (a directory needs its execute bit to be
+  traversed).
+- **`Unable to authenticate ... Connection refused ... :64` in a daemon log.**
+  The container can't reach your atDirectory. Check the `/etc/hosts` entry is a
+  `*.atsign.zone` name, that your atDirectory is up on port 64, and that it binds
+  `0.0.0.0` rather than `127.0.0.1` only.
+- **`Connection timeout to srvd @relay service`.** `srvd` isn't running or isn't
+  reachable from the containers. Confirm it's up and started with
+  `-i vip.ve.atsign.zone` (not `-i 127.0.0.1`).

--- a/tests/npe2e/lib/core_tests/core_tests_docker_utils.dart
+++ b/tests/npe2e/lib/core_tests/core_tests_docker_utils.dart
@@ -52,48 +52,6 @@ Future<List<DockerImage>> ensureDockerDaemonsBuiltParallel({
   );
 }
 
-// Local-run aid: when the npe2e tests run against atServers on the developer's
-// own machine (reached via `/etc/hosts` overrides such as
-// `127.0.0.1 vip.ve.atsign.zone`), mirror those overrides into the daemon
-// containers. A container can't reach the host on 127.0.0.1, so each mapped
-// name is re-pointed at `host-gateway`, Docker's route back to the host.
-//
-// Scoped to `*.atsign.zone` names mapped to 127.0.0.1: that covers the atsign
-// test domains without touching unrelated /etc/hosts entries, and it leaves
-// deliberate black-holes (e.g. `127.1.1.1 unreachable.atsign.zone`) alone. On a
-// clean CI checkout there are no such entries, so this returns nothing (the
-// harness normally runs against the public root.atsign.org).
-List<String> hostGatewayAddHostArgs() {
-  final File hostsFile = File('/etc/hosts');
-  if (!hostsFile.existsSync()) {
-    return const <String>[];
-  }
-
-  final Set<String> names = <String>{};
-  for (String line in hostsFile.readAsLinesSync()) {
-    final int hash = line.indexOf('#');
-    if (hash >= 0) {
-      line = line.substring(0, hash);
-    }
-    final List<String> parts = line.trim().split(RegExp(r'\s+'));
-    if (parts.length < 2 || parts.first != '127.0.0.1') {
-      continue;
-    }
-    for (final String name in parts.skip(1)) {
-      if (name.endsWith('.atsign.zone')) {
-        names.add(name);
-      }
-    }
-  }
-
-  final List<String> args = <String>[];
-  for (final String name in names) {
-    args.add('--add-host');
-    args.add('$name:host-gateway');
-  }
-  return args;
-}
-
 // starts a collection of DockerInstance objects in parallel
 // for each daemonVersion, we will start 2 docker instances:
 // 1. one without -s -u flag (deviceName will be `getDeviceNameNoFlags()`

--- a/tests/npe2e/lib/core_tests/core_tests_docker_utils.dart
+++ b/tests/npe2e/lib/core_tests/core_tests_docker_utils.dart
@@ -52,6 +52,48 @@ Future<List<DockerImage>> ensureDockerDaemonsBuiltParallel({
   );
 }
 
+// Local-run aid: when the npe2e tests run against atServers on the developer's
+// own machine (reached via `/etc/hosts` overrides such as
+// `127.0.0.1 vip.ve.atsign.zone`), mirror those overrides into the daemon
+// containers. A container can't reach the host on 127.0.0.1, so each mapped
+// name is re-pointed at `host-gateway`, Docker's route back to the host.
+//
+// Scoped to `*.atsign.zone` names mapped to 127.0.0.1: that covers the atsign
+// test domains without touching unrelated /etc/hosts entries, and it leaves
+// deliberate black-holes (e.g. `127.1.1.1 unreachable.atsign.zone`) alone. On a
+// clean CI checkout there are no such entries, so this returns nothing (the
+// harness normally runs against the public root.atsign.org).
+List<String> hostGatewayAddHostArgs() {
+  final File hostsFile = File('/etc/hosts');
+  if (!hostsFile.existsSync()) {
+    return const <String>[];
+  }
+
+  final Set<String> names = <String>{};
+  for (String line in hostsFile.readAsLinesSync()) {
+    final int hash = line.indexOf('#');
+    if (hash >= 0) {
+      line = line.substring(0, hash);
+    }
+    final List<String> parts = line.trim().split(RegExp(r'\s+'));
+    if (parts.length < 2 || parts.first != '127.0.0.1') {
+      continue;
+    }
+    for (final String name in parts.skip(1)) {
+      if (name.endsWith('.atsign.zone')) {
+        names.add(name);
+      }
+    }
+  }
+
+  final List<String> args = <String>[];
+  for (final String name in names) {
+    args.add('--add-host');
+    args.add('$name:host-gateway');
+  }
+  return args;
+}
+
 // starts a collection of DockerInstance objects in parallel
 // for each daemonVersion, we will start 2 docker instances:
 // 1. one without -s -u flag (deviceName will be `getDeviceNameNoFlags()`
@@ -70,6 +112,11 @@ Future<List<(String, DockerInstance)>> startDockerDaemonsParallel({
   daemonApkamKeysFile, // atKeys file of daemon to put into the container
 }) async {
   final List<(String, DockerInstance)> dockerInstances = [];
+  final List<String> addHostArgs = hostGatewayAddHostArgs();
+  if (addHostArgs.isNotEmpty) {
+    print('Injecting host /etc/hosts overrides into daemon containers: '
+        '${addHostArgs.join(' ')}');
+  }
   for (final NoPortsVersion daemonVersion in daemonVersions) {
     final DockerImage dockerImage = allDockerImages.firstWhere(
       (image) =>
@@ -107,6 +154,7 @@ Future<List<(String, DockerInstance)>> startDockerDaemonsParallel({
       quiet: false,
       removeWhenStopped: true,
       volumeMappings: [volumeMapping],
+      additionalDockerArgs: addHostArgs,
     );
     final String deviceNameNoFlags = getDeviceNameNoFlags(
       testRunId: testRunId,
@@ -136,6 +184,7 @@ Future<List<(String, DockerInstance)>> startDockerDaemonsParallel({
       quiet: false,
       removeWhenStopped: true,
       volumeMappings: [volumeMapping],
+      additionalDockerArgs: addHostArgs,
     );
     dockerInstances.add((deviceNameWithFlags, dockerInstance2));
   }

--- a/tests/npe2e/lib/docker_utils.dart
+++ b/tests/npe2e/lib/docker_utils.dart
@@ -7,6 +7,49 @@ import 'package:npe2e/docker_instance.dart';
 import 'package:npe2e/language.dart';
 import 'package:npe2e/noports_version.dart';
 
+// Local-run aid: when the npe2e tests run against atServers on the developer's
+// own machine (reached via `/etc/hosts` overrides such as
+// `127.0.0.1 vip.ve.atsign.zone`), mirror those overrides into the containers
+// (daemon / relay / policy server / containerised client). A container can't
+// reach the host on 127.0.0.1, so each mapped name is re-pointed at
+// `host-gateway`, Docker's route back to the host.
+//
+// Scoped to `*.atsign.zone` names mapped to 127.0.0.1: that covers the atsign
+// test domains without touching unrelated /etc/hosts entries, and it leaves
+// deliberate black-holes (e.g. `127.1.1.1 unreachable.atsign.zone`) alone. On a
+// clean CI checkout there are no such entries, so this returns nothing (the
+// harness normally runs against the public root.atsign.org).
+List<String> hostGatewayAddHostArgs() {
+  final File hostsFile = File('/etc/hosts');
+  if (!hostsFile.existsSync()) {
+    return const <String>[];
+  }
+
+  final Set<String> names = <String>{};
+  for (String line in hostsFile.readAsLinesSync()) {
+    final int hash = line.indexOf('#');
+    if (hash >= 0) {
+      line = line.substring(0, hash);
+    }
+    final List<String> parts = line.trim().split(RegExp(r'\s+'));
+    if (parts.length < 2 || parts.first != '127.0.0.1') {
+      continue;
+    }
+    for (final String name in parts.skip(1)) {
+      if (name.endsWith('.atsign.zone')) {
+        names.add(name);
+      }
+    }
+  }
+
+  final List<String> args = <String>[];
+  for (final String name in names) {
+    args.add('--add-host');
+    args.add('$name:host-gateway');
+  }
+  return args;
+}
+
 DockerImage dockerImageForVersion(final NoPortsVersion version) {
   final Language language = version.language;
   final String versionTag = version.version;

--- a/tests/npe2e/lib/policy_tests/policy_flow_shared.dart
+++ b/tests/npe2e/lib/policy_tests/policy_flow_shared.dart
@@ -624,6 +624,8 @@ Future<DockerInstance> startPolicyFlowDaemon({
           '-v -s -u',
     ],
     printCommand: false,
+    // Local-run aid: let the container resolve *.atsign.zone back to the host.
+    additionalDockerArgs: hostGatewayAddHostArgs(),
     volumeMappings: [
       VolumeMapping(
         local: daemonApkamKeysFile.absolute.path,

--- a/tests/npe2e/lib/policy_tests/policy_server.dart
+++ b/tests/npe2e/lib/policy_tests/policy_server.dart
@@ -145,6 +145,8 @@ class PolicyServer {
         rootDomain,
         ...additionalArgs,
       ],
+      // Local-run aid: let the container resolve *.atsign.zone back to the host.
+      additionalDockerArgs: hostGatewayAddHostArgs(),
       volumeMappings: [
         VolumeMapping(
           local: apkamKeysFile.absolute.path,

--- a/tests/npe2e/lib/relay_tests/relay_test_flow_shared.dart
+++ b/tests/npe2e/lib/relay_tests/relay_test_flow_shared.dart
@@ -616,6 +616,8 @@ Future<DockerInstance> _startDaemon({
     uniqueIdentifier:
         '_relay_daemon_${daemonVersion.language.name}_${daemonVersion.version}',
     networkName: networkName,
+    // Local-run aid: let the container resolve *.atsign.zone back to the host.
+    additionalDockerArgs: hostGatewayAddHostArgs(),
     entrypoint: [
       '/bin/bash',
       '-c',
@@ -675,7 +677,12 @@ Future<DockerInstance> _startSelfRelay({
         '_relay_${relayVersion.language.name}_${relayVersion.version}_$metadata',
     networkName: networkName,
     networkAlias: relayAlias,
-    additionalDockerArgs: relayOnly443 ? ['--user', 'root'] : const [],
+    // Local-run aid: let the container resolve *.atsign.zone back to the host,
+    // alongside the --user root needed by the 443 relay.
+    additionalDockerArgs: [
+      ...hostGatewayAddHostArgs(),
+      if (relayOnly443) ...['--user', 'root'],
+    ],
     entrypoint: srvdArgs,
     volumeMappings: [
       VolumeMapping(
@@ -763,6 +770,8 @@ Future<DockerInstance> _runClientCommand({
   return dockerInstance
       .run(
         networkName: networkName,
+        // Local-run aid: let the container resolve *.atsign.zone to the host.
+        additionalDockerArgs: hostGatewayAddHostArgs(),
         entrypoint: ['/bin/bash', '-c', script],
         volumeMappings: [
           VolumeMapping(
@@ -821,6 +830,8 @@ Future<DockerInstance> _runSshnpPrimeCommand({
   return dockerInstance
       .run(
         networkName: networkName,
+        // Local-run aid: let the container resolve *.atsign.zone to the host.
+        additionalDockerArgs: hostGatewayAddHostArgs(),
         entrypoint: ['/bin/bash', '-c', script],
         volumeMappings: [
           VolumeMapping(


### PR DESCRIPTION
## What I did

Enable running the npe2e end-to-end packs against a local atStack, so an atServer
that hasn't been released to production can be tested against the current NoPorts
client and daemon. No effect on CI, which runs against `root.atsign.org`.

## How I did it

- Added a repo-root `.dockerignore`. The npe2e image builds (and the published
  sshnpd image) build with the repo root as their Docker context. It excludes
  melos-managed `pubspec_overrides.yaml` — which pins dependencies to
  host-absolute paths that don't exist inside the container and break the
  in-container `dart pub get` — plus non-source directories. It keeps
  `pubspec.lock` (needed by `dockerhub_sshnpd.yml`'s
  `dart pub get --enforce-lockfile`) and `tools/` (used by
  `Dockerfile.sshnpd-slim`), and is a no-op on a clean CI checkout where the
  overrides are gitignored.
- Injected `--add-host <name>:host-gateway` into each daemon container in
  `startDockerDaemonsParallel`, for every `127.0.0.1 *.atsign.zone` entry in the
  host's `/etc/hosts`. A container can't reach the host on 127.0.0.1, so this
  lets the dockerised daemons resolve the developer's local test domains back to
  the host. It's scoped to `*.atsign.zone`, so unrelated `/etc/hosts` entries and
  deliberate black-holes (e.g. `127.1.1.1 unreachable.atsign.zone`) are left
  alone, and it returns nothing on a clean CI checkout.
- Added `tests/npe2e/README.md` documenting the local-atStack workflow: the
  `/etc/hosts` overrides, starting the atStack and the `srvd` relay (with a
  host-resolvable `-i`, no `--443`), running each pack, and clearing per-run
  state (run directory and leftover containers) between runs on the same commit.

## How to verify it

Against a local atStack on `vip.ve.atsign.zone` (atDirectory on :64, atServers
for @client / @service / @relay, and
`srvd -a @relay -i vip.ve.atsign.zone --root-domain vip.ve.atsign.zone`):

```
dart run tests/npe2e/bin/core_tests.dart \
  --client-atsign @client --daemon-atsign @service --relay-atsign @relay \
  --root-domain vip.ve.atsign.zone --base-directory npe2e_core_tests --batch-size 5
```

Result: core pack 73/73 passed. CI continues to run against `root.atsign.org`
unchanged — both new behaviours are no-ops on a clean checkout.

## Description for the changelog

Support running the npe2e e2e packs against a local atStack.
