### PR TITLE
test(ci): repoint legacy e2e_all job to healthy npe2e atServers

### DIFF
--- a/.github/workflows/e2e_all.yaml
+++ b/.github/workflows/e2e_all.yaml
@@ -25,10 +25,14 @@ jobs:
     # atServer-side, not code. `needs: npe2e` serializes after the npe2e matrix so
     # the shared atSigns aren't double-booked (npe2e daemons removeWhenStopped).
     needs: npe2e
-    # Don't run on PRs from a fork or Dependabot as the secrets aren't available
+    # Don't run on PRs from a fork or Dependabot as the secrets aren't available.
+    # !cancelled() lets this run once npe2e *completes* even if a leg failed
+    # (npe2e is flaky on shared infra today) — we still serialize via `needs` to
+    # avoid double-booking the shared atSigns, but a policy_tests flake must not
+    # skip our hypothesis probe.
     if:
-      ${{ github.event.pull_request.head.repo.fork == false && github.actor !=
-      'dependabot[bot]'}}
+      ${{ !cancelled() && github.event.pull_request.head.repo.fork == false &&
+      github.actor != 'dependabot[bot]'}}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/e2e_all.yaml
+++ b/.github/workflows/e2e_all.yaml
@@ -20,6 +20,11 @@ on:
 
 jobs:
   e2e_all:
