### PR TITLE
ci(e2e_all): make test-run-id unique per git hash and per ci run

### DIFF
--- a/.github/workflows/e2e_all.yaml
+++ b/.github/workflows/e2e_all.yaml
@@ -97,6 +97,7 @@ jobs:
                 --relay-atsign "@rv_am" \
                 --root-domain "root.atsign.org" \
                 --base-directory "$LOGS_DIR" \
+                --test-run-id "$TEST_RUN_ID" \
                 --batch-size 5
           - test_suite: policy_tests
             output_artifact: npe2e_policy_tests_artifacts
@@ -110,6 +111,7 @@ jobs:
                 --npp-atserver-atsign "@npe2e_org_policy02_jttest" \
                 --root-domain "root.atsign.org" \
                 --base-directory "$LOGS_DIR" \
+                --test-run-id "$TEST_RUN_ID" \
                 --test-timeout-seconds 480 \
                 --batch-size 2
           - test_suite: relay_tests
@@ -126,6 +128,7 @@ jobs:
                 --client-versions "d:v5.13.0,d:v5.14.13,d:current" \
                 --daemon-versions "d:v5.13.0,d:v5.14.13,d:current" \
                 --self-relay-versions "d:v5.10.0,d:v5.14.13,d:current" \
+                --test-run-id "$TEST_RUN_ID" \
                 --batch-size 3
 
     steps:
@@ -174,6 +177,11 @@ jobs:
         run: |
           echo "OUTPUT_ARTIFACT=${{ matrix.output_artifact }}" >> $GITHUB_ENV
           echo "LOGS_DIR=${{ matrix.logs_dir }}" >> $GITHUB_ENV
+          # testRunId defaults to the git commit hash, which is identical across
+          # retries/re-runs of the same commit and causes them to collide on the
+          # same APKAM device enrollment against the shared atSigns. Derive an
+          # 8-char id unique per run+attempt instead.
+          echo "TEST_RUN_ID=$(echo "${{ github.run_id }}-${{ github.run_attempt }}" | md5sum | cut -c1-8)" >> $GITHUB_ENV
 
       - name: Run npe2e ${{ matrix.test_suite }}
         run: |


### PR DESCRIPTION
**- What I did**
- Set `--test-run-id` as `md5hash({GitHash}-{GitHubRunId})`. Example: `1234567890-1` then hash would be "cbda1729..." then cut to 8 characters long "cbda1729".
- A unique test run id will ensure a non-colliding test in case we ever re-rerun the tests in the same commit hash

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
ci(e2e_all): make test-run-id unique per git hash and per ci run