+    # HYPOTHESIS TEST (do not merge): repointed from the degraded @e2e_all_v2_*
+    # atServers to the known-healthy @npe2e_org_* set to confirm the failures are
+    # atServer-side, not code. `needs: npe2e` serializes after the npe2e matrix so
+    # the shared atSigns aren't double-booked (npe2e daemons removeWhenStopped).
+    needs: npe2e
     # Don't run on PRs from a fork or Dependabot as the secrets aren't available
     if:
       ${{ github.event.pull_request.head.repo.fork == false && github.actor !=
@@ -35,14 +40,13 @@ jobs:
         run: |
           mkdir -p /tmp/e2e_all
           mkdir -p ~/.atsign/keys/
-          echo '${{ secrets.ATKEYS_E2E_ALL_V2_CLIENT_JTTEST }}' > ~/.atsign/keys/@e2e_all_v2_client_jttest_key.atKeys
-          echo '${{ secrets.ATKEYS_E2E_ALL_V2_DAEMON_JTTEST }}' > ~/.atsign/keys/@e2e_all_v2_daemon_jttest_key.atKeys
-          echo '${{ secrets.ATKEYS_E2E_ALL_V2_POLICY_JTTEST }}' > ~/.atsign/keys/@e2e_all_v2_policy_jttest_key.atKeys
-          echo '${{ secrets.ATKEYS_E2E_ALL_V2_POLICY_LATEST_JTTEST }}' > ~/.atsign/keys/@e2e_all_v2_policy_latest_jttest_key.atKeys
-          echo '${{ secrets.ATKEYS_E2E_ALL_V2_RELAY_JTTEST }}' > ~/.atsign/keys/@e2e_all_v2_relay_jttest_key.atKeys
-          echo '${{ secrets.ATKEYS_E2E_ALL_V2_RELAY_LATEST_JTTEST }}' > ~/.atsign/keys/@e2e_all_v2_relay_latest_jttest_key.atKeys
-          echo '${{ secrets.ATKEYS_E2E_ALL_V2_EVENTS_JTTEST }}' > ~/.atsign/keys/@e2e_all_v2_events_jttest_key.atKeys
-          echo '${{ secrets.ATKEYS_E2E_ALL_V2_SINGLETON_JTTEST }}' > ~/.atsign/keys/@e2e_all_v2_singleton_jttest_key.atKeys
+          # Hypothesis test: use the healthy @npe2e_org_* atSigns (secrets already exist).
+          echo '${{ secrets.ATKEYS_NPE2E_ORG_CLIENT01_JTTEST }}' > ~/.atsign/keys/@npe2e_org_client01_jttest_key.atKeys
+          echo '${{ secrets.ATKEYS_NPE2E_ORG_DAEMON01_JTTEST }}' > ~/.atsign/keys/@npe2e_org_daemon01_jttest_key.atKeys
+          echo '${{ secrets.ATKEYS_NPE2E_ORG_RELAY01_JTTEST }}'  > ~/.atsign/keys/@npe2e_org_relay01_jttest_key.atKeys
+          echo '${{ secrets.ATKEYS_NPE2E_ORG_POLICY01_JTTEST }}' > ~/.atsign/keys/@npe2e_org_policy01_jttest_key.atKeys
+          echo '${{ secrets.ATKEYS_NPE2E_ORG_POLICY02_JTTEST }}' > ~/.atsign/keys/@npe2e_org_policy02_jttest_key.atKeys
+          echo '${{ secrets.ATKEYS_NPE2E_ORG_RELAY02_JTTEST }}'  > ~/.atsign/keys/@npe2e_org_relay02_jttest_key.atKeys
 
       - name: Install expect
         run: |
@@ -51,7 +55,7 @@ jobs:
         run: |
           echo "Test started at: $(date)"
           start_time=$(date +%s)
-          tests/e2e_all/scripts/main.sh @e2e_all_v2_client_jttest @e2e_all_v2_daemon_jttest @rv_am @e2e_all_v2_relay_latest_jttest @e2e_all_v2_policy_jttest @e2e_all_v2_policy_latest_jttest @e2e_all_v2_events_jttest -p -r root.atsign.org
+          tests/e2e_all/scripts/main.sh @npe2e_org_client01_jttest @npe2e_org_daemon01_jttest @rv_am @npe2e_org_relay01_jttest @npe2e_org_policy01_jttest @npe2e_org_policy02_jttest @npe2e_org_relay02_jttest -p -r root.atsign.org
           test_exit_code=$?
           end_time=$(date +%s)
           echo "Test finished at: $(date)"

--- a/.github/workflows/e2e_all.yaml
+++ b/.github/workflows/e2e_all.yaml
@@ -20,16 +20,14 @@ on:
 
 jobs:
   e2e_all:
-    # HYPOTHESIS TEST (do not merge): repointed from the degraded @e2e_all_v2_*
-    # atServers to the known-healthy @npe2e_org_* set to confirm the failures are
-    # atServer-side, not code. `needs: npe2e` serializes after the npe2e matrix so
-    # the shared atSigns aren't double-booked (npe2e daemons removeWhenStopped).
+    # Runs on the @npe2e_org_* atSigns (see the atKeys step below). These are
+    # shared with the npe2e job, so `needs: npe2e` serializes this job after the
+    # matrix has finished and torn its daemons down (removeWhenStopped) — that
+    # avoids double-booking the same atSigns within a run.
     needs: npe2e
-    # Don't run on PRs from a fork or Dependabot as the secrets aren't available.
-    # !cancelled() lets this run once npe2e *completes* even if a leg failed
-    # (npe2e is flaky on shared infra today) — we still serialize via `needs` to
-    # avoid double-booking the shared atSigns, but a policy_tests flake must not
-    # skip our hypothesis probe.
+    # Skip on fork / Dependabot PRs (secrets unavailable). `!cancelled()` keeps
+    # this running once npe2e *completes* even if a leg failed, so a flaky npe2e
+    # leg on shared infra can't skip e2e_all via the `needs:` dependency.
     if:
       ${{ !cancelled() && github.event.pull_request.head.repo.fork == false &&
       github.actor != 'dependabot[bot]'}}
@@ -44,7 +42,9 @@ jobs:
         run: |
           mkdir -p /tmp/e2e_all
           mkdir -p ~/.atsign/keys/
-          # Hypothesis test: use the healthy @npe2e_org_* atSigns (secrets already exist).
+          # atKeys for the @npe2e_org_* atSigns this job runs against. The legacy
+          # @e2e_all_v2_* atServers went unresponsive ~2026-06-13 and produced
+          # spurious old-client timeouts; the @npe2e_org_* atServers are healthy.
           echo '${{ secrets.ATKEYS_NPE2E_ORG_CLIENT01_JTTEST }}' > ~/.atsign/keys/@npe2e_org_client01_jttest_key.atKeys
           echo '${{ secrets.ATKEYS_NPE2E_ORG_DAEMON01_JTTEST }}' > ~/.atsign/keys/@npe2e_org_daemon01_jttest_key.atKeys
           echo '${{ secrets.ATKEYS_NPE2E_ORG_RELAY01_JTTEST }}'  > ~/.atsign/keys/@npe2e_org_relay01_jttest_key.atKeys


### PR DESCRIPTION
## What I did

Repointed the legacy `e2e_all` CI job off the degraded `@e2e_all_v2_*` atServers onto the healthy `@npe2e_org_*` set, so the check goes green again. `e2e_all` had been red on every branch including trunk since ~June 13, 2026 (~3.5 weeks); the root cause is external atServer degradation, not repo code (evidence below). This is a stopgap — the `@e2e_all_v2_*` atServers still need to be repaired or `e2e_all` given its own dedicated atSigns (tracked separately).

## How I did it

`.github/workflows/e2e_all.yaml`, `e2e_all` job only:

- Repoint the 7 positional atSigns to `@npe2e_org_*` (keeping `@rv_am` as the relay). Their atKeys already exist as GitHub secrets — no new provisioning.
- `needs: npe2e` serializes this job after the npe2e matrix (which tears its Docker daemons down, `removeWhenStopped: true`) so the shared atSigns aren't double-booked within a run.
- `!cancelled()` on the `if:` so a flaky npe2e leg can't skip `e2e_all` via the `needs` dependency.

## How to verify it

Evidence the failure is atServer-side, not code:

- The trunk green→red boundary (`aafbadb` → `6d538e7`) contains only a Svelte dependabot bump — no test/harness/product change. The version matrix (`5.9.4/5.11.2/5.13.0`) has been stable in `main.sh` since Nov 2025.
- In the same workflow run, `npe2e (core_tests)` — a port of the same scenarios running the same client versions, but against `@npe2e_org_*` — passes while `e2e_all` on `@e2e_all_v2_*` fails.

Result after repointing: the full legacy suite passed **81/81 in ~6 min** (was 48/81, ~24 min on `@e2e_all_v2_*`). Reviewers can confirm on this PR's `e2e_all` check.