### PR TITLE
feat(srvd): per-socket relay-auth auto-detection + fresh ESCR challenge per connection

### DIFF
--- a/docs/reference/relay-auth-modes.md
+++ b/docs/reference/relay-auth-modes.md
@@ -1,0 +1,230 @@
+# Relay authentication modes
+
+How a NoPorts client and daemon decide, per session, whether to authenticate to
+the relay (`srvd`) using **ESCR** (Encrypted Signed Challenge-Response, the
+strong mode) or **legacy** (`payload`, the original mode), and what the relay
+does in each case.
+
+> Reference for the `noports_core` relay auto-detect work
+> (`RelayAuthMode`, `SrvdChannel.effectiveRelayAuthMode`,
+> `SrvdChannel.escrRequestedButUnreconcilable`). It describes behaviour, not a
+> protocol spec.
+
+## Actors and the two "sides"
+
+Every session opens two connections into the relay:
+
+- **Side A** — the **client** (`sshnp` / `npt` / NoPorts Desktop). A current
+  client can always do ESCR, so its ESCR capability is a given.
+- **Side B** — the **daemon** (`sshnpd`). Older daemons cannot do ESCR; the
+  client learns whether this one can from the daemon ping
+  (`DaemonFeature.supportsRamEscr`).
+
+Each side authenticates independently, and the relay authenticates each incoming
+socket on its own.
+
+## What the relay does with the mode
+
+- **Auto-detecting relay** (current `srvd`; advertises `autoDetectsRelayAuth:
+  true`) — detects each socket's mode *per connection* by timing (a legacy peer
+  sends a `{…}` line immediately; an ESCR peer stays silent until challenged),
+  so the two sides may differ. The client may also send a **definitive
+  auth-modes notification** — a hint `{sideA, sideB}` — so the relay skips the
+  detection window.
+- **Older relay** (does not advertise auto-detect) — applies **one session-wide
+  mode to *both* sockets**: the `relayAuthMode` field of the client's
+  `request_ports` notification. The two sides cannot differ, and the hint is
+  ignored.
+- **443 single-port path** (`--only-port 443`) — multiplexes both sides on one
+  port and is **ESCR-only on every relay version**. Selecting 443 requires ESCR
+  end-to-end (the daemon must support it).
+
+## Client capability
+
+ESCR relay auth was introduced in **NoPorts v5.11.2 (2025-07-04)**. A client
+older than that authenticates to the relay only with **legacy**, never requests
+ESCR, and sends no auth-modes hint — so for an **older client** side A is always
+legacy and `request_ports` declares legacy. The tables assume a current
+(≥ v5.11.2) client except where an "older client" row is shown.
+
+## What the (current) client controls
+
+| Input | Source | Meaning |
+|---|---|---|
+| `relayAuthMode` preference | `--relay-auth-mode` / config / API (default `escr`) | Preferred mode |
+| `relayAuthModeExplicit` | whether the user actually set it | Treat as **prescriptive** rather than a soft default |
+| `only443` | `--only-port 443` | Forces the ESCR-only single-port path |
+| `authenticateDeviceToRvd` | flag | Whether the daemon authenticates to the relay at all |
+
+`effectiveRelayAuthMode(preference, autoDetect, peerSupportsEscr, only443,
+prescribed)`:
+
+```
+if only443:        return escr             # 443 is ESCR-only everywhere
+if prescribed:     return payload if (preference==escr and not peerSupportsEscr) else preference
+if not autoDetect: return payload          # older relay applies ONE mode to both -> safe legacy
+return escr if (preference==escr and peerSupportsEscr) else payload
+```
+
+Evaluated for side A (`peerSupportsEscr = true`), side B (`peerSupportsEscr =
+daemonSupportsEscr`, told to the daemon as `req.relayAuthMode`), and for
+`request_ports` (`autoDetect = false, peerSupportsEscr = true`).
+
+`E` = ESCR, `L` = legacy.
+
+## Matrix A — latest, auto-detecting relay
+
+The relay reconciles each socket independently, so **explicit vs default ESCR
+makes no difference here** (the daemon side degrades to legacy either way and
+the relay/hint reconcile it). No session is ever rejected.
+
+| Client | Preference | Daemon ESCR | Side A | Side B | Relay reconciles via | Outcome |
+|---|---|---|---|---|---|---|
+| current | escr (explicit or not) | yes | E | E | detect + hint `(E,E)` | Both ESCR. ✓ |
+| current | escr (explicit or not) | **no** | E | **L** | detect + hint `(E,L)` | Client ESCR, daemon legacy. ✓ |
+| current | payload | any | L | L | detect `(L,L)` | Both legacy. ✓ |
+| current | **443** | yes | E | E | single ESCR-only port | Both ESCR. ✓ |
+| current | **443** | **no** | — | — | — | **Rejected up front** — 443 is ESCR-only; the daemon can't do it. |
+| **older** (<5.11.2) | — (legacy only) | any | L | L | detect `(L,L)` | Both legacy. ✓ |
+
+## Matrix B — older, non-auto-detecting relay
+
+This relay applies the single `request_ports` mode to **both** sockets and
+ignores the hint, so the two sides cannot differ. (Transitional: production
+relays are upgraded before a formal release, so in practice all sessions use
+Matrix A.)
+
+| Client | Preference | Explicit | Daemon ESCR | request_ports (both) | Side A | Side B | Outcome |
+|---|---|---|---|---|---|---|---|
+| current | escr | no | any | L | L | L | Both legacy (ESCR not used; safe). ✓ |
+| current | escr | **yes** | yes | E | E | E | Both ESCR — explicit forces it. ✓ |
+| current | escr | **yes** | **no** | E | (E) | (L) | **Rejected up front** — cannot reconcile (see below). |
+| current | payload | any | any | L | L | L | Both legacy. ✓ |
+| current | **443** | — | yes | E | E | E | 443 ESCR-only. ✓ |
+| current | **443** | — | **no** | — | — | — | **Rejected up front** — 443 is ESCR-only. |
+| **older** | — | — | any | L | L | L | Both legacy. ✓ |
+
+## Walkthroughs
+
+The rows worth tracing are the ones that are not simply "both ESCR" or "both
+legacy". Two facts about timing shape all of them. First, the client's opening
+request to the relay goes out **before** it has heard back from the daemon about
+whether the daemon can do ESCR, and before it knows whether this relay can work
+out each connection's mode on its own. Second, that opening request names a
+single mode — but **that named mode is only ever used by an older relay**, which
+runs the whole session on one mode; a newer relay that inspects each connection
+itself ignores it. So read the mode in the opening request as "the fallback an
+older relay would use", not "the mode the client will use".
+
+### A newer relay, the client prefers ESCR, the daemon can't → client uses ESCR, daemon uses legacy
+
+1. The client prefers ESCR (the default). Its opening request to the relay names
+   **legacy** as the mode. It has to name something before it knows anything
+   about the daemon or the relay, and legacy is the one mode every relay and
+   every daemon understands, so naming it can never make matters worse.
+2. The relay's reply shows it can work out each connection's mode on its own.
+   That means the mode named in the opening request is never consulted here — the
+   relay will judge the client's connection and the daemon's connection
+   separately. The client's real choice of mode is made in step 4, not step 1.
+3. The client hears back from the daemon: this daemon **cannot** do ESCR.
+4. The client now chooses a mode for each connection on its own merits. Its own
+   connection can always do ESCR, so it uses **ESCR**. The daemon can't, so the
+   daemon's connection uses **legacy**.
+5. The client sends the relay a short follow-up spelling this out — its own
+   connection ESCR, the daemon's connection legacy — so the relay needn't spend
+   time working it out.
+6. The client's connection authenticates with ESCR and the daemon's with legacy,
+   and the relay accepts both.
+
+The client keeps the stronger mode on its own connection while the daemon quietly
+falls back to legacy — with no waiting and no failure.
+
+### An older relay, the client prefers ESCR but didn't insist → both use legacy
+
+1. The client prefers ESCR, but the user didn't explicitly ask for it. The
+   opening request names **legacy**.
+2. The relay's reply shows it is an older relay: it can't judge connections on
+   its own, so it runs the whole session on one mode and ignores any follow-up.
+3. Such a relay can't run one connection on ESCR and the other on legacy, and the
+   client wasn't told to insist on ESCR — so the client just uses the safe mode
+   it already named: **legacy on both connections**.
+4. Both connections authenticate with legacy, and the relay accepts.
+
+ESCR isn't attempted here, even if this daemon could do it. The default stance is
+"only use ESCR where the whole path clearly supports it", and an older relay
+can't give that assurance before the session starts.
+
+### An older relay, the user insisted on ESCR, the daemon can do ESCR → both use ESCR
+
+1. The user explicitly asked for ESCR, so the client is being insistent. Its
+   opening request names **ESCR**, which commits the whole session to it.
+2. The relay is older, so it will run both connections on ESCR.
+3. The client hears back from the daemon: it **can** do ESCR.
+4. Both connections authenticate with ESCR, and the relay accepts.
+
+This is the one situation where explicitly asking for ESCR gets you something an
+older relay wouldn't give you otherwise — ESCR the whole way — and it works only
+because every part of the path happens to support it.
+
+### An older relay, the user insisted on ESCR, the daemon can't → refused before connecting
+
+1. Because the user insisted on ESCR, the opening request named ESCR, so this
+   older relay will require ESCR on **both** connections.
+2. The client hears back from the daemon: it **cannot** do ESCR.
+3. The client is now stuck. It already committed the whole session to ESCR (that
+   went out before it heard from the daemon), this older relay ignores any
+   follow-up, and the daemon can't do ESCR — so the daemon's connection would be
+   turned away by the relay part-way through connecting.
+4. Rather than let that happen, the client stops right away with a clear error.
+
+Quietly dropping just the daemon to legacy wouldn't help: that would create
+exactly the "one connection on ESCR, the other on legacy" split this older relay
+can't handle. What the user asked for and what the daemon can do simply can't
+both be satisfied on this relay, so the client says so up front instead of
+failing halfway through.
+
+### Asking for port 443 with a daemon that can't do ESCR → refused before connecting (any relay)
+
+1. Asking for port 443 puts both connections through a single shared port, and
+   that shared-port path only ever uses ESCR — on every relay, new or old (there
+   is no room in it for a legacy connection). So ESCR is required on both
+   connections no matter what.
+2. The client hears back from the daemon: it **cannot** do ESCR.
+3. The single-port path has no legacy fallback, so the client stops up front
+   rather than let the daemon fail to authenticate part-way through connecting.
+
+## Rejected up front
+
+`SrvdChannel.escrRequestedButUnreconcilable` is true — and the client aborts
+`initialize()` with a clear error — when the daemon **authenticates to the
+relay** (`authenticateDeviceToRvd`) and **cannot do ESCR**, yet ESCR is
+unavoidable on the daemon's socket, i.e. **either**:
+
+- **443** — the single-port path is ESCR-only end-to-end on every relay (even an
+  auto-detecting one), so a non-ESCR daemon can never use it; **or**
+- **explicit ESCR through a non-auto-detecting relay** — the relay forces one
+  mode on both sockets and ignores the hint, so the daemon cannot legacy-degrade
+  on its own.
+
+These are rejected up front rather than failing mid-connect. Every other
+explicit-ESCR case degrades gracefully: the client uses ESCR on its own side,
+the daemon side falls back to legacy where needed, and an auto-detecting relay
+reconciles per socket.
+
+> The tables assume the daemon authenticates to the relay
+> (`authenticateDeviceToRvd`, the default). With `--no-authenticate-device-to-rvd`
+> the daemon does no relay auth at all, so its ESCR capability is moot and
+> nothing is rejected (side A still authenticates as shown; side B does not
+> authenticate).
+
+## Key properties
+
+- **Progressive by default.** Without an explicit flag, ESCR is used only where
+  the whole path supports it; against an older relay both sides stay on legacy,
+  so daemons (and clients) that predate ESCR keep working.
+- **Explicit ESCR forces where it can, degrades where it can't, and hard-errors
+  up front — never mid-connect — in the unreconcilable cases** (443 to a
+  non-ESCR daemon, or explicit ESCR through a non-auto-detecting relay to a
+  non-ESCR daemon).
+- **443 is ESCR-only** on every relay version.
+- **`payload`** always yields legacy on both sides.

--- a/packages/dart/noports_core/CHANGELOG.md
+++ b/packages/dart/noports_core/CHANGELOG.md
@@ -10,7 +10,16 @@
   The relay skips the detection window when a side's mode is known ahead of
   time: side A (the client) from its own request, and side B (the daemon) from
   an optional definitive auth-modes notification the client sends once it has
-  the ping response. Auto-detect remains the fallback.
+  the ping response. A side's mode is also memoised after its first connection
+  authenticates, so only the first connection of a session ever detects — every
+  later connection pair skips straight to the known mode. Auto-detect remains
+  the fallback.
+- fix: the two-port relay path issued one ESCR challenge per session and reused
+  it for every connection, so a captured challenge-response could be replayed
+  onto later connections of the same session. It now issues a fresh challenge
+  per connection (as the 443 single-port path already did), and
+  RelayAuthVerifierESCR is single-use so an instance cannot be reused across
+  connections.
 
 # 6.11.0
 

--- a/packages/dart/noports_core/CHANGELOG.md
+++ b/packages/dart/noports_core/CHANGELOG.md
@@ -1,6 +1,16 @@
 # 6.12.0
 
 - feat: npp policy next iteration
+- feat: the relay (srvd) now auto-detects each connecting side's relay-auth
+  mode (ESCR vs legacy) per socket, instead of being told a single mode for
+  the whole session. Clients and daemons each use their strongest relay auth
+  independently, so a client no longer has to learn the daemon's capabilities
+  (via the daemon ping) before contacting the relay. Clients now default to
+  ESCR. Adds the `srvd --relay-auth-detect-window-ms` option (default 500).
+  The relay skips the detection window when a side's mode is known ahead of
+  time: side A (the client) from its own request, and side B (the daemon) from
+  an optional definitive auth-modes notification the client sends once it has
+  the ping response. Auto-detect remains the fallback.
 
 # 6.11.0
 

--- a/packages/dart/noports_core/CHANGELOG.md
+++ b/packages/dart/noports_core/CHANGELOG.md
@@ -16,10 +16,14 @@
   that advertises it — against an older relay (which applies one session-wide
   mode to both sockets) both sides stay on legacy, so interoperability with
   daemons that predate ESCR is preserved. Explicitly passing
-  `--relay-auth-mode escr` (CLI/config/API) is prescriptive and overrides this:
-  ESCR is forced on both sides even against an older relay, and a daemon that
-  cannot do ESCR becomes a hard error at the feature check ("...does not support
-  the 'ESCR' relay auth mode") rather than a silent fallback.
+  `--relay-auth-mode escr` (CLI/config/API) forces ESCR wherever the path
+  supports it, including against an older relay when the daemon is ESCR-capable;
+  a daemon that cannot do ESCR degrades to legacy on its own side (which an
+  auto-detecting relay reconciles per socket). The one genuinely unreconcilable
+  case — explicit ESCR through a non-auto-detecting relay to a non-ESCR daemon —
+  is rejected up front with a clear error rather than failing mid-connect.
+- reference: `docs/reference/relay-auth-modes.md` documents the full matrix of
+  client request × relay × daemon and the resulting per-side modes.
 - fix: the two-port relay path issued one ESCR challenge per session and reused
   it for every connection, so a captured challenge-response could be replayed
   onto later connections of the same session. It now issues a fresh challenge

--- a/packages/dart/noports_core/CHANGELOG.md
+++ b/packages/dart/noports_core/CHANGELOG.md
@@ -3,17 +3,19 @@
 - feat: npp policy next iteration
 - feat: the relay (srvd) now auto-detects each connecting side's relay-auth
   mode (ESCR vs legacy) per socket, instead of being told a single mode for
-  the whole session. Clients and daemons each use their strongest relay auth
-  independently, so a client no longer has to learn the daemon's capabilities
-  (via the daemon ping) before contacting the relay. Clients now default to
-  ESCR. Adds the `srvd --relay-auth-detect-window-ms` option (default 500).
-  The relay skips the detection window when a side's mode is known ahead of
-  time: side A (the client) from its own request, and side B (the daemon) from
-  an optional definitive auth-modes notification the client sends once it has
-  the ping response. A side's mode is also memoised after its first connection
-  authenticates, so only the first connection of a session ever detects — every
-  later connection pair skips straight to the known mode. Auto-detect remains
-  the fallback.
+  the whole session. Against such a relay the client and daemon each use their
+  strongest relay auth independently. Adds the `srvd
+  --relay-auth-detect-window-ms` option (default 500). The relay skips the
+  detection window when a side's mode is declared up front via a definitive
+  auth-modes notification the client sends once it has the daemon ping response;
+  a side's mode is also memoised after its first connection authenticates, so
+  only the first connection of a session ever detects and every later connection
+  pair skips straight to the known mode. Auto-detect remains the fallback.
+  Rollout is progressive and safe: the relay advertises auto-detection in its
+  response (`autoDetectsRelayAuth`), and a client uses ESCR only against a relay
+  that advertises it — against an older relay (which applies one session-wide
+  mode to both sockets) both sides stay on legacy, so interoperability with
+  daemons that predate ESCR is preserved.
 - fix: the two-port relay path issued one ESCR challenge per session and reused
   it for every connection, so a captured challenge-response could be replayed
   onto later connections of the same session. It now issues a fresh challenge

--- a/packages/dart/noports_core/CHANGELOG.md
+++ b/packages/dart/noports_core/CHANGELOG.md
@@ -15,7 +15,11 @@
   response (`autoDetectsRelayAuth`), and a client uses ESCR only against a relay
   that advertises it — against an older relay (which applies one session-wide
   mode to both sockets) both sides stay on legacy, so interoperability with
-  daemons that predate ESCR is preserved.
+  daemons that predate ESCR is preserved. Explicitly passing
+  `--relay-auth-mode escr` (CLI/config/API) is prescriptive and overrides this:
+  ESCR is forced on both sides even against an older relay, and a daemon that
+  cannot do ESCR becomes a hard error at the feature check ("...does not support
+  the 'ESCR' relay auth mode") rather than a silent fallback.
 - fix: the two-port relay path issued one ESCR challenge per session and reused
   it for every connection, so a captured challenge-response could be replayed
   onto later connections of the same session. It now issues a fresh challenge

--- a/packages/dart/noports_core/lib/src/common/default_args.dart
+++ b/packages/dart/noports_core/lib/src/common/default_args.dart
@@ -23,7 +23,12 @@ class DefaultArgs {
   static const bool authenticateClientToRvd = true;
   static const bool authenticateDeviceToRvd = true;
   static const bool encryptRvdTraffic = true;
-  static const RelayAuthMode relayAuthMode = RelayAuthMode.payload;
+
+  /// Default relay auth mode. ESCR (the strongest) is the default: the relay
+  /// auto-detects each side's mode, so a client can use its best without
+  /// knowing the daemon's capabilities in advance. Legacy remains available as
+  /// an explicit override (`--relay-auth-mode payload`).
+  static const RelayAuthMode relayAuthMode = RelayAuthMode.escr;
 
   /// How long a client should wait for response after pinging a NoPorts daemon
   static const int daemonPingTimeoutSeconds = 20;

--- a/packages/dart/noports_core/lib/src/npt/npt.dart
+++ b/packages/dart/noports_core/lib/src/npt/npt.dart
@@ -192,10 +192,16 @@ class _NptImpl extends NptBase
       DaemonFeature.supportsPortChoice,
       DaemonFeature.controlChannelHeartbeats,
     ];
-    // Note: ESCR does not require DaemonFeature.supportsRamEscr. Relay auth is
-    // negotiated per-socket by the auto-detecting relay, so each side uses its
-    // own best mode independently and a legacy-only daemon just falls back to
-    // legacy (which the relay detects). See sshnp_core.initialize for detail.
+    // By default ESCR does not require DaemonFeature.supportsRamEscr: relay auth
+    // is negotiated per-socket by an auto-detecting relay, so a legacy-only
+    // daemon just falls back to legacy (which the relay detects). But an
+    // explicit --relay-auth-mode escr forces ESCR on both sides, so we then
+    // require the daemon to support it — an incapable daemon is a hard error
+    // rather than a silent fallback. See sshnp_core.initialize for detail.
+    if (params.relayAuthModeExplicit &&
+        params.relayAuthMode == RelayAuthMode.escr) {
+      requiredFeatures.add(DaemonFeature.supportsRamEscr);
+    }
     if (!(params.timeout == DefaultArgs.srvTimeout)) {
       requiredFeatures.add(DaemonFeature.adjustableTimeout);
     }

--- a/packages/dart/noports_core/lib/src/npt/npt.dart
+++ b/packages/dart/noports_core/lib/src/npt/npt.dart
@@ -192,19 +192,11 @@ class _NptImpl extends NptBase
       DaemonFeature.supportsPortChoice,
       DaemonFeature.controlChannelHeartbeats,
     ];
-    // By default ESCR does not require DaemonFeature.supportsRamEscr: relay auth
-    // is negotiated per-socket by an auto-detecting relay, so a legacy-only
-    // daemon just falls back to legacy (which the relay detects). But an
-    // explicit --relay-auth-mode escr forces ESCR on both sides, so we then
-    // require the daemon to support it — an incapable daemon is a hard error
-    // rather than a silent fallback. Only when the daemon actually authenticates
-    // to the relay (authenticateDeviceToRvd); otherwise its ESCR capability is
-    // irrelevant. See sshnp_core.initialize for detail.
-    if (params.relayAuthModeExplicit &&
-        params.relayAuthMode == RelayAuthMode.escr &&
-        params.authenticateDeviceToRvd) {
-      requiredFeatures.add(DaemonFeature.supportsRamEscr);
-    }
+    // We deliberately do NOT require DaemonFeature.supportsRamEscr: a daemon that
+    // cannot do ESCR uses legacy on its own side and the relay reconciles it,
+    // even under an explicit --relay-auth-mode escr. The one unreconcilable case
+    // (explicit ESCR + non-auto-detecting relay + non-ESCR daemon) is rejected
+    // below. See sshnp_core.initialize for detail.
     if (!(params.timeout == DefaultArgs.srvTimeout)) {
       requiredFeatures.add(DaemonFeature.adjustableTimeout);
     }
@@ -249,6 +241,25 @@ class _NptImpl extends NptBase
     }
 
     sendProgress('Required daemon features are supported');
+
+    // Reject an explicit --relay-auth-mode escr this session cannot honour (a
+    // non-auto-detecting relay + a non-ESCR daemon can never agree). Every other
+    // explicit-ESCR case degrades gracefully. See sshnp_core.initialize.
+    if (SrvdChannel.escrRequestedButUnreconcilable(
+      explicitEscr: params.relayAuthModeExplicit &&
+          params.relayAuthMode == RelayAuthMode.escr,
+      only443: params.only443,
+      authenticateDeviceToRvd: params.authenticateDeviceToRvd,
+      autoDetect: _srvdChannel.autoDetectsRelayAuth,
+      daemonSupportsEscr: sshnpdChannel.daemonSupportsRelayAuthEscr,
+    )) {
+      throw SshnpError(
+        'This session requires ESCR relay auth on the device daemon (either'
+        ' --only-port 443, or --relay-auth-mode escr through a relay that does'
+        ' not auto-detect), but the daemon does not support ESCR. Upgrade the'
+        ' daemon, or retry without --only-port 443 / --relay-auth-mode escr.',
+      );
+    }
 
     // The daemon ping has now resolved, so we know which relay-auth mode each
     // side will use. Tell the relay definitively (before the daemon session

--- a/packages/dart/noports_core/lib/src/npt/npt.dart
+++ b/packages/dart/noports_core/lib/src/npt/npt.dart
@@ -192,9 +192,10 @@ class _NptImpl extends NptBase
       DaemonFeature.supportsPortChoice,
       DaemonFeature.controlChannelHeartbeats,
     ];
-    if (params.relayAuthMode == RelayAuthMode.escr) {
-      requiredFeatures.add(DaemonFeature.supportsRamEscr);
-    }
+    // Note: ESCR does not require DaemonFeature.supportsRamEscr. Relay auth is
+    // negotiated per-socket by the auto-detecting relay, so each side uses its
+    // own best mode independently and a legacy-only daemon just falls back to
+    // legacy (which the relay detects). See sshnp_core.initialize for detail.
     if (!(params.timeout == DefaultArgs.srvTimeout)) {
       requiredFeatures.add(DaemonFeature.adjustableTimeout);
     }
@@ -239,6 +240,18 @@ class _NptImpl extends NptBase
     }
 
     sendProgress('Required daemon features are supported');
+
+    // The daemon ping has now resolved, so we know which relay-auth mode each
+    // side will use. Tell the relay definitively (before the daemon session
+    // request, sent from _preRun) so it can skip the auto-detect window; if
+    // this loses the race to the daemon's socket, the relay just auto-detects.
+    final daemonFeatures = sshnpdChannel.pingResponse?['supportedFeatures'];
+    final bool daemonSupportsEscr =
+        daemonFeatures is Map &&
+        daemonFeatures[DaemonFeature.supportsRamEscr.name] == true;
+    await _srvdChannel.sendDefinitiveAuthModes(
+      daemonSupportsEscr: daemonSupportsEscr,
+    );
 
     completeInitialization();
   }

--- a/packages/dart/noports_core/lib/src/npt/npt.dart
+++ b/packages/dart/noports_core/lib/src/npt/npt.dart
@@ -245,12 +245,9 @@ class _NptImpl extends NptBase
     // side will use. Tell the relay definitively (before the daemon session
     // request, sent from _preRun) so it can skip the auto-detect window; if
     // this loses the race to the daemon's socket, the relay just auto-detects.
-    final daemonFeatures = sshnpdChannel.pingResponse?['supportedFeatures'];
-    final bool daemonSupportsEscr =
-        daemonFeatures is Map &&
-        daemonFeatures[DaemonFeature.supportsRamEscr.name] == true;
+    // No-op against a relay that doesn't auto-detect.
     await _srvdChannel.sendDefinitiveAuthModes(
-      daemonSupportsEscr: daemonSupportsEscr,
+      daemonSupportsEscr: sshnpdChannel.daemonSupportsRelayAuthEscr,
     );
 
     completeInitialization();
@@ -273,7 +270,9 @@ class _NptImpl extends NptBase
       rvdHost: _srvdChannel.rvdHost,
       rvdPort: _srvdChannel.daemonPort,
       authenticateToRvd: params.authenticateDeviceToRvd,
-      relayAuthMode: params.relayAuthMode,
+      relayAuthMode: _srvdChannel.daemonRelayAuthMode(
+        daemonSupportsEscr: sshnpdChannel.daemonSupportsRelayAuthEscr,
+      ),
       relayAuthAesKey: _srvdChannel.relayAuthAesKey,
       clientNonce: _srvdChannel.clientNonce,
       rvdNonce: _srvdChannel.rvdNonce,

--- a/packages/dart/noports_core/lib/src/npt/npt.dart
+++ b/packages/dart/noports_core/lib/src/npt/npt.dart
@@ -197,9 +197,12 @@ class _NptImpl extends NptBase
     // daemon just falls back to legacy (which the relay detects). But an
     // explicit --relay-auth-mode escr forces ESCR on both sides, so we then
     // require the daemon to support it — an incapable daemon is a hard error
-    // rather than a silent fallback. See sshnp_core.initialize for detail.
+    // rather than a silent fallback. Only when the daemon actually authenticates
+    // to the relay (authenticateDeviceToRvd); otherwise its ESCR capability is
+    // irrelevant. See sshnp_core.initialize for detail.
     if (params.relayAuthModeExplicit &&
-        params.relayAuthMode == RelayAuthMode.escr) {
+        params.relayAuthMode == RelayAuthMode.escr &&
+        params.authenticateDeviceToRvd) {
       requiredFeatures.add(DaemonFeature.supportsRamEscr);
     }
     if (!(params.timeout == DefaultArgs.srvTimeout)) {

--- a/packages/dart/noports_core/lib/src/srvd/isolates/port_pair_isolate.dart
+++ b/packages/dart/noports_core/lib/src/srvd/isolates/port_pair_isolate.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:isolate';
 import 'dart:math';
+import 'package:noports_core/src/common/types.dart';
 import 'package:noports_core/src/srvd/isolates/relay_worker.dart';
 import 'package:noports_core/src/srvd/isolates/types.dart';
 import 'package:socket_connector/socket_connector.dart';
@@ -25,14 +26,37 @@ class PortPairWorker extends RelayWorker {
   /// Set when we start the session
   int? portB;
 
+  /// The per-side auto-detecting verifiers, kept so that a definitive
+  /// auth-modes notification (see [handleAuthModes]) can steer their detection.
+  RelayAuthVerifierAuto? _authVerifierA;
+  RelayAuthVerifierAuto? _authVerifierB;
+
   PortPairWorker({
     required super.toMain,
     required super.logTraffic,
     required super.verbose,
     required super.loggingTag,
+    required super.relayAuthDetectWindowMs,
   }) {
     reqHandlers['start'] = startSession;
     reqHandlers['stop'] = stop;
+    reqHandlers['auth_modes'] = handleAuthModes;
+  }
+
+  /// Handle a definitive auth-modes message forwarded from the main isolate:
+  /// the requesting client has learnt which mode each side will use and told
+  /// the relay, so we can skip the detection window (see [RelayAuthVerifierAuto]).
+  Future<void> handleAuthModes(IIRequest req) async {
+    final payload = req.payload;
+    final String? sideA = payload['sideA'];
+    final String? sideB = payload['sideB'];
+    logger.info('Definitive auth modes received: sideA=$sideA sideB=$sideB');
+    if (sideA != null) {
+      _authVerifierA?.setKnownMode(RelayAuthMode.values.byName(sideA));
+    }
+    if (sideB != null) {
+      _authVerifierB?.setKnownMode(RelayAuthMode.values.byName(sideB));
+    }
   }
 
   @override
@@ -74,12 +98,11 @@ class PortPairWorker extends RelayWorker {
     srvdSessionParams = req.payload;
     logger.info('Starting socket connector session for $srvdSessionParams');
 
-    RelayAuthVerifier? authVerifierA;
-    RelayAuthVerifier? authVerifierB;
-
-    (authVerifierA, authVerifierB) = await createAuthVerifiers(
+    final (authVerifierA, authVerifierB) = await createAuthVerifiers(
       srvdSessionParams,
     );
+    _authVerifierA = authVerifierA;
+    _authVerifierB = authVerifierB;
 
     /// Create the socket connector
     connector = await SocketConnector.serverToServer(
@@ -89,8 +112,8 @@ class PortPairWorker extends RelayWorker {
       portB: 0,
       verbose: verbose,
       logTraffic: logTraffic,
-      socketAuthVerifierA: authVerifierA?.verifySocketAuth,
-      socketAuthVerifierB: authVerifierB?.verifySocketAuth,
+      socketAuthVerifierA: _authVerifierA?.verifySocketAuth,
+      socketAuthVerifierB: _authVerifierB?.verifySocketAuth,
     );
 
     connector!.connectionStream.listen(

--- a/packages/dart/noports_core/lib/src/srvd/isolates/relay_worker.dart
+++ b/packages/dart/noports_core/lib/src/srvd/isolates/relay_worker.dart
@@ -4,9 +4,7 @@ import 'dart:isolate';
 
 import 'package:at_utils/at_logger.dart';
 import 'package:meta/meta.dart';
-import 'package:at_commons/atsign.dart';
 import 'package:noports_core/src/srvd/isolates/types.dart';
-import 'package:noports_core/sshnp_foundation.dart';
 import 'package:noports_core/src/srvd/relay_auth_verifiers.dart';
 import 'package:noports_core/src/srvd/srvd_session_params.dart';
 
@@ -17,6 +15,11 @@ abstract class RelayWorker implements RelayAuthVerifyHelper {
   final bool logTraffic;
   final bool verbose;
   final String loggingTag;
+
+  /// Window used by [RelayAuthVerifierAuto] to distinguish a legacy connecting
+  /// side (which speaks first) from an ESCR one (which waits to be challenged).
+  final int relayAuthDetectWindowMs;
+
   late final ReceivePort fromMain;
   late final AtSignLogger logger;
   final Map<String, RelayWorkerRequestHandler> reqHandlers = {};
@@ -27,6 +30,7 @@ abstract class RelayWorker implements RelayAuthVerifyHelper {
     required this.logTraffic,
     required this.verbose,
     required this.loggingTag,
+    this.relayAuthDetectWindowMs = defaultRelayAuthDetectWindowMs,
   }) {
     AtSignLogger.defaultLoggingHandler = AtSignLogger.stdErrLoggingHandler;
     AtSignLogger.root_level = verbose ? 'INFO' : 'WARNING';
@@ -84,100 +88,63 @@ abstract class RelayWorker implements RelayAuthVerifyHelper {
     await stop();
   }
 
-  Future<(RelayAuthVerifier?, RelayAuthVerifier?)> createAuthVerifiers(
+  /// Builds a per-socket auto-detecting verifier for each authenticated side.
+  ///
+  /// Side A is the requesting client, whose relay-auth mode it set in its own
+  /// request, so we pass that through as the verifier's `knownMode` — side A
+  /// therefore never pays the detection window and is never misread.
+  ///
+  /// Side B is the daemon, whose mode the client does not know at request time
+  /// (that needs the daemon ping), so side B is left to auto-detect. Once the
+  /// client has learnt the daemon's mode it may send a definitive auth-modes
+  /// notification, which the worker feeds to the verifier via [setKnownMode].
+  ///
+  /// `params.relayAuthMode` is thus authoritative for side A only; the daemon
+  /// (side B) picks its own mode independently and the relay detects it. The
+  /// field is also still honoured by pre-6.5.0 relays which switch on it.
+  ///
+  /// A legacy socket needs the connecting atSign's public key. It is passed
+  /// through here if the request handler already fetched it (`publicKeyA/B`,
+  /// which only happens for an explicit legacy request); otherwise the auto
+  /// verifier looks it up lazily, and only if the socket does turn out to be
+  /// legacy — so ESCR sessions pay no public-key lookup.
+  Future<(RelayAuthVerifierAuto?, RelayAuthVerifierAuto?)> createAuthVerifiers(
     SrvdSessionParams params,
   ) async {
-    switch (params.relayAuthMode) {
-      case RelayAuthMode.payload:
-        return await createPayloadAuthVerifiers(params);
-      case RelayAuthMode.escr:
-        return await createEscrAuthVerifiers(params);
-    }
-  }
-
-  Future<(RelayAuthVerifier?, RelayAuthVerifier?)> createPayloadAuthVerifiers(
-    SrvdSessionParams params,
-  ) async {
-    RelayAuthVerifier? authVerifierA;
-    RelayAuthVerifier? authVerifierB;
-
-    Map expectedPayloadForSignature = {
+    final String dataToVerify = jsonEncode({
       'sessionId': params.sessionId,
       'clientNonce': params.clientNonce,
       'rvdNonce': params.rvdNonce,
-    };
+    });
+
+    RelayAuthVerifierAuto? authVerifierA;
+    RelayAuthVerifierAuto? authVerifierB;
 
     if (params.authenticateSocketA) {
-      String? pkAtSignA =
-          params.publicKeyA ??
-          (await rpcToMain(
-            IIRequest.create('lookup', 'public:publickey${params.atSignA}'),
-          )).payload;
-      if (pkAtSignA == null) {
-        logger.shout(
-          'Cannot spawn socket connector.'
-          ' Authenticator for ${params.atSignA}'
-          ' could not be created as PublicKey could not be'
-          ' fetched from the atServer.',
-        );
-        throw Exception(
-          'Failed to create SocketAuthenticator'
-          ' for ${params.atSignA} due to failure to get public key for ${params.atSignA}',
-        );
-      }
-      authVerifierA = RelayAuthVerifierLegacy(
-        pkAtSignA,
-        jsonEncode(expectedPayloadForSignature),
-        params.rvdNonce,
-        params.atSignA,
-        params.atSignA.toAtsign(),
-        params.sessionId,
+      authVerifierA = RelayAuthVerifierAuto(
+        '${params.sessionId} sideA',
+        this,
+        atSign: params.atSignA,
+        sessionId: params.sessionId,
+        dataToVerify: dataToVerify,
+        rvdNonce: params.rvdNonce,
+        publicKey: params.publicKeyA,
+        detectWindow: Duration(milliseconds: relayAuthDetectWindowMs),
+        knownMode: params.relayAuthMode,
       );
     }
 
     if (params.authenticateSocketB) {
-      String? pkAtSignB =
-          params.publicKeyB ??
-          (await rpcToMain(
-            IIRequest.create('lookup', 'public:publickey${params.atSignB}'),
-          )).payload;
-      if (pkAtSignB == null) {
-        logger.shout(
-          'Cannot spawn socket connector.'
-          ' Authenticator for ${params.atSignB}'
-          ' could not be created as PublicKey could not be'
-          ' fetched from the atServer',
-        );
-        throw Exception(
-          'Failed to create SocketAuthenticator'
-          ' for ${params.atSignB} due to failure to get public key for ${params.atSignB}',
-        );
-      }
-      authVerifierB = RelayAuthVerifierLegacy(
-        pkAtSignB,
-        jsonEncode(expectedPayloadForSignature),
-        params.rvdNonce,
-        params.atSignB,
-        params.atSignB.toAtsign(),
-        params.sessionId,
+      authVerifierB = RelayAuthVerifierAuto(
+        '${params.sessionId} sideB',
+        this,
+        atSign: params.atSignB,
+        sessionId: params.sessionId,
+        dataToVerify: dataToVerify,
+        rvdNonce: params.rvdNonce,
+        publicKey: params.publicKeyB,
+        detectWindow: Duration(milliseconds: relayAuthDetectWindowMs),
       );
-    }
-
-    return (authVerifierA, authVerifierB);
-  }
-
-  Future<(RelayAuthVerifier?, RelayAuthVerifier?)> createEscrAuthVerifiers(
-    SrvdSessionParams params,
-  ) async {
-    RelayAuthVerifierESCR? authVerifierA;
-    RelayAuthVerifierESCR? authVerifierB;
-
-    if (params.authenticateSocketA) {
-      authVerifierA = RelayAuthVerifierESCR('${params.sessionId} sideA', this);
-    }
-
-    if (params.authenticateSocketB) {
-      authVerifierB = RelayAuthVerifierESCR('${params.sessionId} sideB', this);
     }
 
     return (authVerifierA, authVerifierB);

--- a/packages/dart/noports_core/lib/src/srvd/isolates/relay_worker.dart
+++ b/packages/dart/noports_core/lib/src/srvd/isolates/relay_worker.dart
@@ -90,18 +90,14 @@ abstract class RelayWorker implements RelayAuthVerifyHelper {
 
   /// Builds a per-socket auto-detecting verifier for each authenticated side.
   ///
-  /// Side A is the requesting client, whose relay-auth mode it set in its own
-  /// request, so we pass that through as the verifier's `knownMode` — side A
-  /// therefore never pays the detection window and is never misread.
-  ///
-  /// Side B is the daemon, whose mode the client does not know at request time
-  /// (that needs the daemon ping), so side B is left to auto-detect. Once the
-  /// client has learnt the daemon's mode it may send a definitive auth-modes
-  /// notification, which the worker feeds to the verifier via [setKnownMode].
-  ///
-  /// `params.relayAuthMode` is thus authoritative for side A only; the daemon
-  /// (side B) picks its own mode independently and the relay detects it. The
-  /// field is also still honoured by pre-6.5.0 relays which switch on it.
+  /// Both sides are left to auto-detect: the client declares the universally-
+  /// safe legacy mode in `request_ports` (so a relay that does NOT auto-detect
+  /// applies one mode both sides can do), and it decides its *actual* per-side
+  /// mode only after learning this relay auto-detects — so `params.relayAuthMode`
+  /// no longer reflects either side's real mode and must not be used as a
+  /// `knownMode` here. Once the client has resolved the modes it sends a
+  /// definitive auth-modes notification, which the worker feeds to each verifier
+  /// via [setKnownMode] to skip the detection window.
   ///
   /// A legacy socket needs the connecting atSign's public key. It is passed
   /// through here if the request handler already fetched it (`publicKeyA/B`,
@@ -130,7 +126,6 @@ abstract class RelayWorker implements RelayAuthVerifyHelper {
         rvdNonce: params.rvdNonce,
         publicKey: params.publicKeyA,
         detectWindow: Duration(milliseconds: relayAuthDetectWindowMs),
-        knownMode: params.relayAuthMode,
       );
     }
 

--- a/packages/dart/noports_core/lib/src/srvd/isolates/types.dart
+++ b/packages/dart/noports_core/lib/src/srvd/isolates/types.dart
@@ -5,6 +5,7 @@ typedef PortPairIsolateParams = (
   bool, // logTraffic
   bool, // verbose
   String, // loggingTag
+  int, // relayAuthDetectWindowMs
 );
 typedef SinglePortIsolateParams = (
   SendPort,

--- a/packages/dart/noports_core/lib/src/srvd/relay_auth_verifiers.dart
+++ b/packages/dart/noports_core/lib/src/srvd/relay_auth_verifiers.dart
@@ -515,6 +515,8 @@ class RelayAuthVerifierLegacy implements RelayAuthVerifier {
     logger = AtSignLogger(' $runtimeType ($tag) ');
   }
 
+  /// Verify a legacy signature envelope [message] (a JSON string).
+  ///
   /// We expect the authenticating client to send a JSON message with
   /// this structure:
   /// ```json
@@ -527,7 +529,62 @@ class RelayAuthVerifierLegacy implements RelayAuthVerifier {
   /// ```
   /// The signature is verified against [dataToVerify] and, although not
   /// strictly necessary, the rvdNonce is also checked in what the client
-  /// send in the payload
+  /// sent in the payload. Throws a [RAVE] on any failure; returns normally
+  /// on success.
+  ///
+  /// Extracted from [verifySocketAuth] so that [RelayAuthVerifierAuto] can
+  /// reuse the exact same legacy verification once it has detected, at the
+  /// socket level, that a connecting side is using legacy auth.
+  ///
+  /// Synchronous: nothing here needs to await, and keeping it sync lets the
+  /// legacy [verifySocketAuth] `onData` callback stay synchronous (so a second
+  /// data chunk cannot re-enter it mid-verification).
+  void verifyEnvelope(String message) {
+    logger.finer('$tag received data: $message');
+    final envelope = jsonDecode(message);
+    logger.finer('$tag decoded JSON message OK');
+
+    final hashingAlgo = HashingAlgoType.values.byName(envelope['hashingAlgo']);
+    final signingAlgo = SigningAlgoType.values.byName(envelope['signingAlgo']);
+
+    final payload = envelope['payload'];
+    if (payload == null || payload is! Map) {
+      throw RAVE(
+        'Received an auth signature which does not include the payload',
+        RAVEReason.malformedChallengeResponse,
+      );
+    }
+    if (payload['rvdNonce'] != rvdNonce) {
+      throw RAVE(
+        'Received rvdNonce which does not match what is expected',
+        RAVEReason.dataMismatch,
+      );
+    }
+
+    final AtSigningVerificationInput input =
+        AtSigningVerificationInput(
+            dataToVerify,
+            base64Decode(envelope['signature']),
+            publicKey,
+          )
+          ..signingAlgorithm = DefaultSigningAlgo(null, hashingAlgo)
+          ..signingMode = AtSigningMode.data
+          ..signingAlgoType = signingAlgo
+          ..hashingAlgoType = hashingAlgo;
+
+    final AtSigningResult atSigningResult = AtChopsImpl(
+      AtChopsKeys(),
+    ).verify(input);
+    if (atSigningResult.result != true) {
+      logger.shout('$tag : verification FAILURE : ${atSigningResult.result}');
+      throw RAVE(
+        'Signature verification failed. Signatures did not match.',
+        RAVEReason.signatureVerificationFailed,
+      );
+    }
+    logger.info('$tag : verification SUCCESS : ${atSigningResult.result}');
+  }
+
   @override
   Future<(bool, Stream<Uint8List>?)> verifySocketAuth(Socket socket) async {
     Completer<(bool, Stream<Uint8List>?)> completer = Completer();
@@ -557,13 +614,8 @@ class RelayAuthVerifierLegacy implements RelayAuthVerifier {
             }
             buffer.addAll(data);
             if (buffer.contains(10)) {
-              logger.finer('original buffer length ${buffer.length}');
-
               List<int> authBuffer = buffer.sublist(0, buffer.indexOf(10));
-              logger.finer('authBuffer length ${authBuffer.length}');
-
               buffer.removeRange(0, buffer.indexOf(10) + 1);
-              logger.finer('remaining buffer length ${buffer.length}');
 
               final String message;
               try {
@@ -575,71 +627,9 @@ class RelayAuthVerifierLegacy implements RelayAuthVerifier {
                   RAVEReason.malformedChallengeResponse,
                 );
               }
-              logger.finer('$tag received data: $message');
-              var envelope = jsonDecode(message);
-              logger.finer('$tag decoded JSON message OK');
 
-              final hashingAlgo = HashingAlgoType.values.byName(
-                envelope['hashingAlgo'],
-              );
-              final signingAlgo = SigningAlgoType.values.byName(
-                envelope['signingAlgo'],
-              );
+              verifyEnvelope(message);
 
-              var payload = envelope['payload'];
-              if (payload == null || payload is! Map) {
-                if (!completer.isCompleted) {
-                  completer.completeError(
-                    'Received an auth signature'
-                    ' which does not include the payload',
-                  );
-                }
-                return;
-              }
-              if (payload['rvdNonce'] != rvdNonce) {
-                if (!completer.isCompleted) {
-                  completer.completeError(
-                    'Received rvdNonce which does not match what is expected',
-                  );
-                }
-                return;
-              }
-
-              AtSigningVerificationInput input =
-                  AtSigningVerificationInput(
-                      dataToVerify,
-                      base64Decode(envelope['signature']),
-                      publicKey,
-                    )
-                    ..signingAlgorithm = DefaultSigningAlgo(null, hashingAlgo)
-                    ..signingMode = AtSigningMode.data
-                    ..signingAlgoType = signingAlgo
-                    ..hashingAlgoType = hashingAlgo;
-
-              AtChopsKeys atChopsKeys = AtChopsKeys();
-              AtChops atChops = AtChopsImpl(atChopsKeys);
-              AtSigningResult atSigningResult = atChops.verify(input);
-              bool result = atSigningResult.result;
-
-              if (result == false) {
-                logger.shout(
-                  '$tag :'
-                  ' verification FAILURE :'
-                  ' ${atSigningResult.result}',
-                );
-                if (!completer.isCompleted) {
-                  completer.completeError(
-                    'Signature verification failed. Signatures did not match.',
-                  );
-                }
-                return;
-              }
-
-              logger.info(
-                '$tag :'
-                ' verification SUCCESS :'
-                ' ${atSigningResult.result}',
-              );
               authenticated = true;
               if (!completer.isCompleted) {
                 completer.complete((true, sc.stream));
@@ -687,6 +677,356 @@ class RelayAuthVerifierLegacy implements RelayAuthVerifier {
         }
       },
     );
+    return completer.future;
+  }
+}
+
+/// Default detection window for [RelayAuthVerifierAuto] (see that class).
+const int defaultRelayAuthDetectWindowMs = 500;
+
+/// A [RelayAuthVerifier] which auto-detects, per socket, whether the connecting
+/// side is using ESCR ([RelayAuthVerifierESCR]) or legacy ([RelayAuthVerifierLegacy])
+/// auth, without being told in advance. This lets the client and daemon each
+/// use the strongest auth they support, independently, and frees the client from
+/// having to learn the daemon's capabilities (via the daemon ping) before it can
+/// commit to a session-wide auth mode.
+///
+/// Detection relies on the opposite "who speaks first" semantics of the two
+/// schemes, both of which are left byte-for-byte unchanged on the wire:
+/// - A **legacy** connecting side writes its JSON signature envelope (starting
+///   with `{`) immediately on connect and never reads first.
+/// - An **ESCR** connecting side stays silent until the relay sends it a
+///   challenge, then replies `${sessionId}:${payload}`.
+///
+/// So this verifier:
+/// 1. Begins listening and starts a one-shot [detectWindow] timer.
+/// 2. If inbound data arrives first, it must be legacy — the first byte is `{` —
+///    so we run legacy verification (looking up the connecting atSign's public
+///    key lazily, only on this branch, unless one was pre-supplied).
+/// 3. If the window elapses with no data, we assume ESCR: send the challenge and
+///    run ESCR verification.
+///
+/// Trade-off: because the ESCR wire is unchanged (the peer waits to be
+/// challenged), every ESCR socket waits out [detectWindow] before the challenge
+/// is sent. [detectWindow] must exceed a legacy peer's first-packet arrival
+/// (≈ one RTT after connect); if it is too short, a slow legacy peer is misread
+/// as ESCR and, having been sent a challenge it does not read, its onward stream
+/// is corrupted. Raise it for high-latency legacy peers; lower it to speed ESCR.
+///
+/// The window is only the *fallback*. When the mode for a side is known ahead
+/// of the socket connecting — via the [knownMode] constructor argument (side A,
+/// whose mode the requesting client set in its own request) or via
+/// [setKnownMode] (side B, once the client has learnt the daemon's mode and
+/// sent the relay a definitive auth-modes notification) — detection is skipped:
+/// a known ESCR side is challenged immediately, and a known legacy side simply
+/// waits for its envelope with the timer cancelled (so it is never misread).
+/// A known mode is applied only while the socket is still being detected, never
+/// after it has committed by sending bytes, so a stale/incorrect ESCR hint can
+/// never challenge a socket that has already spoken legacy.
+class RelayAuthVerifierAuto implements RelayAuthVerifier {
+  @override
+  final String tag;
+
+  final RelayAuthVerifyHelper helper;
+
+  /// The atSign expected on this side of the tunnel. On the two-port relay path
+  /// the side (A/B) is known from which port the socket arrived on, so we know
+  /// the atSign up front; it is used for the legacy public-key lookup.
+  final String expectedAtSign;
+
+  final String _sessionId;
+
+  /// Legacy branch: the data whose signature is verified — the JSON encoding of
+  /// `{sessionId, clientNonce, rvdNonce}`.
+  final String dataToVerify;
+
+  /// Legacy branch: the rvdNonce which must appear in the signed payload.
+  final String rvdNonce;
+
+  /// Legacy branch: a pre-supplied public key for [expectedAtSign]. If null it
+  /// is looked up lazily (and only if the socket turns out to be legacy).
+  final String? publicKey;
+
+  /// How long to wait for the connecting side to speak (legacy) before assuming
+  /// ESCR and sending a challenge.
+  final Duration detectWindow;
+
+  late final AtSignLogger logger;
+
+  /// The composed ESCR verifier, used if the socket turns out to be ESCR. It
+  /// owns the challenge and the ESCR verification logic, and is the source of
+  /// [atSign] / [sessionId] / [isSideA] once ESCR has been verified.
+  late final RelayAuthVerifierESCR _escr;
+
+  /// The mode this side will use, if known ahead of detection. Set from the
+  /// constructor (side A) or [setKnownMode] (side B). Null means "detect".
+  RelayAuthMode? _knownMode;
+
+  /// Set by [verifySocketAuth] while it is running so [setKnownMode] can apply a
+  /// mode to the in-flight detection. Null before the socket has connected.
+  Future<void> Function(RelayAuthMode)? _resolveKnownMode;
+
+  RelayAuthVerifierAuto(
+    this.tag,
+    this.helper, {
+    required String atSign,
+    required String sessionId,
+    required this.dataToVerify,
+    required this.rvdNonce,
+    required this.detectWindow,
+    this.publicKey,
+    RelayAuthMode? knownMode,
+  }) : expectedAtSign = atSign,
+       _sessionId = sessionId {
+    logger = AtSignLogger(' $runtimeType ($tag) ');
+    _escr = RelayAuthVerifierESCR(tag, helper);
+    _knownMode = knownMode;
+  }
+
+  /// Tell this verifier which mode the connecting side will use, so it can skip
+  /// the [detectWindow] heuristic. Safe to call at any time and more than once:
+  /// the mode is applied only while the socket is still being detected (never
+  /// after it has committed by sending bytes), so an ESCR hint can never
+  /// challenge a socket that has already spoken legacy.
+  void setKnownMode(RelayAuthMode mode) {
+    _knownMode = mode;
+    final resolve = _resolveKnownMode;
+    if (resolve != null) {
+      unawaited(resolve(mode));
+    }
+  }
+
+  @override
+  Atsign? get atSign => _escr.atSign ?? expectedAtSign.toAtsign();
+
+  @override
+  String? get sessionId => _escr.sessionId ?? _sessionId;
+
+  /// `true` for side A (client), `false` for side B (daemon). Only populated
+  /// when the socket was verified via ESCR.
+  bool? get isSideA => _escr.isSideA;
+
+  @override
+  Future<(bool, Stream<Uint8List>?)> verifySocketAuth(Socket socket) async {
+    final completer = Completer<(bool, Stream<Uint8List>?)>();
+    final sc = StreamController<Uint8List>();
+    final buffer = <int>[];
+    bool authenticated = false;
+
+    // 'detecting' -> 'legacy' | 'escr'. Guarded by [mutex] so the detection
+    // timer and inbound-data events cannot race to pick different modes.
+    String mode = 'detecting';
+    final mutex = Mutex();
+    Timer? detectTimer;
+
+    logger.info(
+      'starting auto-detect listen'
+      ' (window ${detectWindow.inMilliseconds}ms)',
+    );
+
+    Future<void> failAuth(Object e) async {
+      logger.shout('auto verification FAILED with exception : $e');
+      if (!completer.isCompleted) {
+        try {
+          socket.writeln('Socket auth failed');
+          await socket.flush();
+          socket.destroy();
+        } catch (_) {
+        } finally {
+          completer.completeError('Error during socket authentication: $e');
+        }
+      }
+    }
+
+    void completeSuccess() {
+      authenticated = true;
+      if (!completer.isCompleted) {
+        completer.complete((true, sc.stream));
+      } else if (!sc.isClosed) {
+        sc.addError('Verify succeeded but completer already completed!!!');
+      }
+      if (buffer.isNotEmpty) {
+        if (!sc.isClosed) {
+          try {
+            sc.add(Uint8List.fromList(buffer));
+          } catch (err) {
+            logger.shout('finishing verify: sc.add failed with $err');
+          }
+        }
+        buffer.clear();
+      }
+    }
+
+    Future<void> handleLegacyLine(String message) async {
+      final String pk =
+          publicKey ??
+          await helper.lookup(_sessionId, 'public:publickey$expectedAtSign');
+      final legacy = RelayAuthVerifierLegacy(
+        pk,
+        dataToVerify,
+        rvdNonce,
+        tag,
+        expectedAtSign.toAtsign(),
+        _sessionId,
+      );
+      // Throws on failure. Note: legacy sends nothing back to the connecting
+      // side, so (unlike ESCR) we must not write to the socket here.
+      legacy.verifyEnvelope(message);
+      logger.info('Auto-detected LEGACY; verification success');
+      completeSuccess();
+    }
+
+    Future<void> handleEscrLine(String response) async {
+      for (final cu in response.codeUnits) {
+        if (isUnprintable(cu)) {
+          throw RAVE(
+            'received unprintable code units',
+            RAVEReason.malformedChallengeResponse,
+          );
+        }
+      }
+      final verified = await _escr.verifyChallengeResponse(response);
+      if (!verified) {
+        throw RAVE(
+          '(but verifyChallengeResponse did not throw an exception)',
+          RAVEReason.signatureVerificationFailed,
+        );
+      }
+      logger.info('Auto-detected ESCR; verification success');
+      socket.writeln('ok');
+      await socket.flush();
+      completeSuccess();
+    }
+
+    // Resolve this side to a concrete mode, skipping detection. The caller of
+    // [resolveLocked] must already hold [mutex]; [resolve] acquires it. A known
+    // ESCR side is challenged immediately; a known legacy side just waits for
+    // its signed envelope (timer cancelled). Both are no-ops once the socket
+    // has already committed to a mode, so a stale ESCR hint can never challenge
+    // a socket that has already sent bytes.
+    Future<void> resolveLocked(RelayAuthMode m) async {
+      if (mode != 'detecting' || authenticated) return;
+      detectTimer?.cancel();
+      if (m == RelayAuthMode.escr) {
+        mode = 'escr';
+        logger.info('resolving to ESCR; sending challenge');
+        socket.writeln(_escr.challenge);
+        await socket.flush();
+      } else {
+        mode = 'legacy';
+        logger.info('resolving to LEGACY; awaiting signed envelope');
+      }
+    }
+
+    Future<void> resolve(RelayAuthMode m) async {
+      await mutex.acquire();
+      try {
+        await resolveLocked(m);
+      } catch (e) {
+        await failAuth(e);
+      } finally {
+        mutex.release();
+      }
+    }
+
+    // Let setKnownMode() (called when the client's definitive auth-modes
+    // notification arrives) steer this in-flight detection.
+    _resolveKnownMode = resolve;
+
+    socket.listen(
+      (Uint8List data) async {
+        await mutex.acquire();
+        try {
+          if (authenticated) {
+            if (!sc.isClosed) {
+              try {
+                sc.add(data);
+              } catch (err) {
+                logger.shout('post-verify sc.add failed with $err');
+              }
+            }
+            return;
+          }
+
+          // The first unsolicited bytes can only be legacy (a JSON object);
+          // an ESCR peer sends nothing until we challenge it.
+          if (mode == 'detecting') {
+            detectTimer?.cancel();
+            final int? firstByte = data.isNotEmpty ? data.first : null;
+            if (firstByte == 0x7B /* '{' */ ) {
+              mode = 'legacy';
+            } else {
+              throw RAVE(
+                'Unexpected first byte $firstByte from connecting side'
+                ' (legacy sends a JSON object; ESCR sends nothing until'
+                ' challenged)',
+                RAVEReason.malformedChallengeResponse,
+              );
+            }
+          }
+
+          if (buffer.length + data.length >
+              RelayAuthVerifier.maxAuthBufferLength) {
+            throw RAVE(
+              'Too much data from client'
+              ' (more than ${RelayAuthVerifier.maxAuthBufferLength} bytes)',
+              RAVEReason.malformedChallengeResponse,
+            );
+          }
+          buffer.addAll(data);
+          if (buffer.contains(10)) {
+            final int idx = buffer.indexOf(10);
+            final List<int> lineBytes = buffer.sublist(0, idx);
+            buffer.removeRange(0, idx + 1);
+            final String line = String.fromCharCodes(lineBytes);
+            if (mode == 'legacy') {
+              await handleLegacyLine(line);
+            } else {
+              await handleEscrLine(line.trim());
+            }
+          }
+        } catch (e) {
+          await failAuth(e);
+        } finally {
+          mutex.release();
+        }
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        if (!sc.isClosed) {
+          sc.addError(error);
+          sc.close();
+        }
+      },
+      onDone: () {
+        if (!sc.isClosed) {
+          sc.close();
+        }
+      },
+    );
+
+    // If the mode is already known (side A from the request, or a side B hint
+    // that arrived before the socket connected) apply it now and skip the
+    // window; otherwise fall back to the timing heuristic.
+    await mutex.acquire();
+    try {
+      if (mode == 'detecting' && !authenticated) {
+        if (_knownMode != null) {
+          await resolveLocked(_knownMode!);
+        } else {
+          detectTimer = Timer(detectWindow, () {
+            logger.info(
+              'no data within ${detectWindow.inMilliseconds}ms; assuming ESCR',
+            );
+            resolve(RelayAuthMode.escr);
+          });
+        }
+      }
+    } catch (e) {
+      await failAuth(e);
+    } finally {
+      mutex.release();
+    }
+
     return completer.future;
   }
 }

--- a/packages/dart/noports_core/lib/src/srvd/relay_auth_verifiers.dart
+++ b/packages/dart/noports_core/lib/src/srvd/relay_auth_verifiers.dart
@@ -98,9 +98,19 @@ class RelayAuthVerifierESCR implements RelayAuthVerifier {
 
   final RelayAuthVerifyHelper helper;
 
+  /// A fresh, unguessable challenge for this one authentication. It is the sole
+  /// replay protection, so it MUST be fresh per connection — which is why this
+  /// verifier is single-use ([_consumed]): a new instance (hence a new
+  /// challenge) is required for every connection. Reusing one instance across a
+  /// session's connections would reissue the same challenge and let a captured
+  /// response be replayed onto further connections.
   final String challenge = AtChopsUtil.generateSymmetricKey(
     EncryptionKeyType.aes256,
   ).key;
+
+  /// Set once this verifier has issued its challenge and verified (or attempted
+  /// to verify) a response. Guards against instance reuse — see [challenge].
+  bool _consumed = false;
 
   /// If [randomlyFail] > 0 && random.nextInt([randomlyFail]) == 0
   /// then fail the verification
@@ -126,11 +136,17 @@ class RelayAuthVerifierESCR implements RelayAuthVerifier {
   }
 
   Future<bool> verifyChallengeResponse(String response) async {
-    // TODO Eliminate re-entrance race conditions
-    // TODO While not a problem right now, is laying a trap for the future
-    atSign = null;
-    isSideA = null;
-    sessionId = null;
+    // Single-use. Verifying a second response on the same instance would mean
+    // its challenge is being reused across connections, so refuse it. This also
+    // removes what used to be a re-entrance hazard here (shared atSign /
+    // sessionId / isSideA fields), since only one response is ever processed.
+    if (_consumed) {
+      throw StateError(
+        'RelayAuthVerifierESCR is single-use: construct a new instance per'
+        ' connection so that each gets its own fresh challenge',
+      );
+    }
+    _consumed = true;
 
     String abbreviated = response;
     if (response.length > 40) {
@@ -322,6 +338,14 @@ class RelayAuthVerifierESCR implements RelayAuthVerifier {
 
   @override
   Future<(bool, Stream<Uint8List>?)> verifySocketAuth(Socket socket) async {
+    // Single-use: refuse before reissuing a stale challenge to a new socket.
+    if (_consumed) {
+      throw StateError(
+        'RelayAuthVerifierESCR is single-use: construct a new instance per'
+        ' connection so that each gets its own fresh challenge',
+      );
+    }
+
     Completer<(bool, Stream<Uint8List>?)> completer = Completer();
     bool authenticated = false;
     StreamController<Uint8List> sc = StreamController();
@@ -723,6 +747,12 @@ const int defaultRelayAuthDetectWindowMs = 500;
 /// A known mode is applied only while the socket is still being detected, never
 /// after it has committed by sending bytes, so a stale/incorrect ESCR hint can
 /// never challenge a socket that has already spoken legacy.
+///
+/// The same verifier instance authenticates every connection on its side of the
+/// session (a session typically carries many), so once one connection's mode is
+/// verified it is remembered and every later connection skips detection too:
+/// only the very first connection on a side — and only if its mode was not
+/// already known — ever pays the window.
 class RelayAuthVerifierAuto implements RelayAuthVerifier {
   @override
   final String tag;
@@ -753,13 +783,9 @@ class RelayAuthVerifierAuto implements RelayAuthVerifier {
 
   late final AtSignLogger logger;
 
-  /// The composed ESCR verifier, used if the socket turns out to be ESCR. It
-  /// owns the challenge and the ESCR verification logic, and is the source of
-  /// [atSign] / [sessionId] / [isSideA] once ESCR has been verified.
-  late final RelayAuthVerifierESCR _escr;
-
-  /// The mode this side will use, if known ahead of detection. Set from the
-  /// constructor (side A) or [setKnownMode] (side B). Null means "detect".
+  /// The mode this side will use, if known. Set from the constructor (side A),
+  /// [setKnownMode] (side B), or memoised after the first connection on this
+  /// side authenticates successfully. Null means "detect".
   RelayAuthMode? _knownMode;
 
   /// Set by [verifySocketAuth] while it is running so [setKnownMode] can apply a
@@ -779,7 +805,6 @@ class RelayAuthVerifierAuto implements RelayAuthVerifier {
   }) : expectedAtSign = atSign,
        _sessionId = sessionId {
     logger = AtSignLogger(' $runtimeType ($tag) ');
-    _escr = RelayAuthVerifierESCR(tag, helper);
     _knownMode = knownMode;
   }
 
@@ -796,18 +821,22 @@ class RelayAuthVerifierAuto implements RelayAuthVerifier {
     }
   }
 
+  // On the two-port path the side (and thus atSign) is known from the port the
+  // socket arrived on, so we report the expected values directly. These are not
+  // consulted by SocketConnector.serverToServer (which uses the returned
+  // stream); they exist only to satisfy the RelayAuthVerifier interface.
   @override
-  Atsign? get atSign => _escr.atSign ?? expectedAtSign.toAtsign();
+  Atsign? get atSign => expectedAtSign.toAtsign();
 
   @override
-  String? get sessionId => _escr.sessionId ?? _sessionId;
-
-  /// `true` for side A (client), `false` for side B (daemon). Only populated
-  /// when the socket was verified via ESCR.
-  bool? get isSideA => _escr.isSideA;
+  String? get sessionId => _sessionId;
 
   @override
   Future<(bool, Stream<Uint8List>?)> verifySocketAuth(Socket socket) async {
+    // A fresh ESCR verifier per connection: single-use, so each connection gets
+    // its own fresh challenge (never reused across the session's connections).
+    final RelayAuthVerifierESCR escr = RelayAuthVerifierESCR(tag, helper);
+
     final completer = Completer<(bool, Stream<Uint8List>?)>();
     final sc = StreamController<Uint8List>();
     final buffer = <int>[];
@@ -840,6 +869,13 @@ class RelayAuthVerifierAuto implements RelayAuthVerifier {
 
     void completeSuccess() {
       authenticated = true;
+      // Every connection on this side of the session uses the same
+      // authenticator, so remember the mode we just verified: subsequent
+      // connections skip detection and go straight to it (see [_knownMode]).
+      // Cached only on success, so a failed or hostile probe cannot poison it.
+      _knownMode ??= (mode == 'escr')
+          ? RelayAuthMode.escr
+          : RelayAuthMode.payload;
       if (!completer.isCompleted) {
         completer.complete((true, sc.stream));
       } else if (!sc.isClosed) {
@@ -885,7 +921,7 @@ class RelayAuthVerifierAuto implements RelayAuthVerifier {
           );
         }
       }
-      final verified = await _escr.verifyChallengeResponse(response);
+      final verified = await escr.verifyChallengeResponse(response);
       if (!verified) {
         throw RAVE(
           '(but verifyChallengeResponse did not throw an exception)',
@@ -910,7 +946,7 @@ class RelayAuthVerifierAuto implements RelayAuthVerifier {
       if (m == RelayAuthMode.escr) {
         mode = 'escr';
         logger.info('resolving to ESCR; sending challenge');
-        socket.writeln(_escr.challenge);
+        socket.writeln(escr.challenge);
         await socket.flush();
       } else {
         mode = 'legacy';

--- a/packages/dart/noports_core/lib/src/srvd/session_info.dart
+++ b/packages/dart/noports_core/lib/src/srvd/session_info.dart
@@ -1,3 +1,5 @@
+import 'dart:isolate';
+
 import 'package:noports_core/events.dart';
 import 'package:noports_core/src/srvd/srvd_session_params.dart';
 import 'package:socket_connector/socket_connector.dart';
@@ -17,5 +19,9 @@ class SessionInfo {
 
   AtEventConfig? eventLoggingConfig;
 
-  SessionInfo({required this.params, required this.connector});
+  /// SendPort to this session's port-pair worker isolate, used to forward
+  /// later per-session messages (e.g. a definitive auth-modes notification).
+  final SendPort? toWorker;
+
+  SessionInfo({required this.params, required this.connector, this.toWorker});
 }

--- a/packages/dart/noports_core/lib/src/srvd/srvd_impl.dart
+++ b/packages/dart/noports_core/lib/src/srvd/srvd_impl.dart
@@ -46,6 +46,11 @@ class SrvdImpl
   final bool bind443;
   @override
   final int localBindPort443;
+
+  /// Window (ms) the auto-detecting relay auth verifiers wait for a connecting
+  /// side to speak (legacy) before assuming ESCR and issuing a challenge.
+  final int relayAuthDetectWindowMs;
+
   @override
   bool verbose = false;
 
@@ -70,6 +75,7 @@ class SrvdImpl
     required this.verbose,
     required this.bind443,
     required this.localBindPort443,
+    required this.relayAuthDetectWindowMs,
   }) {
     logger.hierarchicalLoggingEnabled = true;
     logger.logger.level = Level.SHOUT;
@@ -118,6 +124,7 @@ class SrvdImpl
         verbose: p.verbose,
         bind443: p.bind443,
         localBindPort443: p.localBindPort443,
+        relayAuthDetectWindowMs: p.relayAuthDetectWindowMs,
       );
 
       if (p.verbose) {
@@ -197,6 +204,8 @@ class SrvdImpl
       switch (messageType) {
         case 'request_ports':
           return await handleRequestPorts(n);
+        case 'auth_modes':
+          return await handleAuthModes(n);
         case 'sessions':
           return await handleSessionMessages(topic, n);
         case 'discover_request':
@@ -399,6 +408,7 @@ class SrvdImpl
     sessions[sessionParams.sessionId] = SessionInfo(
       params: sessionParams,
       connector: null,
+      toWorker: ppiSendToSpawned,
     );
 
     var (portA, portB) = ports;
@@ -461,6 +471,79 @@ class SrvdImpl
       Future.delayed(
         Duration(seconds: 30),
       ).whenComplete(() => preFetched.remove(sessionParams.sessionId)),
+    );
+  }
+
+  /// A requesting client, having learnt (via the daemon ping) which relay-auth
+  /// mode each side of its session will use, sends this so the relay can skip
+  /// the auto-detect window (see [Srvd] / RelayAuthVerifierAuto). Best-effort:
+  /// if it arrives after a socket has already connected, that socket falls back
+  /// to auto-detect. Only the session's requester (side A) may send it.
+  ///
+  /// Several relay instances share this atSign and all receive this
+  /// notification, but only one is actually handling the session — the one
+  /// whose response the client accepted. We match on that response's [rvdNonce]
+  /// (unique per relay instance's response) so the others ignore it. (When the
+  /// client cannot handle multiple acks, only the mutex-winning relay records
+  /// the session at all, so this is a belt-and-braces check there.)
+  Future<void> handleAuthModes(AtNotification n) async {
+    if (n.value == null) {
+      logger.warning('Received auth_modes with empty value from ${n.from}');
+      return;
+    }
+    final Map decoded;
+    try {
+      decoded = jsonDecode(n.value!);
+    } catch (e) {
+      logger.warning('Malformed auth_modes request from ${n.from}: $e');
+      return;
+    }
+
+    final String? sessionId = decoded['sessionId'];
+    if (sessionId == null) {
+      logger.warning('auth_modes request from ${n.from} has no sessionId');
+      return;
+    }
+
+    final SessionInfo? si = sessions[sessionId];
+    if (si == null) {
+      logger.info('auth_modes: this relay does not know session $sessionId');
+      return;
+    }
+    if (n.from != si.params.atSignA) {
+      logger.shout(
+        'auth_modes: ${n.from} is not the requester (${si.params.atSignA})'
+        ' of session $sessionId',
+      );
+      return;
+    }
+    if (decoded['rvdNonce'] != si.params.rvdNonce) {
+      logger.info(
+        'auth_modes: rvdNonce (${decoded['rvdNonce']}) is not this relay\'s'
+        ' rvdNonce (${si.params.rvdNonce}) for $sessionId'
+        ' — another instance is handling it; ignoring',
+      );
+      return;
+    }
+
+    final SendPort? toWorker = si.toWorker;
+    if (toWorker == null) {
+      logger.info(
+        'auth_modes: no worker isolate for session $sessionId'
+        ' (only443 sessions do not auto-detect)',
+      );
+      return;
+    }
+
+    toWorker.send(
+      IIRequest.create('auth_modes', {
+        'sideA': decoded['sideA'],
+        'sideB': decoded['sideB'],
+      }),
+    );
+    logger.info(
+      'Forwarded definitive auth modes for $sessionId to worker:'
+      ' sideA=${decoded['sideA']} sideB=${decoded['sideB']}',
     );
   }
 
@@ -610,6 +693,7 @@ class SrvdImpl
       BuildEnv.enableSnoop && logTraffic,
       verbose,
       sessionParams.sessionId,
+      relayAuthDetectWindowMs,
     );
 
     logger.info(
@@ -628,6 +712,7 @@ class SrvdImpl
         logTraffic: connectorParams.$2,
         verbose: connectorParams.$3,
         loggingTag: connectorParams.$4,
+        relayAuthDetectWindowMs: connectorParams.$5,
       );
 
       await worker.run();

--- a/packages/dart/noports_core/lib/src/srvd/srvd_params.dart
+++ b/packages/dart/noports_core/lib/src/srvd/srvd_params.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:at_cli_commons/at_cli_commons.dart';
 import 'package:noports_core/src/srvd/build_env.dart';
+import 'package:noports_core/src/srvd/relay_auth_verifiers.dart'
+    show defaultRelayAuthDetectWindowMs;
 
 class SrvdParams {
   final String atSign;
@@ -24,6 +26,10 @@ class SrvdParams {
   /// to forward port 443 on the host to some local port in the container
   final int localBindPort443;
 
+  /// How long (ms) the auto-detecting relay auth verifiers wait for a
+  /// connecting side to speak (legacy) before assuming ESCR and challenging it.
+  final int relayAuthDetectWindowMs;
+
   // Non param variables
   static final ArgParser parser = _createArgParser();
 
@@ -40,6 +46,7 @@ class SrvdParams {
     required this.perSessionStorage,
     required this.bind443,
     required this.localBindPort443,
+    required this.relayAuthDetectWindowMs,
     required this.debug,
   });
 
@@ -71,6 +78,7 @@ class SrvdParams {
       localBindPort443: r['443-bind-port'] == null
           ? 443
           : int.parse(r['443-bind-port']),
+      relayAuthDetectWindowMs: int.parse(r['relay-auth-detect-window-ms']),
       debug: r['debug'],
     );
   }
@@ -172,6 +180,17 @@ class SrvdParams {
           'The actual port to bind to - for example in a docker env you may'
           ' wish to forward port 443 on the host to a different port in the'
           ' container',
+    );
+    parser.addOption(
+      'relay-auth-detect-window-ms',
+      mandatory: false,
+      defaultsTo: '$defaultRelayAuthDetectWindowMs',
+      help:
+          'How long (ms) to wait for a connecting side to send its legacy auth'
+          ' before assuming it is using ESCR and issuing a challenge. Must'
+          ' exceed a legacy peer\'s first-packet arrival (~one RTT after'
+          ' connect); larger is safer for legacy peers, smaller speeds up ESCR'
+          ' handshakes.',
     );
     parser.addFlag(
       'help',

--- a/packages/dart/noports_core/lib/src/srvd/srvd_util_mixin.dart
+++ b/packages/dart/noports_core/lib/src/srvd/srvd_util_mixin.dart
@@ -163,6 +163,9 @@ mixin SrvdUtilMixin {
           portB: portB,
           rvdNonce: sessionParams.rvdNonce,
           supportsEventLogging: true,
+          // This srvd auto-detects each socket's relay-auth mode per side, so
+          // clients may safely use their strongest mode independently.
+          autoDetectsRelayAuth: true,
         ),
       );
     } else {

--- a/packages/dart/noports_core/lib/src/srvd/srvd_util_mixin.dart
+++ b/packages/dart/noports_core/lib/src/srvd/srvd_util_mixin.dart
@@ -43,6 +43,8 @@ mixin SrvdUtilMixin {
       switch (messageType) {
         case 'request_ports':
           return topic.split('.').length == 1;
+        case 'auth_modes':
+          return topic.split('.').length == 1;
         case 'sessions':
           final parts = topic.split('.');
           if (parts.length != 2) {

--- a/packages/dart/noports_core/lib/src/sshnp/impl/sshnp_dart_pure_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/impl/sshnp_dart_pure_impl.dart
@@ -151,7 +151,9 @@ class SshnpDartPureImpl extends SshnpCore
       host: srvdChannel.rvdHost,
       port: srvdChannel.daemonPort,
       authenticateToRvd: params.authenticateDeviceToRvd,
-      relayAuthMode: params.relayAuthMode,
+      relayAuthMode: srvdChannel.daemonRelayAuthMode(
+        daemonSupportsEscr: sshnpdChannel.daemonSupportsRelayAuthEscr,
+      ),
       relayAuthAesKey: srvdChannel.relayAuthAesKey,
       clientNonce: srvdChannel.clientNonce,
       rvdNonce: srvdChannel.rvdNonce,

--- a/packages/dart/noports_core/lib/src/sshnp/impl/sshnp_openssh_local_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/impl/sshnp_openssh_local_impl.dart
@@ -60,7 +60,9 @@ class SshnpOpensshLocalImpl extends SshnpCore
       host: srvdChannel.rvdHost,
       port: srvdChannel.daemonPort,
       authenticateToRvd: params.authenticateDeviceToRvd,
-      relayAuthMode: params.relayAuthMode,
+      relayAuthMode: srvdChannel.daemonRelayAuthMode(
+        daemonSupportsEscr: sshnpdChannel.daemonSupportsRelayAuthEscr,
+      ),
       relayAuthAesKey: srvdChannel.relayAuthAesKey,
       clientNonce: srvdChannel.clientNonce,
       rvdNonce: srvdChannel.rvdNonce,

--- a/packages/dart/noports_core/lib/src/sshnp/models/sshnp_arg.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/models/sshnp_arg.dart
@@ -398,9 +398,11 @@ class SshnpArg {
         ' "escr" (encrypted signed challenge response) is strongest and is the'
         ' default: it is used wherever the whole path supports it, while older'
         ' relays/daemons fall back to legacy and the relay auto-detects each'
-        ' side. Passing "escr" EXPLICITLY is prescriptive - it is forced on both'
-        ' sides and a daemon that cannot do ESCR becomes a hard error rather'
-        ' than a silent fallback. "payload" is the legacy mode. Alias: --ram',
+        ' side. Passing "escr" EXPLICITLY forces ESCR wherever the path supports'
+        ' it - the daemon side degrades to legacy if it cannot do ESCR, which an'
+        ' auto-detecting relay reconciles - and errors only when the relay does'
+        ' not auto-detect AND the daemon cannot do ESCR. "payload" is the legacy'
+        ' mode. Alias: --ram',
     defaultsTo: 'escr',
     allowed: ['payload', 'escr'],
     // allowed: RelayAuthMode.values.map((c) => c.name).toList(),

--- a/packages/dart/noports_core/lib/src/sshnp/models/sshnp_arg.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/models/sshnp_arg.dart
@@ -396,9 +396,11 @@ class SshnpArg {
     help:
         'The authentication mode to use when authenticating to the relay.'
         ' "escr" (encrypted signed challenge response) is strongest and is the'
-        ' default; the relay auto-detects each side\'s mode. "payload" is the'
-        ' legacy mode, kept for talking to relays which predate auto-detect.'
-        ' Alias: --ram',
+        ' default: it is used wherever the whole path supports it, while older'
+        ' relays/daemons fall back to legacy and the relay auto-detects each'
+        ' side. Passing "escr" EXPLICITLY is prescriptive - it is forced on both'
+        ' sides and a daemon that cannot do ESCR becomes a hard error rather'
+        ' than a silent fallback. "payload" is the legacy mode. Alias: --ram',
     defaultsTo: 'escr',
     allowed: ['payload', 'escr'],
     // allowed: RelayAuthMode.values.map((c) => c.name).toList(),

--- a/packages/dart/noports_core/lib/src/sshnp/models/sshnp_arg.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/models/sshnp_arg.dart
@@ -394,13 +394,14 @@ class SshnpArg {
     name: 'relay-auth-mode',
     aliases: ['ram'],
     help:
-        'The authentication mode to use. "escr" (encrypted signed challenge'
-        ' response) is strongest.'
+        'The authentication mode to use when authenticating to the relay.'
+        ' "escr" (encrypted signed challenge response) is strongest and is the'
+        ' default; the relay auto-detects each side\'s mode. "payload" is the'
+        ' legacy mode, kept for talking to relays which predate auto-detect.'
         ' Alias: --ram',
-    defaultsTo: 'payload',
+    defaultsTo: 'escr',
     allowed: ['payload', 'escr'],
     // allowed: RelayAuthMode.values.map((c) => c.name).toList(),
-    // defaultsTo: RelayAuthMode.payload.name,
   );
   static const daemonPingTimeoutArg = SshnpArg(
     name: 'daemon-ping-timeout',

--- a/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
@@ -27,6 +27,13 @@ abstract interface class ClientParams {
 
   RelayAuthMode get relayAuthMode;
 
+  /// Whether [relayAuthMode] was explicitly chosen by the caller (CLI flag,
+  /// config file, or API) rather than left at the default. When true the caller
+  /// is being prescriptive: the mode is forced on BOTH sides of the session and
+  /// the daemon is required to support it (an ESCR-incapable daemon is a
+  /// hard error) instead of the mode being softly negotiated per socket.
+  bool get relayAuthModeExplicit;
+
   bool get encryptRvdTraffic;
 
   String? get atKeysFilePath;
@@ -80,6 +87,9 @@ abstract class ClientParamsBase implements ClientParams {
   final RelayAuthMode relayAuthMode;
 
   @override
+  final bool relayAuthModeExplicit;
+
+  @override
   final bool encryptRvdTraffic;
 
   @override
@@ -121,6 +131,7 @@ abstract class ClientParamsBase implements ClientParams {
     this.authenticateClientToRvd = DefaultArgs.authenticateClientToRvd,
     this.authenticateDeviceToRvd = DefaultArgs.authenticateDeviceToRvd,
     required this.relayAuthMode,
+    this.relayAuthModeExplicit = false,
     this.encryptRvdTraffic = DefaultArgs.encryptRvdTraffic,
     this.daemonPingTimeout = DefaultArgs.daemonPingTimeoutDuration,
     required this.only443,
@@ -194,6 +205,7 @@ class NptParams extends ClientParamsBase
     super.authenticateClientToRvd = DefaultArgs.authenticateClientToRvd,
     super.authenticateDeviceToRvd = DefaultArgs.authenticateDeviceToRvd,
     super.relayAuthMode = DefaultArgs.relayAuthMode,
+    super.relayAuthModeExplicit = false,
     super.encryptRvdTraffic = DefaultArgs.encryptRvdTraffic,
     required this.inline,
     super.daemonPingTimeout,
@@ -280,6 +292,7 @@ class SshnpParams extends ClientParamsBase
     super.authenticateClientToRvd = DefaultArgs.authenticateClientToRvd,
     super.authenticateDeviceToRvd = DefaultArgs.authenticateDeviceToRvd,
     super.relayAuthMode = DefaultArgs.relayAuthMode,
+    super.relayAuthModeExplicit = false,
     super.encryptRvdTraffic = DefaultArgs.encryptRvdTraffic,
     super.daemonPingTimeout,
     super.only443 = false,
@@ -330,6 +343,10 @@ class SshnpParams extends ClientParamsBase
       authenticateDeviceToRvd:
           params2.authenticateDeviceToRvd ?? params1.authenticateDeviceToRvd,
       relayAuthMode: params2.relayAuthMode ?? params1.relayAuthMode,
+      // An explicitly-set mode in the incoming partial makes it prescriptive;
+      // otherwise inherit whatever the base params already resolved.
+      relayAuthModeExplicit:
+          params2.relayAuthMode != null || params1.relayAuthModeExplicit,
       encryptRvdTraffic: params2.encryptRvdTraffic ?? params1.encryptRvdTraffic,
       daemonPingTimeout: params2.daemonPingTimeout ?? params1.daemonPingTimeout,
       only443: params2.only443 ?? params1.only443,
@@ -389,6 +406,9 @@ class SshnpParams extends ClientParamsBase
           partial.authenticateDeviceToRvd ??
           DefaultArgs.authenticateDeviceToRvd,
       relayAuthMode: partial.relayAuthMode ?? DefaultArgs.relayAuthMode,
+      // A mode present in the partial came from a CLI flag or config file, so
+      // the caller chose it deliberately — treat it as prescriptive.
+      relayAuthModeExplicit: partial.relayAuthMode != null,
       encryptRvdTraffic:
           partial.encryptRvdTraffic ?? DefaultArgs.encryptRvdTraffic,
       daemonPingTimeout:

--- a/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
@@ -135,12 +135,15 @@ abstract class ClientParamsBase implements ClientParams {
         ' when using the "${SshnpArg.only443Arg.name}" flag',
       );
     }
-    if (relayAuthMode == RelayAuthMode.escr &&
-        (!authenticateClientToRvd || !authenticateDeviceToRvd)) {
+    // The 443 single-port relay multiplexes both sides onto one port and
+    // identifies each from its authenticated payload, so both sides must
+    // authenticate. General ESCR sessions do NOT require this: the relay
+    // auto-detects and verifies each socket independently, so one side may
+    // authenticate with ESCR while the other does not authenticate at all.
+    if (only443 && (!authenticateClientToRvd || !authenticateDeviceToRvd)) {
       throw ArgumentError(
-        'Both client and device need to authenticate to the'
-        ' relay when using'
-        ' "${SshnpArg.relayAuthModeArg.name} ${RelayAuthMode.escr.name}"',
+        'Both client and device must authenticate to the relay'
+        ' when using the "${SshnpArg.only443Arg.name}" flag',
       );
     }
   }
@@ -190,7 +193,7 @@ class NptParams extends ClientParamsBase
     super.rootDomain = DefaultArgs.rootDomain,
     super.authenticateClientToRvd = DefaultArgs.authenticateClientToRvd,
     super.authenticateDeviceToRvd = DefaultArgs.authenticateDeviceToRvd,
-    super.relayAuthMode = RelayAuthMode.payload,
+    super.relayAuthMode = DefaultArgs.relayAuthMode,
     super.encryptRvdTraffic = DefaultArgs.encryptRvdTraffic,
     required this.inline,
     super.daemonPingTimeout,
@@ -276,7 +279,7 @@ class SshnpParams extends ClientParamsBase
     this.addForwardsToTunnel = DefaultArgs.addForwardsToTunnel,
     super.authenticateClientToRvd = DefaultArgs.authenticateClientToRvd,
     super.authenticateDeviceToRvd = DefaultArgs.authenticateDeviceToRvd,
-    super.relayAuthMode = RelayAuthMode.payload,
+    super.relayAuthMode = DefaultArgs.relayAuthMode,
     super.encryptRvdTraffic = DefaultArgs.encryptRvdTraffic,
     super.daemonPingTimeout,
     super.only443 = false,
@@ -385,7 +388,7 @@ class SshnpParams extends ClientParamsBase
       authenticateDeviceToRvd:
           partial.authenticateDeviceToRvd ??
           DefaultArgs.authenticateDeviceToRvd,
-      relayAuthMode: partial.relayAuthMode ?? RelayAuthMode.payload,
+      relayAuthMode: partial.relayAuthMode ?? DefaultArgs.relayAuthMode,
       encryptRvdTraffic:
           partial.encryptRvdTraffic ?? DefaultArgs.encryptRvdTraffic,
       daemonPingTimeout:

--- a/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/models/sshnp_params.dart
@@ -464,6 +464,14 @@ class SshnpParams extends ClientParamsBase
       SshnpArg.authenticateClientToRvdArg.name: authenticateClientToRvd,
       SshnpArg.authenticateDeviceToRvdArg.name: authenticateDeviceToRvd,
       SshnpArg.encryptRvdTrafficArg.name: encryptRvdTraffic,
+      // Persist the relay-auth mode ONLY when it was explicitly chosen: the
+      // key's presence is what marks it prescriptive on reload (fromPartial
+      // derives relayAuthModeExplicit from it being non-null). Writing it
+      // unconditionally would silently make every saved config prescriptive;
+      // null is dropped by toConfigLines/round-trips as absent.
+      SshnpArg.relayAuthModeArg.name: relayAuthModeExplicit
+          ? relayAuthMode.name
+          : null,
     };
     args.removeWhere(
       (key, value) => !parserType.shouldParse(SshnpArg.fromName(key).parseWhen),

--- a/packages/dart/noports_core/lib/src/sshnp/sshnp_core.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/sshnp_core.dart
@@ -133,9 +133,12 @@ abstract class SshnpCore
     if (params.sendSshPublicKey) {
       requiredFeatures.add(DaemonFeature.acceptsPublicKeys);
     }
-    if (params.relayAuthMode == RelayAuthMode.escr) {
-      requiredFeatures.add(DaemonFeature.supportsRamEscr);
-    }
+    // Note: we deliberately do NOT require DaemonFeature.supportsRamEscr when
+    // using ESCR. Relay auth is negotiated per-socket by the auto-detecting
+    // relay, so each side uses its own best mode independently — the client
+    // need not know (or wait to learn, via the daemon ping) what the daemon
+    // will do. A daemon that cannot do ESCR simply falls back to legacy and
+    // the relay detects it.
     sendProgress('Sending daemon feature check request');
 
     Future<List<(DaemonFeature feature, bool supported, String reason)>>
@@ -179,6 +182,18 @@ abstract class SshnpCore
       if (!supported) throw SshnpError(reason);
     }
     sendProgress('Required daemon features are supported');
+
+    // The daemon ping has now resolved, so we know which relay-auth mode each
+    // side will use. Tell the relay definitively (before the daemon session
+    // request is sent, below) so it can skip the auto-detect window; if this
+    // loses the race to the daemon's socket, the relay just auto-detects.
+    final daemonFeatures = sshnpdChannel.pingResponse?['supportedFeatures'];
+    final bool daemonSupportsEscr =
+        daemonFeatures is Map &&
+        daemonFeatures[DaemonFeature.supportsRamEscr.name] == true;
+    await srvdChannel.sendDefinitiveAuthModes(
+      daemonSupportsEscr: daemonSupportsEscr,
+    );
   }
 
   @override

--- a/packages/dart/noports_core/lib/src/sshnp/sshnp_core.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/sshnp_core.dart
@@ -133,12 +133,18 @@ abstract class SshnpCore
     if (params.sendSshPublicKey) {
       requiredFeatures.add(DaemonFeature.acceptsPublicKeys);
     }
-    // Note: we deliberately do NOT require DaemonFeature.supportsRamEscr when
-    // using ESCR. Relay auth is negotiated per-socket by the auto-detecting
-    // relay, so each side uses its own best mode independently — the client
-    // need not know (or wait to learn, via the daemon ping) what the daemon
-    // will do. A daemon that cannot do ESCR simply falls back to legacy and
-    // the relay detects it.
+    // By default we do NOT require DaemonFeature.supportsRamEscr: relay auth is
+    // negotiated per-socket by an auto-detecting relay, so a daemon that cannot
+    // do ESCR simply falls back to legacy and the relay detects it — no ping
+    // wait. BUT when the user explicitly prescribes --relay-auth-mode escr we
+    // force ESCR on both sides, so we DO require the daemon to support it: an
+    // incapable daemon becomes a hard error ("...does not support the 'ESCR'
+    // relay auth mode") rather than a silent fallback that would contradict the
+    // explicit request.
+    if (params.relayAuthModeExplicit &&
+        params.relayAuthMode == RelayAuthMode.escr) {
+      requiredFeatures.add(DaemonFeature.supportsRamEscr);
+    }
     sendProgress('Sending daemon feature check request');
 
     Future<List<(DaemonFeature feature, bool supported, String reason)>>

--- a/packages/dart/noports_core/lib/src/sshnp/sshnp_core.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/sshnp_core.dart
@@ -133,23 +133,14 @@ abstract class SshnpCore
     if (params.sendSshPublicKey) {
       requiredFeatures.add(DaemonFeature.acceptsPublicKeys);
     }
-    // By default we do NOT require DaemonFeature.supportsRamEscr: relay auth is
-    // negotiated per-socket by an auto-detecting relay, so a daemon that cannot
-    // do ESCR simply falls back to legacy and the relay detects it — no ping
-    // wait. BUT when the user explicitly prescribes --relay-auth-mode escr we
-    // force ESCR on both sides, so we DO require the daemon to support it: an
-    // incapable daemon becomes a hard error ("...does not support the 'ESCR'
-    // relay auth mode") rather than a silent fallback that would contradict the
-    // explicit request. Only when the daemon actually authenticates to the relay
-    // (authenticateDeviceToRvd) — otherwise it does no relay auth at all and its
-    // ESCR capability is irrelevant, so requiring it would wrongly reject a
-    // supported config (client authenticates with ESCR, device not at all). This
-    // mirrors the DaemonFeature.srAuth guard above.
-    if (params.relayAuthModeExplicit &&
-        params.relayAuthMode == RelayAuthMode.escr &&
-        params.authenticateDeviceToRvd) {
-      requiredFeatures.add(DaemonFeature.supportsRamEscr);
-    }
+    // We deliberately do NOT require DaemonFeature.supportsRamEscr here: relay
+    // auth is negotiated per-socket by an auto-detecting relay, so a daemon that
+    // cannot do ESCR simply uses legacy on its own side and the relay reconciles
+    // it — no ping-gated wait, no abort. Even an explicit --relay-auth-mode escr
+    // degrades the daemon side to legacy rather than failing. The single case
+    // that genuinely cannot be reconciled (explicit ESCR + a non-auto-detecting
+    // relay + a non-ESCR daemon) is rejected below, once both the relay response
+    // and the ping have resolved.
     sendProgress('Sending daemon feature check request');
 
     Future<List<(DaemonFeature feature, bool supported, String reason)>>
@@ -193,6 +184,29 @@ abstract class SshnpCore
       if (!supported) throw SshnpError(reason);
     }
     sendProgress('Required daemon features are supported');
+
+    // Reject an explicit --relay-auth-mode escr that this session genuinely
+    // cannot honour: a non-auto-detecting relay applies one mode to both sockets
+    // (and ignores the definitive-auth-modes hint), so if the daemon also cannot
+    // do ESCR the two ends can never agree. Fail fast with a clear message
+    // rather than a mid-connect handshake failure. Every other explicit-ESCR
+    // case degrades gracefully (side A ESCR, daemon side legacy, relay
+    // reconciles per socket).
+    if (SrvdChannel.escrRequestedButUnreconcilable(
+      explicitEscr: params.relayAuthModeExplicit &&
+          params.relayAuthMode == RelayAuthMode.escr,
+      only443: params.only443,
+      authenticateDeviceToRvd: params.authenticateDeviceToRvd,
+      autoDetect: srvdChannel.autoDetectsRelayAuth,
+      daemonSupportsEscr: sshnpdChannel.daemonSupportsRelayAuthEscr,
+    )) {
+      throw SshnpError(
+        'This session requires ESCR relay auth on the device daemon (either'
+        ' --only-port 443, or --relay-auth-mode escr through a relay that does'
+        ' not auto-detect), but the daemon does not support ESCR. Upgrade the'
+        ' daemon, or retry without --only-port 443 / --relay-auth-mode escr.',
+      );
+    }
 
     // The daemon ping has now resolved, so we know which relay-auth mode each
     // side will use. Tell the relay definitively (before the daemon session

--- a/packages/dart/noports_core/lib/src/sshnp/sshnp_core.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/sshnp_core.dart
@@ -140,9 +140,14 @@ abstract class SshnpCore
     // force ESCR on both sides, so we DO require the daemon to support it: an
     // incapable daemon becomes a hard error ("...does not support the 'ESCR'
     // relay auth mode") rather than a silent fallback that would contradict the
-    // explicit request.
+    // explicit request. Only when the daemon actually authenticates to the relay
+    // (authenticateDeviceToRvd) — otherwise it does no relay auth at all and its
+    // ESCR capability is irrelevant, so requiring it would wrongly reject a
+    // supported config (client authenticates with ESCR, device not at all). This
+    // mirrors the DaemonFeature.srAuth guard above.
     if (params.relayAuthModeExplicit &&
-        params.relayAuthMode == RelayAuthMode.escr) {
+        params.relayAuthMode == RelayAuthMode.escr &&
+        params.authenticateDeviceToRvd) {
       requiredFeatures.add(DaemonFeature.supportsRamEscr);
     }
     sendProgress('Sending daemon feature check request');

--- a/packages/dart/noports_core/lib/src/sshnp/sshnp_core.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/sshnp_core.dart
@@ -186,13 +186,10 @@ abstract class SshnpCore
     // The daemon ping has now resolved, so we know which relay-auth mode each
     // side will use. Tell the relay definitively (before the daemon session
     // request is sent, below) so it can skip the auto-detect window; if this
-    // loses the race to the daemon's socket, the relay just auto-detects.
-    final daemonFeatures = sshnpdChannel.pingResponse?['supportedFeatures'];
-    final bool daemonSupportsEscr =
-        daemonFeatures is Map &&
-        daemonFeatures[DaemonFeature.supportsRamEscr.name] == true;
+    // loses the race to the daemon's socket, the relay just auto-detects. No-op
+    // against a relay that doesn't auto-detect.
     await srvdChannel.sendDefinitiveAuthModes(
-      daemonSupportsEscr: daemonSupportsEscr,
+      daemonSupportsEscr: sshnpdChannel.daemonSupportsRelayAuthEscr,
     );
   }
 

--- a/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/relay_messages.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/relay_messages.dart
@@ -9,12 +9,20 @@ class RelayResponse {
   final String rvdNonce;
   final bool supportsEventLogging;
 
+  /// Whether this relay auto-detects each socket's relay-auth mode per side.
+  /// Only such a relay can reconcile a client and daemon that use different
+  /// modes; against a relay that does not (older releases, and the CSV
+  /// response format), the client must fall back to legacy for both sides.
+  /// Absent in older/CSV responses -> false.
+  final bool autoDetectsRelayAuth;
+
   RelayResponse({
     required this.address,
     required this.portA,
     required this.portB,
     required this.rvdNonce,
     required this.supportsEventLogging,
+    this.autoDetectsRelayAuth = false,
   });
 
   Map<String, dynamic> toJson() => {
@@ -23,6 +31,7 @@ class RelayResponse {
     'portB': portB,
     'rvdNonce': rvdNonce,
     'supportsEventLogging': supportsEventLogging,
+    'autoDetectsRelayAuth': autoDetectsRelayAuth,
   };
 
   factory RelayResponse.fromJson(Map<String, dynamic> json) {
@@ -32,6 +41,7 @@ class RelayResponse {
       portB: json['portB'],
       rvdNonce: json['rvdNonce'],
       supportsEventLogging: json['supportsEventLogging'],
+      autoDetectsRelayAuth: json['autoDetectsRelayAuth'] ?? false,
     );
   }
 }

--- a/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/srvd_channel.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/srvd_channel.dart
@@ -67,6 +67,37 @@ abstract class SrvdChannel<T>
 
   bool get supportsEventLogging => relayResponse.supportsEventLogging;
 
+  /// Whether the relay we were assigned auto-detects each socket's relay-auth
+  /// mode per side. Only such a relay can reconcile a client and daemon using
+  /// different modes; older relays apply one session-wide mode to both sockets.
+  bool get autoDetectsRelayAuth => relayResponse.autoDetectsRelayAuth;
+
+  /// The relay-auth mode a side will actually use. ESCR only when the client
+  /// prefers it ([preference]), the relay auto-detects ([autoDetect] — otherwise
+  /// it applies one mode to both sides, so ESCR would break a peer that can't do
+  /// it), and the peer supports it ([peerSupportsEscr]); otherwise legacy, which
+  /// every relay and daemon understands. This is the progressive-rollout gate:
+  /// ESCR is used only where the whole path is known to handle it.
+  @visibleForTesting
+  static RelayAuthMode effectiveRelayAuthMode({
+    required RelayAuthMode preference,
+    required bool autoDetect,
+    required bool peerSupportsEscr,
+  }) =>
+      (preference == RelayAuthMode.escr && autoDetect && peerSupportsEscr)
+      ? RelayAuthMode.escr
+      : RelayAuthMode.payload;
+
+  /// The relay-auth mode the daemon (side B) should use for this session, told
+  /// to it in the session request. ESCR only when this client prefers it, the
+  /// relay auto-detects, and [daemonSupportsEscr]; otherwise legacy.
+  RelayAuthMode daemonRelayAuthMode({required bool daemonSupportsEscr}) =>
+      effectiveRelayAuthMode(
+        preference: params.relayAuthMode,
+        autoDetect: autoDetectsRelayAuth,
+        peerSupportsEscr: daemonSupportsEscr,
+      );
+
   // * Volatile fields set at runtime
 
   String? aesKeyC2D;
@@ -134,7 +165,13 @@ abstract class SrvdChannel<T>
 
     RelayAuthenticator? relayAuthenticator;
     if (params.authenticateClientToRvd) {
-      switch (params.relayAuthMode) {
+      // Side A is us; our own ESCR support is a given, so peerSupportsEscr: true.
+      final RelayAuthMode sideAMode = SrvdChannel.effectiveRelayAuthMode(
+        preference: params.relayAuthMode,
+        autoDetect: autoDetectsRelayAuth,
+        peerSupportsEscr: true,
+      );
+      switch (sideAMode) {
         case RelayAuthMode.payload:
           relayAuthenticator = RelayAuthenticatorLegacy(
             signAndWrapAndJsonEncode(atClient, {
@@ -183,41 +220,35 @@ abstract class SrvdChannel<T>
     return srv.run();
   }
 
-  /// Tell the relay definitively which relay-auth mode each side of this
-  /// session will use, so it can skip the per-socket auto-detect window.
+  /// Tell the relay definitively which relay-auth mode each side of this session
+  /// will use, so it can skip the per-socket auto-detect window.
   ///
-  /// Side A is this client, whose mode is [params.relayAuthMode]. Side B is the
-  /// daemon: it uses ESCR only if this client is offering ESCR *and* the daemon
-  /// supports it ([daemonSupportsEscr], learnt from the daemon ping); otherwise
-  /// legacy. Best-effort and fire-and-forget: it is sent before the daemon
-  /// session request so it usually reaches the relay before the daemon's socket
-  /// does, but if it loses that race the relay simply auto-detects. A failure to
-  /// send is logged and swallowed — it only forfeits the optimisation.
+  /// Only meaningful — and only sent — when the relay auto-detects; an older
+  /// relay applies one session-wide mode and does not handle this notification.
+  /// Side A is this client; side B is the daemon, which uses ESCR only if it
+  /// supports it ([daemonSupportsEscr], learnt from the daemon ping).
+  /// Best-effort and fire-and-forget: sent before the daemon session request so
+  /// it usually reaches the relay before the daemon's socket does; if it loses
+  /// that race the relay simply auto-detects. A send failure is logged and
+  /// swallowed — it only forfeits the optimisation.
   ///
-  /// Several relay instances can share the relay atSign; we selected exactly one
-  /// (whose response we accepted) and only it is handling this session. We
-  /// include that relay's [rvdNonce] — unique to its response — so the other
-  /// instances, which also receive this notification, ignore it.
-  /// The mode the daemon (side B) will use to authenticate to the relay: ESCR
-  /// only if this client is offering ESCR (i.e. it is sending a session AES key,
-  /// which is what makes the daemon choose ESCR) *and* the daemon supports ESCR;
-  /// otherwise legacy. Isolated as a named, testable helper because getting it
-  /// wrong is dangerous: an "escr" hint for a side that actually speaks legacy
-  /// would have the relay challenge a socket that never reads it, corrupting the
-  /// stream.
-  @visibleForTesting
-  static RelayAuthMode sideBAuthMode(
-    RelayAuthMode clientMode,
-    bool daemonSupportsEscr,
-  ) => (clientMode == RelayAuthMode.escr && daemonSupportsEscr)
-      ? RelayAuthMode.escr
-      : RelayAuthMode.payload;
-
+  /// Several relay instances can share the relay atSign; we selected one (whose
+  /// response we accepted) and include its unique [rvdNonce] so the others,
+  /// which also receive this notification, ignore it.
   Future<void> sendDefinitiveAuthModes({required bool daemonSupportsEscr}) async {
-    final RelayAuthMode sideA = params.relayAuthMode;
-    final RelayAuthMode sideB = sideBAuthMode(
-      params.relayAuthMode,
-      daemonSupportsEscr,
+    // Nothing to declare to a relay that doesn't auto-detect (it wouldn't act on
+    // this notification, and both sides are legacy there anyway).
+    if (!autoDetectsRelayAuth) return;
+
+    final RelayAuthMode sideA = effectiveRelayAuthMode(
+      preference: params.relayAuthMode,
+      autoDetect: autoDetectsRelayAuth,
+      peerSupportsEscr: true,
+    );
+    final RelayAuthMode sideB = effectiveRelayAuthMode(
+      preference: params.relayAuthMode,
+      autoDetect: autoDetectsRelayAuth,
+      peerSupportsEscr: daemonSupportsEscr,
     );
 
     final AtKey authModesKey = AtKey()
@@ -337,7 +368,15 @@ abstract class SrvdChannel<T>
       authenticateSocketA: params.authenticateClientToRvd,
       authenticateSocketB: params.authenticateDeviceToRvd,
       clientNonce: clientNonce,
-      relayAuthMode: params.relayAuthMode,
+      // Declare the universally-safe legacy mode: a relay that does NOT
+      // auto-detect applies this one mode to both sockets, and legacy works with
+      // every daemon. A relay that DOES auto-detect ignores this and detects
+      // each side. The only exception is the 443 single-port relay, which
+      // multiplexes both sides on one port and requires ESCR (it rejects
+      // payload), so we keep declaring ESCR there.
+      relayAuthMode: params.only443
+          ? RelayAuthMode.escr
+          : RelayAuthMode.payload,
       relayAuthAesKey: relayAuthAesKey,
       only443: params.only443,
       multipleAcksOk: true,

--- a/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/srvd_channel.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/srvd_channel.dart
@@ -72,30 +72,41 @@ abstract class SrvdChannel<T>
   /// different modes; older relays apply one session-wide mode to both sockets.
   bool get autoDetectsRelayAuth => relayResponse.autoDetectsRelayAuth;
 
-  /// The relay-auth mode a side will actually use. ESCR only when the client
-  /// prefers it ([preference]), the relay auto-detects ([autoDetect] — otherwise
-  /// it applies one mode to both sides, so ESCR would break a peer that can't do
-  /// it), and the peer supports it ([peerSupportsEscr]); otherwise legacy, which
-  /// every relay and daemon understands. This is the progressive-rollout gate:
-  /// ESCR is used only where the whole path is known to handle it.
+  /// The relay-auth mode a side will actually use. This is the
+  /// progressive-rollout gate: ESCR is used only where the whole path is known
+  /// to handle it, otherwise legacy — which every relay and daemon understands.
+  ///
+  /// - [only443]: the 443 single-port relay multiplexes both sides on one port
+  ///   and is ESCR-only on every relay version (it rejects a legacy payload), so
+  ///   the 443 path always uses ESCR regardless of the rest.
+  /// - [autoDetect]: a relay that does NOT auto-detect applies one session-wide
+  ///   mode to both sockets — we declared the universally-safe legacy mode in
+  ///   request_ports, so both sides use it (ESCR would break a peer that can't
+  ///   do it). A relay that DOES auto-detect lets each side use its own best.
+  /// - [preference]/[peerSupportsEscr]: with an auto-detecting relay, a side
+  ///   uses ESCR only when the client prefers it and the peer supports it.
   @visibleForTesting
   static RelayAuthMode effectiveRelayAuthMode({
     required RelayAuthMode preference,
     required bool autoDetect,
     required bool peerSupportsEscr,
-  }) =>
-      (preference == RelayAuthMode.escr && autoDetect && peerSupportsEscr)
-      ? RelayAuthMode.escr
-      : RelayAuthMode.payload;
+    required bool only443,
+  }) {
+    if (only443) return RelayAuthMode.escr;
+    if (!autoDetect) return RelayAuthMode.payload;
+    return (preference == RelayAuthMode.escr && peerSupportsEscr)
+        ? RelayAuthMode.escr
+        : RelayAuthMode.payload;
+  }
 
   /// The relay-auth mode the daemon (side B) should use for this session, told
-  /// to it in the session request. ESCR only when this client prefers it, the
-  /// relay auto-detects, and [daemonSupportsEscr]; otherwise legacy.
+  /// to it in the session request. See [effectiveRelayAuthMode].
   RelayAuthMode daemonRelayAuthMode({required bool daemonSupportsEscr}) =>
       effectiveRelayAuthMode(
         preference: params.relayAuthMode,
         autoDetect: autoDetectsRelayAuth,
         peerSupportsEscr: daemonSupportsEscr,
+        only443: params.only443,
       );
 
   // * Volatile fields set at runtime
@@ -170,6 +181,7 @@ abstract class SrvdChannel<T>
         preference: params.relayAuthMode,
         autoDetect: autoDetectsRelayAuth,
         peerSupportsEscr: true,
+        only443: params.only443,
       );
       switch (sideAMode) {
         case RelayAuthMode.payload:
@@ -244,11 +256,13 @@ abstract class SrvdChannel<T>
       preference: params.relayAuthMode,
       autoDetect: autoDetectsRelayAuth,
       peerSupportsEscr: true,
+      only443: params.only443,
     );
     final RelayAuthMode sideB = effectiveRelayAuthMode(
       preference: params.relayAuthMode,
       autoDetect: autoDetectsRelayAuth,
       peerSupportsEscr: daemonSupportsEscr,
+      only443: params.only443,
     );
 
     final AtKey authModesKey = AtKey()

--- a/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/srvd_channel.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/srvd_channel.dart
@@ -98,11 +98,54 @@ abstract class SrvdChannel<T>
     required bool prescribed,
   }) {
     if (only443) return RelayAuthMode.escr;
-    if (prescribed) return preference;
+    if (prescribed) {
+      // Honour the explicit choice, but never ask a peer to speak ESCR it
+      // cannot do: degrade THIS side to legacy and let the relay reconcile per
+      // socket (the client always supports ESCR, so side A is unaffected; a
+      // non-ESCR daemon simply falls back to legacy and the relay/hint sort it
+      // out). The one genuinely unreconcilable case -- explicit ESCR through a
+      // non-auto-detecting relay to a non-ESCR daemon -- is rejected up front
+      // (see [escrRequestedButUnreconcilable] / initialize()), not silently
+      // mis-sent here.
+      if (preference == RelayAuthMode.escr && !peerSupportsEscr) {
+        return RelayAuthMode.payload;
+      }
+      return preference;
+    }
     if (!autoDetect) return RelayAuthMode.payload;
     return (preference == RelayAuthMode.escr && peerSupportsEscr)
         ? RelayAuthMode.escr
         : RelayAuthMode.payload;
+  }
+
+  /// Whether ESCR is unavoidably required of the daemon this session but the
+  /// daemon cannot do it — in which case the session must be rejected up front
+  /// rather than fail mid-connect.
+  ///
+  /// Never true unless the daemon both authenticates to the relay
+  /// ([authenticateDeviceToRvd]) and cannot do ESCR ([daemonSupportsEscr]
+  /// false) — otherwise there is nothing to reconcile. Given that, ESCR is
+  /// unavoidable on the daemon's socket when EITHER:
+  /// - [only443] — the 443 single-port path is ESCR-only end-to-end on every
+  ///   relay (a legacy socket has no side field), so a non-ESCR daemon can never
+  ///   use it; or
+  /// - the user explicitly chose ESCR ([explicitEscr]) AND the relay does NOT
+  ///   auto-detect ([autoDetect] false) — an older relay applies one mode to
+  ///   both sockets and ignores the definitive-auth-modes hint, so the daemon
+  ///   cannot legacy-degrade independently.
+  ///
+  /// In every other explicit-ESCR case the client uses ESCR on its own side and
+  /// the daemon side degrades to legacy where needed, which an auto-detecting
+  /// relay reconciles per socket.
+  static bool escrRequestedButUnreconcilable({
+    required bool explicitEscr,
+    required bool only443,
+    required bool authenticateDeviceToRvd,
+    required bool autoDetect,
+    required bool daemonSupportsEscr,
+  }) {
+    if (!authenticateDeviceToRvd || daemonSupportsEscr) return false;
+    return only443 || (explicitEscr && !autoDetect);
   }
 
   /// The relay-auth mode the daemon (side B) should use for this session, told

--- a/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/srvd_channel.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/srvd_channel.dart
@@ -183,6 +183,72 @@ abstract class SrvdChannel<T>
     return srv.run();
   }
 
+  /// Tell the relay definitively which relay-auth mode each side of this
+  /// session will use, so it can skip the per-socket auto-detect window.
+  ///
+  /// Side A is this client, whose mode is [params.relayAuthMode]. Side B is the
+  /// daemon: it uses ESCR only if this client is offering ESCR *and* the daemon
+  /// supports it ([daemonSupportsEscr], learnt from the daemon ping); otherwise
+  /// legacy. Best-effort and fire-and-forget: it is sent before the daemon
+  /// session request so it usually reaches the relay before the daemon's socket
+  /// does, but if it loses that race the relay simply auto-detects. A failure to
+  /// send is logged and swallowed — it only forfeits the optimisation.
+  ///
+  /// Several relay instances can share the relay atSign; we selected exactly one
+  /// (whose response we accepted) and only it is handling this session. We
+  /// include that relay's [rvdNonce] — unique to its response — so the other
+  /// instances, which also receive this notification, ignore it.
+  /// The mode the daemon (side B) will use to authenticate to the relay: ESCR
+  /// only if this client is offering ESCR (i.e. it is sending a session AES key,
+  /// which is what makes the daemon choose ESCR) *and* the daemon supports ESCR;
+  /// otherwise legacy. Isolated as a named, testable helper because getting it
+  /// wrong is dangerous: an "escr" hint for a side that actually speaks legacy
+  /// would have the relay challenge a socket that never reads it, corrupting the
+  /// stream.
+  @visibleForTesting
+  static RelayAuthMode sideBAuthMode(
+    RelayAuthMode clientMode,
+    bool daemonSupportsEscr,
+  ) => (clientMode == RelayAuthMode.escr && daemonSupportsEscr)
+      ? RelayAuthMode.escr
+      : RelayAuthMode.payload;
+
+  Future<void> sendDefinitiveAuthModes({required bool daemonSupportsEscr}) async {
+    final RelayAuthMode sideA = params.relayAuthMode;
+    final RelayAuthMode sideB = sideBAuthMode(
+      params.relayAuthMode,
+      daemonSupportsEscr,
+    );
+
+    final AtKey authModesKey = AtKey()
+      ..key = '${params.device}.auth_modes.${Srvd.namespace}'
+      ..sharedBy = params.clientAtSign
+      ..sharedWith = params.srvdAtSign
+      ..metadata = (Metadata()
+        ..namespaceAware = false
+        ..ttl = 10000);
+
+    final String value = jsonEncode({
+      'sessionId': sessionId,
+      'rvdNonce': rvdNonce,
+      'sideA': sideA.name,
+      'sideB': sideB.name,
+    });
+
+    logger.info('Sending definitive auth modes to srvd: $value');
+    try {
+      await notify(
+        authModesKey,
+        value,
+        checkForFinalDeliveryStatus: false,
+        waitForFinalDeliveryStatus: false,
+        ttln: Duration(minutes: 1),
+      );
+    } catch (e) {
+      logger.warning('Failed to send definitive auth modes to srvd: $e');
+    }
+  }
+
   @protected
   @visibleForTesting
   Future<void> getHostAndPortFromSrvd({

--- a/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/srvd_channel.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/srvd_channel/srvd_channel.dart
@@ -79,6 +79,10 @@ abstract class SrvdChannel<T>
   /// - [only443]: the 443 single-port relay multiplexes both sides on one port
   ///   and is ESCR-only on every relay version (it rejects a legacy payload), so
   ///   the 443 path always uses ESCR regardless of the rest.
+  /// - [prescribed]: the caller explicitly chose [preference] (CLI/config/API),
+  ///   so honor it verbatim on both sides — overriding the progressive gate.
+  ///   ESCR here is validated up front by requiring the daemon feature, so an
+  ///   incapable daemon is a hard error rather than a silent fallback.
   /// - [autoDetect]: a relay that does NOT auto-detect applies one session-wide
   ///   mode to both sockets — we declared the universally-safe legacy mode in
   ///   request_ports, so both sides use it (ESCR would break a peer that can't
@@ -91,8 +95,10 @@ abstract class SrvdChannel<T>
     required bool autoDetect,
     required bool peerSupportsEscr,
     required bool only443,
+    required bool prescribed,
   }) {
     if (only443) return RelayAuthMode.escr;
+    if (prescribed) return preference;
     if (!autoDetect) return RelayAuthMode.payload;
     return (preference == RelayAuthMode.escr && peerSupportsEscr)
         ? RelayAuthMode.escr
@@ -107,6 +113,7 @@ abstract class SrvdChannel<T>
         autoDetect: autoDetectsRelayAuth,
         peerSupportsEscr: daemonSupportsEscr,
         only443: params.only443,
+        prescribed: params.relayAuthModeExplicit,
       );
 
   // * Volatile fields set at runtime
@@ -182,6 +189,7 @@ abstract class SrvdChannel<T>
         autoDetect: autoDetectsRelayAuth,
         peerSupportsEscr: true,
         only443: params.only443,
+        prescribed: params.relayAuthModeExplicit,
       );
       switch (sideAMode) {
         case RelayAuthMode.payload:
@@ -257,12 +265,14 @@ abstract class SrvdChannel<T>
       autoDetect: autoDetectsRelayAuth,
       peerSupportsEscr: true,
       only443: params.only443,
+      prescribed: params.relayAuthModeExplicit,
     );
     final RelayAuthMode sideB = effectiveRelayAuthMode(
       preference: params.relayAuthMode,
       autoDetect: autoDetectsRelayAuth,
       peerSupportsEscr: daemonSupportsEscr,
       only443: params.only443,
+      prescribed: params.relayAuthModeExplicit,
     );
 
     final AtKey authModesKey = AtKey()
@@ -382,15 +392,19 @@ abstract class SrvdChannel<T>
       authenticateSocketA: params.authenticateClientToRvd,
       authenticateSocketB: params.authenticateDeviceToRvd,
       clientNonce: clientNonce,
-      // Declare the universally-safe legacy mode: a relay that does NOT
-      // auto-detect applies this one mode to both sockets, and legacy works with
-      // every daemon. A relay that DOES auto-detect ignores this and detects
-      // each side. The only exception is the 443 single-port relay, which
-      // multiplexes both sides on one port and requires ESCR (it rejects
-      // payload), so we keep declaring ESCR there.
-      relayAuthMode: params.only443
-          ? RelayAuthMode.escr
-          : RelayAuthMode.payload,
+      // Declare the mode a relay that does NOT auto-detect must apply to BOTH
+      // sockets (it is sent before we learn whether this relay auto-detects).
+      // That is exactly effectiveRelayAuthMode with autoDetect:false — the
+      // universally-safe legacy mode by default, but ESCR when the path forces
+      // it: the 443 single-port relay (ESCR-only), or an explicit --relay-auth-mode.
+      // An auto-detecting relay ignores this field and detects each side.
+      relayAuthMode: effectiveRelayAuthMode(
+        preference: params.relayAuthMode,
+        autoDetect: false,
+        peerSupportsEscr: true,
+        only443: params.only443,
+        prescribed: params.relayAuthModeExplicit,
+      ),
       relayAuthAesKey: relayAuthAesKey,
       only443: params.only443,
       multipleAcksOk: true,

--- a/packages/dart/noports_core/lib/src/sshnp/util/sshnpd_channel/sshnpd_channel.dart
+++ b/packages/dart/noports_core/lib/src/sshnp/util/sshnpd_channel/sshnpd_channel.dart
@@ -66,6 +66,15 @@ abstract class SshnpdChannel
   /// [featureCheck] function.
   late final bool twinKeys;
 
+  /// Whether the daemon advertised support for the ESCR relay-auth mode (reads
+  /// the live ping response). Used to decide, progressively, whether the daemon
+  /// side of a session may use ESCR; false for daemons that predate it.
+  bool get daemonSupportsRelayAuthEscr {
+    final features = pingResponse?['supportedFeatures'];
+    return features is Map &&
+        features[DaemonFeature.supportsRamEscr.name] == true;
+  }
+
   SshnpdChannel({
     required this.atClient,
     required this.params,

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -897,28 +897,30 @@ class SshnpdImpl
     RelayAuthenticator? relayAuthenticator;
 
     if (req.authenticateToRvd) {
-      // Choose our own best relay-auth mode, independent of whatever mode the
-      // client committed to for itself. A session AES key in the request means
-      // the client set us up for ESCR (the strongest mode) — use it; otherwise
-      // fall back to legacy. The auto-detecting relay accepts whichever we use,
-      // so the two ends need not agree on a mode.
-      if (req.relayAuthAesKey != null) {
-        relayAuthenticator = RelayAuthenticatorESCR(
-          sessionId: req.sessionId,
-          relayAuthAesKey: req.relayAuthAesKey!,
-          publicSigningKeyUri: publicSigningKeyUri,
-          publicSigningKey: publicSigningKey,
-          privateSigningKey: privateSigningKey,
-          isSideA: false,
-        );
-      } else {
-        relayAuthenticator = RelayAuthenticatorLegacy(
-          signAndWrapAndJsonEncode(atClient, {
-            'sessionId': req.sessionId,
-            'clientNonce': req.clientNonce,
-            'rvdNonce': req.rvdNonce,
-          }),
-        );
+      // Use the mode the client told us to use. The client computes the mode
+      // this session's relay can reconcile: legacy against a relay that does not
+      // auto-detect (so both sides stay legacy and interoperate with any peer),
+      // ESCR only where the whole path is known to support it.
+      switch (req.relayAuthMode) {
+        case RelayAuthMode.payload:
+          relayAuthenticator = RelayAuthenticatorLegacy(
+            signAndWrapAndJsonEncode(atClient, {
+              'sessionId': req.sessionId,
+              'clientNonce': req.clientNonce,
+              'rvdNonce': req.rvdNonce,
+            }),
+          );
+          break;
+        case RelayAuthMode.escr:
+          relayAuthenticator = RelayAuthenticatorESCR(
+            sessionId: req.sessionId,
+            relayAuthAesKey: req.relayAuthAesKey!,
+            publicSigningKeyUri: publicSigningKeyUri,
+            publicSigningKey: publicSigningKey,
+            privateSigningKey: privateSigningKey,
+            isSideA: false,
+          );
+          break;
       }
     }
 
@@ -1257,28 +1259,30 @@ class SshnpdImpl
 
     RelayAuthenticator? relayAuthenticator;
     if (authenticateToRvd) {
-      // Choose our own best relay-auth mode, independent of whatever mode the
-      // client committed to for itself. A session AES key in the request means
-      // the client set us up for ESCR (the strongest mode) — use it; otherwise
-      // fall back to legacy. The auto-detecting relay accepts whichever we use,
-      // so the two ends need not agree on a mode.
-      if (req.relayAuthAesKey != null) {
-        relayAuthenticator = RelayAuthenticatorESCR(
-          sessionId: req.sessionId,
-          relayAuthAesKey: req.relayAuthAesKey!,
-          publicSigningKeyUri: publicSigningKeyUri,
-          publicSigningKey: publicSigningKey,
-          privateSigningKey: privateSigningKey,
-          isSideA: false,
-        );
-      } else {
-        relayAuthenticator = RelayAuthenticatorLegacy(
-          signAndWrapAndJsonEncode(atClient, {
-            'sessionId': req.sessionId,
-            'clientNonce': req.clientNonce,
-            'rvdNonce': req.rvdNonce,
-          }),
-        );
+      // Use the mode the client told us to use. The client computes the mode
+      // this session's relay can reconcile: legacy against a relay that does not
+      // auto-detect (so both sides stay legacy and interoperate with any peer),
+      // ESCR only where the whole path is known to support it.
+      switch (req.relayAuthMode) {
+        case RelayAuthMode.payload:
+          relayAuthenticator = RelayAuthenticatorLegacy(
+            signAndWrapAndJsonEncode(atClient, {
+              'sessionId': req.sessionId,
+              'clientNonce': req.clientNonce,
+              'rvdNonce': req.rvdNonce,
+            }),
+          );
+          break;
+        case RelayAuthMode.escr:
+          relayAuthenticator = RelayAuthenticatorESCR(
+            sessionId: req.sessionId,
+            relayAuthAesKey: req.relayAuthAesKey!,
+            publicSigningKeyUri: publicSigningKeyUri,
+            publicSigningKey: publicSigningKey,
+            privateSigningKey: privateSigningKey,
+            isSideA: false,
+          );
+          break;
       }
     }
 

--- a/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
+++ b/packages/dart/noports_core/lib/src/sshnpd/sshnpd_impl.dart
@@ -897,26 +897,28 @@ class SshnpdImpl
     RelayAuthenticator? relayAuthenticator;
 
     if (req.authenticateToRvd) {
-      switch (req.relayAuthMode) {
-        case RelayAuthMode.payload:
-          relayAuthenticator = RelayAuthenticatorLegacy(
-            signAndWrapAndJsonEncode(atClient, {
-              'sessionId': req.sessionId,
-              'clientNonce': req.clientNonce,
-              'rvdNonce': req.rvdNonce,
-            }),
-          );
-          break;
-        case RelayAuthMode.escr:
-          relayAuthenticator = RelayAuthenticatorESCR(
-            sessionId: req.sessionId,
-            relayAuthAesKey: req.relayAuthAesKey!,
-            publicSigningKeyUri: publicSigningKeyUri,
-            publicSigningKey: publicSigningKey,
-            privateSigningKey: privateSigningKey,
-            isSideA: false,
-          );
-          break;
+      // Choose our own best relay-auth mode, independent of whatever mode the
+      // client committed to for itself. A session AES key in the request means
+      // the client set us up for ESCR (the strongest mode) — use it; otherwise
+      // fall back to legacy. The auto-detecting relay accepts whichever we use,
+      // so the two ends need not agree on a mode.
+      if (req.relayAuthAesKey != null) {
+        relayAuthenticator = RelayAuthenticatorESCR(
+          sessionId: req.sessionId,
+          relayAuthAesKey: req.relayAuthAesKey!,
+          publicSigningKeyUri: publicSigningKeyUri,
+          publicSigningKey: publicSigningKey,
+          privateSigningKey: privateSigningKey,
+          isSideA: false,
+        );
+      } else {
+        relayAuthenticator = RelayAuthenticatorLegacy(
+          signAndWrapAndJsonEncode(atClient, {
+            'sessionId': req.sessionId,
+            'clientNonce': req.clientNonce,
+            'rvdNonce': req.rvdNonce,
+          }),
+        );
       }
     }
 
@@ -1255,26 +1257,28 @@ class SshnpdImpl
 
     RelayAuthenticator? relayAuthenticator;
     if (authenticateToRvd) {
-      switch (req.relayAuthMode) {
-        case RelayAuthMode.payload:
-          relayAuthenticator = RelayAuthenticatorLegacy(
-            signAndWrapAndJsonEncode(atClient, {
-              'sessionId': req.sessionId,
-              'clientNonce': req.clientNonce,
-              'rvdNonce': req.rvdNonce,
-            }),
-          );
-          break;
-        case RelayAuthMode.escr:
-          relayAuthenticator = RelayAuthenticatorESCR(
-            sessionId: req.sessionId,
-            relayAuthAesKey: req.relayAuthAesKey!,
-            publicSigningKeyUri: publicSigningKeyUri,
-            publicSigningKey: publicSigningKey,
-            privateSigningKey: privateSigningKey,
-            isSideA: false,
-          );
-          break;
+      // Choose our own best relay-auth mode, independent of whatever mode the
+      // client committed to for itself. A session AES key in the request means
+      // the client set us up for ESCR (the strongest mode) — use it; otherwise
+      // fall back to legacy. The auto-detecting relay accepts whichever we use,
+      // so the two ends need not agree on a mode.
+      if (req.relayAuthAesKey != null) {
+        relayAuthenticator = RelayAuthenticatorESCR(
+          sessionId: req.sessionId,
+          relayAuthAesKey: req.relayAuthAesKey!,
+          publicSigningKeyUri: publicSigningKeyUri,
+          publicSigningKey: publicSigningKey,
+          privateSigningKey: privateSigningKey,
+          isSideA: false,
+        );
+      } else {
+        relayAuthenticator = RelayAuthenticatorLegacy(
+          signAndWrapAndJsonEncode(atClient, {
+            'sessionId': req.sessionId,
+            'clientNonce': req.clientNonce,
+            'rvdNonce': req.rvdNonce,
+          }),
+        );
       }
     }
 

--- a/packages/dart/noports_core/test/srvd/handle_auth_modes_test.dart
+++ b/packages/dart/noports_core/test/srvd/handle_auth_modes_test.dart
@@ -1,0 +1,173 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:at_client/at_client.dart';
+import 'package:noports_core/src/srvd/isolates/types.dart';
+import 'package:noports_core/src/srvd/relay_auth_verifiers.dart'
+    show defaultRelayAuthDetectWindowMs;
+import 'package:noports_core/src/srvd/session_info.dart';
+import 'package:noports_core/src/srvd/srvd_impl.dart';
+import 'package:noports_core/src/srvd/srvd_session_params.dart';
+import 'package:test/test.dart';
+
+import '../sshnp/sshnp_mocks.dart';
+
+void main() {
+  group('SrvdImpl.handleAuthModes', () {
+    const clientAtsign = '@alice';
+    const daemonAtsign = '@bob';
+    const relayAtSign = '@relay';
+    const sessionId = 'sess-123';
+
+    // The rvdNonce THIS relay instance generated for the session.
+    const relayRvdNonce = '2026-01-01T00:00:00.000001';
+
+    late SrvdImpl srvd;
+    late ReceivePort workerPort;
+    late List<dynamic> forwarded;
+
+    SrvdImpl makeSrvd() => SrvdImpl(
+      atClient: MockAtClient(),
+      atSign: relayAtSign.toAtsign(),
+      homeDirectory: Directory.current.path,
+      atKeysFilePath: Directory.current.path,
+      managerAtsign: 'open',
+      ipAddress: '127.0.0.1',
+      logTraffic: false,
+      verbose: false,
+      bind443: false,
+      localBindPort443: 443,
+      relayAuthDetectWindowMs: defaultRelayAuthDetectWindowMs,
+    );
+
+    /// Registers a session owned by this relay instance, wiring [toWorker] to a
+    /// [ReceivePort] we can inspect. [rvdNonce] is the nonce this instance
+    /// generated; [toWorker] null models the only443 path (no worker isolate).
+    void registerSession({
+      String rvdNonce = relayRvdNonce,
+      bool withWorker = true,
+    }) {
+      srvd.sessions[sessionId] = SessionInfo(
+        params: SrvdSessionParams(
+          sessionId: sessionId,
+          atSignA: clientAtsign,
+          atSignB: daemonAtsign,
+          authenticateSocketA: true,
+          authenticateSocketB: true,
+          rvdNonce: rvdNonce,
+          only443: false,
+          multipleAcksOk: true,
+          preFetch: const [],
+          sendJsonResponse: true,
+        ),
+        connector: null,
+        toWorker: withWorker ? workerPort.sendPort : null,
+      );
+    }
+
+    AtNotification authModes({
+      String from = clientAtsign,
+      String? value,
+      String rvdNonce = relayRvdNonce,
+      String sideA = 'escr',
+      String sideB = 'escr',
+      String sid = sessionId,
+    }) {
+      final v =
+          value ??
+          jsonEncode({
+            'sessionId': sid,
+            'rvdNonce': rvdNonce,
+            'sideA': sideA,
+            'sideB': sideB,
+          });
+      return AtNotification(
+        'notif-id',
+        '$relayAtSign:local.auth_modes.sshrvd$from',
+        from,
+        relayAtSign,
+        123,
+        'key',
+        true,
+      )..value = v;
+    }
+
+    /// Runs [handleAuthModes] and gives the port a moment to deliver.
+    Future<void> deliver(AtNotification n) async {
+      await srvd.handleAuthModes(n);
+      await Future.delayed(const Duration(milliseconds: 20));
+    }
+
+    setUp(() {
+      srvd = makeSrvd();
+      workerPort = ReceivePort();
+      forwarded = [];
+      workerPort.listen(forwarded.add);
+    });
+
+    tearDown(() => workerPort.close());
+
+    test('forwards to the worker when sender and rvdNonce match', () async {
+      registerSession();
+      await deliver(authModes(sideA: 'escr', sideB: 'payload'));
+
+      expect(forwarded, hasLength(1));
+      final req = forwarded.single as IIRequest;
+      expect(req.type, 'auth_modes');
+      expect(req.payload['sideA'], 'escr');
+      expect(req.payload['sideB'], 'payload');
+    });
+
+    test('ignores a notification whose rvdNonce is another instance\'s',
+        () async {
+      // Several relays share @relay; this instance generated relayRvdNonce, but
+      // the client accepted a different instance's response, so its
+      // notification carries that other instance's nonce.
+      registerSession(rvdNonce: relayRvdNonce);
+      await deliver(authModes(rvdNonce: 'a-different-instances-nonce'));
+
+      expect(forwarded, isEmpty);
+    });
+
+    test('ignores a notification from someone other than the requester',
+        () async {
+      registerSession();
+      await deliver(authModes(from: daemonAtsign)); // not atSignA
+
+      expect(forwarded, isEmpty);
+    });
+
+    test('ignores a notification for a session this relay does not know',
+        () async {
+      // no registerSession()
+      await deliver(authModes());
+
+      expect(forwarded, isEmpty);
+    });
+
+    test('ignores a malformed (non-JSON) value', () async {
+      registerSession();
+      await deliver(authModes(value: 'not json'));
+
+      expect(forwarded, isEmpty);
+    });
+
+    test('ignores a value with no sessionId', () async {
+      registerSession();
+      await deliver(authModes(value: jsonEncode({'sideA': 'escr'})));
+
+      expect(forwarded, isEmpty);
+    });
+
+    test('does not throw when the session has no worker (only443 path)',
+        () async {
+      registerSession(withWorker: false);
+      // Should simply no-op rather than blow up.
+      await deliver(authModes());
+
+      expect(forwarded, isEmpty);
+    });
+  });
+}

--- a/packages/dart/noports_core/test/srvd/notification_subscription_test.dart
+++ b/packages/dart/noports_core/test/srvd/notification_subscription_test.dart
@@ -205,6 +205,7 @@ void main() {
           verbose: false,
           bind443: bind443,
           localBindPort443: localBindPort443,
+          relayAuthDetectWindowMs: defaultRelayAuthDetectWindowMs,
         );
       }
 

--- a/packages/dart/noports_core/test/srvd/notification_subscription_test.dart
+++ b/packages/dart/noports_core/test/srvd/notification_subscription_test.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 
 import 'package:at_client/at_client.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:noports_core/src/srvd/relay_auth_verifiers.dart'
+    show defaultRelayAuthDetectWindowMs;
 import 'package:noports_core/src/srvd/srvd_impl.dart';
 import 'package:noports_core/srvd.dart';
 import 'package:test/test.dart';
@@ -71,6 +73,7 @@ void main() {
         verbose: false,
         bind443: false,
         localBindPort443: 443,
+        relayAuthDetectWindowMs: defaultRelayAuthDetectWindowMs,
       );
 
       // Create a stream controller to simulate the notification received from the sshnp

--- a/packages/dart/noports_core/test/srvd/relay_auth_verifier_auto_test.dart
+++ b/packages/dart/noports_core/test/srvd/relay_auth_verifier_auto_test.dart
@@ -1,0 +1,438 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+import 'dart:io';
+
+import 'package:at_chops/at_chops.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:noports_core/src/common/types.dart';
+import 'package:noports_core/src/srv/relay_authenticators.dart';
+import 'package:noports_core/src/srvd/relay_auth_verifiers.dart';
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+class MockRelayAuthVerifyHelper extends Mock
+    implements RelayAuthVerifyHelper {}
+
+class MockSocket extends Mock implements Socket {}
+
+class MockStreamSubscription<T> extends Mock implements StreamSubscription<T> {}
+
+/// Builds a legacy signature envelope, exactly as the legacy connecting side
+/// would send it: `{"payload":..,"signature":..,"hashingAlgo":..,"signingAlgo":..}`.
+String signLegacyPayload(AtChops atChops, Map payload) {
+  final Map envelope = {'payload': payload};
+  final AtSigningInput signingInput = AtSigningInput(jsonEncode(payload))
+    ..signingMode = AtSigningMode.data;
+  final AtSigningResult sr = atChops.sign(signingInput);
+  envelope['signature'] = sr.result.toString();
+  envelope['hashingAlgo'] = sr.atSigningMetaData.hashingAlgoType!.name;
+  envelope['signingAlgo'] = sr.atSigningMetaData.signingAlgoType!.name;
+  return jsonEncode(envelope);
+}
+
+/// Wires up a [MockSocket] whose `writeln` calls are captured into [written],
+/// and whose `listen` handler is exposed via [onData] so the test can feed
+/// inbound bytes on demand.
+MockSocket makeMockSocket({
+  required List<String> written,
+  required void Function(void Function(Uint8List) fn) onData,
+}) {
+  final mockSocket = MockSocket();
+  when(() => mockSocket.writeln(any())).thenAnswer((invocation) {
+    final args = invocation.positionalArguments;
+    written.add(args.isEmpty ? '' : (args.first ?? '').toString());
+  });
+  when(() => mockSocket.flush()).thenAnswer((_) async {});
+  when(() => mockSocket.destroy()).thenReturn(null);
+  when(
+    () => mockSocket.listen(
+      any(),
+      onError: any(named: 'onError'),
+      onDone: any(named: 'onDone'),
+    ),
+  ).thenAnswer((invocation) {
+    onData(invocation.positionalArguments[0] as void Function(Uint8List));
+    return MockStreamSubscription<Uint8List>();
+  });
+  return mockSocket;
+}
+
+void main() {
+  group('RelayAuthVerifierAuto', () {
+    late AtChops atChops;
+    late String legacyPublicKey;
+
+    setUpAll(() {
+      final kp = AtChopsUtil.generateAtEncryptionKeyPair(keySize: 2048);
+      atChops = AtChopsImpl(AtChopsKeys.create(kp, null));
+      legacyPublicKey = kp.atPublicKey.publicKey;
+    });
+
+    test('auto-detects LEGACY from a leading "{" (pre-supplied key)', () async {
+      final rvdNonce = DateTime.now().toIso8601String();
+      final sessionId = Uuid().v4();
+      final payload = {'sessionId': sessionId, 'rvdNonce': rvdNonce};
+      final envelope = signLegacyPayload(atChops, payload);
+
+      final helper = MockRelayAuthVerifyHelper();
+      final written = <String>[];
+      late void Function(Uint8List) feed;
+      final mockSocket = makeMockSocket(
+        written: written,
+        onData: (fn) => feed = fn,
+      );
+
+      final verifier = RelayAuthVerifierAuto(
+        'auto sideA',
+        helper,
+        atSign: '@alice',
+        sessionId: sessionId,
+        dataToVerify: jsonEncode(payload),
+        rvdNonce: rvdNonce,
+        detectWindow: const Duration(seconds: 5), // must not fire in this test
+        publicKey: legacyPublicKey,
+      );
+
+      final resultFuture = verifier.verifySocketAuth(mockSocket);
+      feed(Uint8List.fromList(utf8.encode('$envelope\n')));
+
+      final (authenticated, stream) = await resultFuture;
+      expect(authenticated, true);
+      expect(stream, isNotNull);
+      // Legacy sends nothing back to the connecting side, so the relay must
+      // not have written anything (a challenge would corrupt a legacy peer).
+      expect(written, isEmpty);
+      // Legacy branch must not have consulted the helper for a key lookup.
+      verifyNever(() => helper.lookup(any(), any()));
+    });
+
+    test('auto-detects LEGACY and looks the public key up lazily', () async {
+      final rvdNonce = DateTime.now().toIso8601String();
+      final sessionId = Uuid().v4();
+      final payload = {'sessionId': sessionId, 'rvdNonce': rvdNonce};
+      final envelope = signLegacyPayload(atChops, payload);
+
+      final helper = MockRelayAuthVerifyHelper();
+      when(
+        () => helper.lookup(sessionId, 'public:publickey@alice'),
+      ).thenAnswer((_) async => legacyPublicKey);
+
+      final written = <String>[];
+      late void Function(Uint8List) feed;
+      final mockSocket = makeMockSocket(
+        written: written,
+        onData: (fn) => feed = fn,
+      );
+
+      final verifier = RelayAuthVerifierAuto(
+        'auto sideA',
+        helper,
+        atSign: '@alice',
+        sessionId: sessionId,
+        dataToVerify: jsonEncode(payload),
+        rvdNonce: rvdNonce,
+        detectWindow: const Duration(seconds: 5),
+        // no publicKey -> must be looked up
+      );
+
+      final resultFuture = verifier.verifySocketAuth(mockSocket);
+      feed(Uint8List.fromList(utf8.encode('$envelope\n')));
+
+      final (authenticated, _) = await resultFuture;
+      expect(authenticated, true);
+      expect(written, isEmpty);
+      verify(() => helper.lookup(sessionId, 'public:publickey@alice')).called(1);
+    });
+
+    test('auto-detects ESCR after silence, then challenges & verifies', () async {
+      final sessionId = Uuid().v4();
+      final relayAuthAesKey =
+          AtChopsUtil.generateSymmetricKey(EncryptionKeyType.aes256).key;
+      final signingKP = AtChopsUtil.generateAtEncryptionKeyPair(keySize: 2048);
+      const publicSigningKeyUri = '_apsk.my_enrollment_id.a.__e@alice';
+
+      final helper = MockRelayAuthVerifyHelper();
+      when(
+        () => helper.isSessionActive(sessionId),
+      ).thenAnswer((_) async => true);
+      when(
+        () => helper.getRelayAuthAesKey(sessionId),
+      ).thenAnswer((_) async => relayAuthAesKey);
+      when(
+        () => helper.lookup(sessionId, publicSigningKeyUri),
+      ).thenAnswer((_) async => signingKP.atPublicKey.publicKey);
+
+      // The connecting (client) side which will answer the relay's challenge.
+      final authenticator = RelayAuthenticatorESCR(
+        sessionId: sessionId,
+        relayAuthAesKey: relayAuthAesKey,
+        publicSigningKeyUri: publicSigningKeyUri,
+        publicSigningKey: signingKP.atPublicKey.publicKey,
+        privateSigningKey: signingKP.atPrivateKey.privateKey,
+        isSideA: true,
+      );
+
+      final written = <String>[];
+      late void Function(Uint8List) feed;
+      final mockSocket = makeMockSocket(
+        written: written,
+        onData: (fn) => feed = fn,
+      );
+
+      final verifier = RelayAuthVerifierAuto(
+        'auto sideA',
+        helper,
+        atSign: '@alice',
+        sessionId: sessionId,
+        dataToVerify: 'unused for escr',
+        rvdNonce: 'unused for escr',
+        detectWindow: const Duration(milliseconds: 50),
+      );
+
+      final resultFuture = verifier.verifySocketAuth(mockSocket);
+
+      // Stay silent past the detection window: the relay should conclude ESCR
+      // and write the challenge.
+      await Future.delayed(const Duration(milliseconds: 250));
+      expect(
+        written,
+        hasLength(1),
+        reason: 'relay should have written exactly the challenge',
+      );
+      final challenge = written.first;
+
+      // Client answers the challenge; relay verifies and replies "ok".
+      final response = await authenticator.responseToChallenge(challenge);
+      feed(Uint8List.fromList(utf8.encode('$response\n')));
+
+      final (authenticated, stream) = await resultFuture;
+      expect(authenticated, true);
+      expect(stream, isNotNull);
+      expect(written, [challenge, 'ok']);
+      expect(verifier.sessionId, sessionId);
+      expect(verifier.atSign, '@alice');
+      expect(verifier.isSideA, true);
+    });
+
+    test('rejects an unexpected first byte (neither "{" nor silence)', () async {
+      final helper = MockRelayAuthVerifyHelper();
+      final written = <String>[];
+      late void Function(Uint8List) feed;
+      final mockSocket = makeMockSocket(
+        written: written,
+        onData: (fn) => feed = fn,
+      );
+
+      final verifier = RelayAuthVerifierAuto(
+        'auto sideA',
+        helper,
+        atSign: '@alice',
+        sessionId: Uuid().v4(),
+        dataToVerify: 'x',
+        rvdNonce: 'x',
+        detectWindow: const Duration(seconds: 5),
+      );
+
+      final resultFuture = verifier.verifySocketAuth(mockSocket);
+      feed(Uint8List.fromList(utf8.encode('not json\n')));
+
+      await expectLater(resultFuture, throwsA(anything));
+    });
+
+    test('known-ESCR side is challenged immediately, not after the window',
+        () async {
+      final fx = escrFixture();
+      final written = <String>[];
+      late void Function(Uint8List) feed;
+      final mockSocket = makeMockSocket(
+        written: written,
+        onData: (fn) => feed = fn,
+      );
+
+      final verifier = RelayAuthVerifierAuto(
+        'auto sideA',
+        fx.helper,
+        atSign: '@alice',
+        sessionId: fx.sessionId,
+        dataToVerify: 'unused for escr',
+        rvdNonce: 'unused for escr',
+        detectWindow: const Duration(seconds: 5), // must NOT be waited out
+        knownMode: RelayAuthMode.escr,
+      );
+
+      final resultFuture = verifier.verifySocketAuth(mockSocket);
+      // Well under the 5s window: the challenge must already be out.
+      await Future.delayed(const Duration(milliseconds: 100));
+      expect(
+        written,
+        hasLength(1),
+        reason: 'a known-ESCR side must be challenged without waiting',
+      );
+
+      final response = await fx.authenticator.responseToChallenge(written.first);
+      feed(Uint8List.fromList(utf8.encode('$response\n')));
+
+      final (authenticated, _) = await resultFuture;
+      expect(authenticated, true);
+      expect(written, [written.first, 'ok']);
+    });
+
+    test('known-LEGACY side is never challenged, even past the window',
+        () async {
+      final rvdNonce = DateTime.now().toIso8601String();
+      final sessionId = Uuid().v4();
+      final payload = {'sessionId': sessionId, 'rvdNonce': rvdNonce};
+      final envelope = signLegacyPayload(atChops, payload);
+
+      final helper = MockRelayAuthVerifyHelper();
+      final written = <String>[];
+      late void Function(Uint8List) feed;
+      final mockSocket = makeMockSocket(
+        written: written,
+        onData: (fn) => feed = fn,
+      );
+
+      final verifier = RelayAuthVerifierAuto(
+        'auto sideA',
+        helper,
+        atSign: '@alice',
+        sessionId: sessionId,
+        dataToVerify: jsonEncode(payload),
+        rvdNonce: rvdNonce,
+        detectWindow: const Duration(milliseconds: 50), // short on purpose
+        publicKey: legacyPublicKey,
+        knownMode: RelayAuthMode.payload,
+      );
+
+      final resultFuture = verifier.verifySocketAuth(mockSocket);
+      // Wait well past the (short) window: a known-legacy side must not be
+      // challenged (the timer must have been cancelled).
+      await Future.delayed(const Duration(milliseconds: 200));
+      expect(written, isEmpty, reason: 'known-legacy side must not be challenged');
+
+      feed(Uint8List.fromList(utf8.encode('$envelope\n')));
+      final (authenticated, _) = await resultFuture;
+      expect(authenticated, true);
+      expect(written, isEmpty);
+    });
+
+    test('setKnownMode(escr) resolves an in-flight detection immediately',
+        () async {
+      final fx = escrFixture();
+      final written = <String>[];
+      late void Function(Uint8List) feed;
+      final mockSocket = makeMockSocket(
+        written: written,
+        onData: (fn) => feed = fn,
+      );
+
+      final verifier = RelayAuthVerifierAuto(
+        'auto sideB',
+        fx.helper,
+        atSign: '@alice',
+        sessionId: fx.sessionId,
+        dataToVerify: 'unused for escr',
+        rvdNonce: 'unused for escr',
+        detectWindow: const Duration(seconds: 5),
+        // no knownMode: it arrives later, as the notification would
+      );
+
+      final resultFuture = verifier.verifySocketAuth(mockSocket);
+      // Let the detection window timer start, then deliver the hint (as the
+      // client's definitive auth-modes notification would).
+      await Future.delayed(const Duration(milliseconds: 50));
+      expect(written, isEmpty);
+      verifier.setKnownMode(RelayAuthMode.escr);
+
+      await Future.delayed(const Duration(milliseconds: 100));
+      expect(
+        written,
+        hasLength(1),
+        reason: 'setKnownMode(escr) should challenge without waiting the window',
+      );
+
+      final response = await fx.authenticator.responseToChallenge(written.first);
+      feed(Uint8List.fromList(utf8.encode('$response\n')));
+      final (authenticated, _) = await resultFuture;
+      expect(authenticated, true);
+    });
+
+    test('setKnownMode is ignored once the socket has committed to legacy',
+        () async {
+      final rvdNonce = DateTime.now().toIso8601String();
+      final sessionId = Uuid().v4();
+      final payload = {'sessionId': sessionId, 'rvdNonce': rvdNonce};
+      final envelope = signLegacyPayload(atChops, payload);
+
+      final helper = MockRelayAuthVerifyHelper();
+      final written = <String>[];
+      late void Function(Uint8List) feed;
+      final mockSocket = makeMockSocket(
+        written: written,
+        onData: (fn) => feed = fn,
+      );
+
+      final verifier = RelayAuthVerifierAuto(
+        'auto sideB',
+        helper,
+        atSign: '@alice',
+        sessionId: sessionId,
+        dataToVerify: jsonEncode(payload),
+        rvdNonce: rvdNonce,
+        detectWindow: const Duration(seconds: 5),
+        publicKey: legacyPublicKey,
+      );
+
+      final resultFuture = verifier.verifySocketAuth(mockSocket);
+      feed(Uint8List.fromList(utf8.encode('$envelope\n'))); // commits to legacy
+      final (authenticated, _) = await resultFuture;
+      expect(authenticated, true);
+
+      // A late (and here, wrong) hint must be a no-op — never challenge a socket
+      // that has already spoken legacy.
+      verifier.setKnownMode(RelayAuthMode.escr);
+      await Future.delayed(const Duration(milliseconds: 50));
+      expect(
+        written,
+        isEmpty,
+        reason: 'must not challenge a socket that already committed to legacy',
+      );
+    });
+  });
+}
+
+/// Sets up the helper stubs and a client-side [RelayAuthenticatorESCR] for an
+/// ESCR exchange, sharing one session id / key material.
+({
+  RelayAuthVerifyHelper helper,
+  RelayAuthenticatorESCR authenticator,
+  String sessionId,
+})
+escrFixture() {
+  final sessionId = Uuid().v4();
+  final relayAuthAesKey =
+      AtChopsUtil.generateSymmetricKey(EncryptionKeyType.aes256).key;
+  final signingKP = AtChopsUtil.generateAtEncryptionKeyPair(keySize: 2048);
+  const publicSigningKeyUri = '_apsk.my_enrollment_id.a.__e@alice';
+
+  final helper = MockRelayAuthVerifyHelper();
+  when(() => helper.isSessionActive(sessionId)).thenAnswer((_) async => true);
+  when(
+    () => helper.getRelayAuthAesKey(sessionId),
+  ).thenAnswer((_) async => relayAuthAesKey);
+  when(
+    () => helper.lookup(sessionId, publicSigningKeyUri),
+  ).thenAnswer((_) async => signingKP.atPublicKey.publicKey);
+
+  final authenticator = RelayAuthenticatorESCR(
+    sessionId: sessionId,
+    relayAuthAesKey: relayAuthAesKey,
+    publicSigningKeyUri: publicSigningKeyUri,
+    publicSigningKey: signingKP.atPublicKey.publicKey,
+    privateSigningKey: signingKP.atPrivateKey.privateKey,
+    isSideA: true,
+  );
+
+  return (helper: helper, authenticator: authenticator, sessionId: sessionId);
+}

--- a/packages/dart/noports_core/test/srvd/relay_auth_verifier_auto_test.dart
+++ b/packages/dart/noports_core/test/srvd/relay_auth_verifier_auto_test.dart
@@ -212,7 +212,6 @@ void main() {
       expect(written, [challenge, 'ok']);
       expect(verifier.sessionId, sessionId);
       expect(verifier.atSign, '@alice');
-      expect(verifier.isSideA, true);
     });
 
     test('rejects an unexpected first byte (neither "{" nor silence)', () async {
@@ -398,6 +397,68 @@ void main() {
         isEmpty,
         reason: 'must not challenge a socket that already committed to legacy',
       );
+    });
+
+    test('memoises the mode: a later connection on the same side skips the window',
+        () async {
+      final fx = escrFixture();
+      final verifier = RelayAuthVerifierAuto(
+        'auto sideB',
+        fx.helper,
+        atSign: '@alice',
+        sessionId: fx.sessionId,
+        dataToVerify: 'unused for escr',
+        rvdNonce: 'unused for escr',
+        detectWindow: const Duration(milliseconds: 300),
+      );
+
+      // Connection 1: mode unknown -> auto-detect via silence -> ESCR, which
+      // only challenges after the window elapses.
+      final written1 = <String>[];
+      late void Function(Uint8List) feed1;
+      final sock1 = makeMockSocket(
+        written: written1,
+        onData: (fn) => feed1 = fn,
+      );
+      final f1 = verifier.verifySocketAuth(sock1);
+      await Future.delayed(const Duration(milliseconds: 380)); // past the window
+      expect(
+        written1,
+        hasLength(1),
+        reason: 'first connection is challenged only after the window',
+      );
+      feed1(
+        Uint8List.fromList(
+          utf8.encode(
+            '${await fx.authenticator.responseToChallenge(written1.first)}\n',
+          ),
+        ),
+      );
+      expect((await f1).$1, true);
+
+      // Connection 2: SAME verifier, new socket. The mode is now memoised, so
+      // the challenge must appear well before the 300ms window would elapse.
+      final written2 = <String>[];
+      late void Function(Uint8List) feed2;
+      final sock2 = makeMockSocket(
+        written: written2,
+        onData: (fn) => feed2 = fn,
+      );
+      final f2 = verifier.verifySocketAuth(sock2);
+      await Future.delayed(const Duration(milliseconds: 30)); // << 300ms window
+      expect(
+        written2,
+        hasLength(1),
+        reason: 'later connection is challenged immediately (memoised ESCR)',
+      );
+      feed2(
+        Uint8List.fromList(
+          utf8.encode(
+            '${await fx.authenticator.responseToChallenge(written2.first)}\n',
+          ),
+        ),
+      );
+      expect((await f2).$1, true);
     });
   });
 }

--- a/packages/dart/noports_core/test/srvd/relay_authentication_escr_test.dart
+++ b/packages/dart/noports_core/test/srvd/relay_authentication_escr_test.dart
@@ -237,5 +237,35 @@ void main() {
       expect(verifier.sessionId, null);
       expect(verifier.isSideA, null);
     });
+
+    test('is single-use: verifying a second response throws', () async {
+      RelayAuthenticatorESCR authenticator = RelayAuthenticatorESCR(
+        sessionId: relaySessionId,
+        relayAuthAesKey: relayAuthAesKey,
+        publicSigningKeyUri: publicSigningKeyUri,
+        publicSigningKey: signingKP.atPublicKey.publicKey,
+        privateSigningKey: signingKP.atPrivateKey.privateKey,
+        isSideA: false,
+      );
+      RelayAuthVerifierESCR verifier = RelayAuthVerifierESCR(
+        'single-use',
+        helper,
+      );
+
+      // First use is fine.
+      final verified = await verifier.verifyChallengeResponse(
+        await authenticator.responseToChallenge(verifier.challenge),
+      );
+      expect(verified, true);
+
+      // A second use would reuse this verifier's (already issued) challenge
+      // across connections, so it must be refused.
+      await expectLater(
+        verifier.verifyChallengeResponse(
+          await authenticator.responseToChallenge(verifier.challenge),
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
   });
 }

--- a/packages/dart/noports_core/test/sshnp/models/sshnp_params_test.dart
+++ b/packages/dart/noports_core/test/sshnp/models/sshnp_params_test.dart
@@ -237,7 +237,7 @@ void main() {
           true,
         );
       });
-      test('ClientParamsBase escr requires both sides auth', () {
+      test('ClientParamsBase 443 requires both sides auth', () {
         expect(
           () => SshnpParams(
             clientAtSign: '@myClientAtSign',
@@ -283,6 +283,21 @@ void main() {
             relayAuthMode: RelayAuthMode.escr,
             authenticateClientToRvd: true,
             authenticateDeviceToRvd: true,
+          ).relayAuthMode,
+          RelayAuthMode.escr,
+        );
+      });
+      test('ClientParamsBase non-443 escr allows one-sided auth', () {
+        // With per-socket auto-detect at the relay, ESCR (outside the 443
+        // single-port path) no longer requires both sides to authenticate.
+        expect(
+          SshnpParams(
+            clientAtSign: '@myClientAtSign',
+            sshnpdAtSign: '',
+            srvdAtSign: '',
+            relayAuthMode: RelayAuthMode.escr,
+            authenticateClientToRvd: true,
+            authenticateDeviceToRvd: false,
           ).relayAuthMode,
           RelayAuthMode.escr,
         );

--- a/packages/dart/noports_core/test/sshnp/models/sshnp_params_test.dart
+++ b/packages/dart/noports_core/test/sshnp/models/sshnp_params_test.dart
@@ -302,6 +302,51 @@ void main() {
           RelayAuthMode.escr,
         );
       });
+
+      test('explicit relayAuthMode survives a config round-trip as prescriptive',
+          () {
+        final reloaded = SshnpParams.fromConfigLines(
+          'profile',
+          SshnpParams(
+            clientAtSign: '@client',
+            sshnpdAtSign: '@daemon',
+            srvdAtSign: '@srvd',
+            relayAuthMode: RelayAuthMode.escr,
+            relayAuthModeExplicit: true,
+          ).toConfigLines(),
+        );
+        expect(reloaded.relayAuthMode, RelayAuthMode.escr);
+        expect(reloaded.relayAuthModeExplicit, true);
+      });
+
+      test('an explicit payload mode also survives a config round-trip', () {
+        final reloaded = SshnpParams.fromConfigLines(
+          'profile',
+          SshnpParams(
+            clientAtSign: '@client',
+            sshnpdAtSign: '@daemon',
+            srvdAtSign: '@srvd',
+            relayAuthMode: RelayAuthMode.payload,
+            relayAuthModeExplicit: true,
+          ).toConfigLines(),
+        );
+        expect(reloaded.relayAuthMode, RelayAuthMode.payload);
+        expect(reloaded.relayAuthModeExplicit, true);
+      });
+
+      test('a non-explicit (default) relayAuthMode is not persisted, so a saved '
+          'config does not silently become prescriptive on reload', () {
+        final reloaded = SshnpParams.fromConfigLines(
+          'profile',
+          SshnpParams(
+            clientAtSign: '@client',
+            sshnpdAtSign: '@daemon',
+            srvdAtSign: '@srvd',
+            // relayAuthMode left at default, relayAuthModeExplicit false
+          ).toConfigLines(),
+        );
+        expect(reloaded.relayAuthModeExplicit, false);
+      });
       test('SshnpParams.clientAtSign test', () {
         final params = SshnpParams(
           clientAtSign: '@myClientAtSign',

--- a/packages/dart/noports_core/test/sshnp/sshnp_core_test.dart
+++ b/packages/dart/noports_core/test/sshnp/sshnp_core_test.dart
@@ -242,6 +242,103 @@ void main() {
         );
       });
     }); // group Initialization
+
+    group('explicit-escr daemon feature gate', () {
+      // Captures the requiredFeatures list that initialize() passes to
+      // featureCheck for the given params, by running the real
+      // SshnpCore.initialize() through StubbedSshnp.
+      Future<List<DaemonFeature>> requiredFeaturesFor(SshnpParams params) async {
+        when(() => mockAtClient.getPreferences()).thenReturn(null);
+        when(() => mockAtClient.setPreferences(any())).thenReturn(null);
+        final sshnpCore = StubbedSshnp(
+          atClient: mockAtClient,
+          params: params,
+          sshnpdChannel: mockSshnpdChannel,
+          srvdChannel: mockSrvdChannel,
+        );
+        sshnpCore.stubAsyncInitialization(
+          stubbedCallInitialization: stubbedCallInitialization,
+          stubbedInitialize: stubbedInitialize,
+          stubbedCompleteInitialization: stubbedCompleteInitialization,
+        );
+        whenInitialization(identityKeyPair: sshnpCore.identityKeyPair);
+        await sshnpCore.callInitialization();
+        final captured = verify(
+          () => mockSshnpdChannel.featureCheck(captureAny()),
+        ).captured;
+        return captured.last as List<DaemonFeature>;
+      }
+
+      SshnpParams paramsWith({
+        required RelayAuthMode relayAuthMode,
+        required bool relayAuthModeExplicit,
+        required bool authenticateDeviceToRvd,
+      }) => SshnpParams(
+        clientAtSign: '@client',
+        sshnpdAtSign: '@daemon',
+        srvdAtSign: '@srvd',
+        relayAuthMode: relayAuthMode,
+        relayAuthModeExplicit: relayAuthModeExplicit,
+        authenticateDeviceToRvd: authenticateDeviceToRvd,
+      );
+
+      test('explicit escr + device authenticates to relay -> requires '
+          'supportsRamEscr', () async {
+        expect(
+          await requiredFeaturesFor(
+            paramsWith(
+              relayAuthMode: RelayAuthMode.escr,
+              relayAuthModeExplicit: true,
+              authenticateDeviceToRvd: true,
+            ),
+          ),
+          contains(DaemonFeature.supportsRamEscr),
+        );
+      });
+
+      test('explicit escr but device does NOT authenticate to relay -> does '
+          'NOT require supportsRamEscr (regression fix)', () async {
+        // The daemon does no relay auth, so its ESCR capability is irrelevant;
+        // requiring it would wrongly reject a documented-supported config.
+        expect(
+          await requiredFeaturesFor(
+            paramsWith(
+              relayAuthMode: RelayAuthMode.escr,
+              relayAuthModeExplicit: true,
+              authenticateDeviceToRvd: false,
+            ),
+          ),
+          isNot(contains(DaemonFeature.supportsRamEscr)),
+        );
+      });
+
+      test('default (non-explicit) escr -> does NOT require supportsRamEscr',
+          () async {
+        expect(
+          await requiredFeaturesFor(
+            paramsWith(
+              relayAuthMode: RelayAuthMode.escr,
+              relayAuthModeExplicit: false,
+              authenticateDeviceToRvd: true,
+            ),
+          ),
+          isNot(contains(DaemonFeature.supportsRamEscr)),
+        );
+      });
+
+      test('explicit payload -> does NOT require supportsRamEscr', () async {
+        expect(
+          await requiredFeaturesFor(
+            paramsWith(
+              relayAuthMode: RelayAuthMode.payload,
+              relayAuthModeExplicit: true,
+              authenticateDeviceToRvd: true,
+            ),
+          ),
+          isNot(contains(DaemonFeature.supportsRamEscr)),
+        );
+      });
+    }); // group explicit-escr daemon feature gate
   }); // group SshnpCore
 
   group('A group of tests related to sshnp', () {

--- a/packages/dart/noports_core/test/sshnp/sshnp_core_test.dart
+++ b/packages/dart/noports_core/test/sshnp/sshnp_core_test.dart
@@ -243,11 +243,13 @@ void main() {
       });
     }); // group Initialization
 
-    group('explicit-escr daemon feature gate', () {
-      // Captures the requiredFeatures list that initialize() passes to
-      // featureCheck for the given params, by running the real
-      // SshnpCore.initialize() through StubbedSshnp.
-      Future<List<DaemonFeature>> requiredFeaturesFor(SshnpParams params) async {
+    group('explicit-escr unreconcilable rejection', () {
+      // Runs the real SshnpCore.initialize() (via StubbedSshnp). The default
+      // mocks report the unreconcilable environment for explicit escr: a
+      // NON-auto-detecting relay (MockSrvdChannel.autoDetectsRelayAuth == false)
+      // and a NON-escr daemon (MockSshnpdChannel.daemonSupportsRelayAuthEscr ==
+      // false).
+      Future<void> runInit(SshnpParams params) {
         when(() => mockAtClient.getPreferences()).thenReturn(null);
         when(() => mockAtClient.setPreferences(any())).thenReturn(null);
         final sshnpCore = StubbedSshnp(
@@ -262,11 +264,7 @@ void main() {
           stubbedCompleteInitialization: stubbedCompleteInitialization,
         );
         whenInitialization(identityKeyPair: sshnpCore.identityKeyPair);
-        await sshnpCore.callInitialization();
-        final captured = verify(
-          () => mockSshnpdChannel.featureCheck(captureAny()),
-        ).captured;
-        return captured.last as List<DaemonFeature>;
+        return sshnpCore.callInitialization();
       }
 
       SshnpParams paramsWith({
@@ -282,63 +280,60 @@ void main() {
         authenticateDeviceToRvd: authenticateDeviceToRvd,
       );
 
-      test('explicit escr + device authenticates to relay -> requires '
-          'supportsRamEscr', () async {
-        expect(
-          await requiredFeaturesFor(
+      test('aborts: explicit escr + non-auto-detecting relay + non-escr daemon '
+          '+ device authenticates', () async {
+        await expectLater(
+          runInit(
             paramsWith(
               relayAuthMode: RelayAuthMode.escr,
               relayAuthModeExplicit: true,
               authenticateDeviceToRvd: true,
             ),
           ),
-          contains(DaemonFeature.supportsRamEscr),
+          throwsA(isA<SshnpError>()),
         );
       });
 
-      test('explicit escr but device does NOT authenticate to relay -> does '
-          'NOT require supportsRamEscr (regression fix)', () async {
-        // The daemon does no relay auth, so its ESCR capability is irrelevant;
-        // requiring it would wrongly reject a documented-supported config.
-        expect(
-          await requiredFeaturesFor(
-            paramsWith(
-              relayAuthMode: RelayAuthMode.escr,
-              relayAuthModeExplicit: true,
-              authenticateDeviceToRvd: false,
-            ),
-          ),
-          isNot(contains(DaemonFeature.supportsRamEscr)),
-        );
-      });
-
-      test('default (non-explicit) escr -> does NOT require supportsRamEscr',
-          () async {
-        expect(
-          await requiredFeaturesFor(
+      test('does not abort: escr not explicit (graceful default)', () async {
+        await expectLater(
+          runInit(
             paramsWith(
               relayAuthMode: RelayAuthMode.escr,
               relayAuthModeExplicit: false,
               authenticateDeviceToRvd: true,
             ),
           ),
-          isNot(contains(DaemonFeature.supportsRamEscr)),
+          completes,
         );
       });
 
-      test('explicit payload -> does NOT require supportsRamEscr', () async {
-        expect(
-          await requiredFeaturesFor(
+      test('does not abort: device does not authenticate to the relay',
+          () async {
+        await expectLater(
+          runInit(
+            paramsWith(
+              relayAuthMode: RelayAuthMode.escr,
+              relayAuthModeExplicit: true,
+              authenticateDeviceToRvd: false,
+            ),
+          ),
+          completes,
+        );
+      });
+
+      test('does not abort: explicit payload', () async {
+        await expectLater(
+          runInit(
             paramsWith(
               relayAuthMode: RelayAuthMode.payload,
               relayAuthModeExplicit: true,
               authenticateDeviceToRvd: true,
             ),
           ),
-          isNot(contains(DaemonFeature.supportsRamEscr)),
+          completes,
         );
       });
-    }); // group explicit-escr daemon feature gate
+    }); // group explicit-escr unreconcilable rejection
   }); // group SshnpCore
 
   group('A group of tests related to sshnp', () {

--- a/packages/dart/noports_core/test/sshnp/sshnp_mocks.dart
+++ b/packages/dart/noports_core/test/sshnp/sshnp_mocks.dart
@@ -44,6 +44,9 @@ class MockSshnpParams extends Mock implements SshnpParams {
   RelayAuthMode get relayAuthMode => RelayAuthMode.payload;
 
   @override
+  bool get relayAuthModeExplicit => false;
+
+  @override
   bool get only443 => false;
 }
 

--- a/packages/dart/noports_core/test/sshnp/sshnp_mocks.dart
+++ b/packages/dart/noports_core/test/sshnp/sshnp_mocks.dart
@@ -49,7 +49,10 @@ class MockSshnpParams extends Mock implements SshnpParams {
 
 class MockSshnpdChannel extends Mock implements SshnpdChannel {}
 
-class MockSrvdChannel extends Mock implements SrvdChannel {}
+class MockSrvdChannel extends Mock implements SrvdChannel {
+  @override
+  Future<void> sendDefinitiveAuthModes({required bool daemonSupportsEscr}) async {}
+}
 
 /// [dart:io] Mocks
 class MockProcess extends Mock implements Process {}

--- a/packages/dart/noports_core/test/sshnp/sshnp_mocks.dart
+++ b/packages/dart/noports_core/test/sshnp/sshnp_mocks.dart
@@ -47,11 +47,21 @@ class MockSshnpParams extends Mock implements SshnpParams {
   bool get only443 => false;
 }
 
-class MockSshnpdChannel extends Mock implements SshnpdChannel {}
+class MockSshnpdChannel extends Mock implements SshnpdChannel {
+  @override
+  bool get daemonSupportsRelayAuthEscr => false;
+}
 
 class MockSrvdChannel extends Mock implements SrvdChannel {
   @override
   Future<void> sendDefinitiveAuthModes({required bool daemonSupportsEscr}) async {}
+
+  @override
+  bool get autoDetectsRelayAuth => false;
+
+  @override
+  RelayAuthMode daemonRelayAuthMode({required bool daemonSupportsEscr}) =>
+      RelayAuthMode.payload;
 }
 
 /// [dart:io] Mocks

--- a/packages/dart/noports_core/test/sshnp/util/srvd_channel/srvd_channel_test.dart
+++ b/packages/dart/noports_core/test/sshnp/util/srvd_channel/srvd_channel_test.dart
@@ -692,22 +692,38 @@ void main() {
       }
     });
 
-    test('prescribed mode is honoured verbatim, overriding the auto gate', () {
-      // The user explicitly chose the mode; use it on both sides regardless of
-      // whether the relay auto-detects or the peer advertises escr (an incapable
-      // daemon is caught up front by the feature-check, not silently downgraded).
+    test('prescribed escr is forced where the peer can do it, degraded where '
+        'it cannot', () {
+      for (final ad in [true, false]) {
+        // Peer supports escr -> escr forced regardless of auto-detect.
+        expect(
+          call(
+            preference: RelayAuthMode.escr,
+            autoDetect: ad,
+            peerSupportsEscr: true,
+            prescribed: true,
+          ),
+          RelayAuthMode.escr,
+          reason: 'prescribed escr + capable peer must be escr (ad=$ad)',
+        );
+        // Peer cannot do escr -> degrade THIS side to legacy (the client always
+        // can, so this only bites side B; side A passes peerSupportsEscr:true).
+        expect(
+          call(
+            preference: RelayAuthMode.escr,
+            autoDetect: ad,
+            peerSupportsEscr: false,
+            prescribed: true,
+          ),
+          RelayAuthMode.payload,
+          reason: 'prescribed escr + incapable peer must degrade (ad=$ad)',
+        );
+      }
+    });
+
+    test('prescribed payload is forced to legacy regardless', () {
       for (final ad in [true, false]) {
         for (final ps in [true, false]) {
-          expect(
-            call(
-              preference: RelayAuthMode.escr,
-              autoDetect: ad,
-              peerSupportsEscr: ps,
-              prescribed: true,
-            ),
-            RelayAuthMode.escr,
-            reason: 'prescribed escr must force escr (ad=$ad ps=$ps)',
-          );
           expect(
             call(
               preference: RelayAuthMode.payload,
@@ -716,7 +732,6 @@ void main() {
               prescribed: true,
             ),
             RelayAuthMode.payload,
-            reason: 'prescribed payload must force payload (ad=$ad ps=$ps)',
           );
         }
       }
@@ -733,6 +748,65 @@ void main() {
         ),
         RelayAuthMode.escr,
       );
+    });
+  });
+
+  group('SrvdChannel.escrRequestedButUnreconcilable', () {
+    bool call({
+      bool explicitEscr = true,
+      bool only443 = false,
+      bool authenticateDeviceToRvd = true,
+      bool autoDetect = false,
+      bool daemonSupportsEscr = false,
+    }) => SrvdChannel.escrRequestedButUnreconcilable(
+      explicitEscr: explicitEscr,
+      only443: only443,
+      authenticateDeviceToRvd: authenticateDeviceToRvd,
+      autoDetect: autoDetect,
+      daemonSupportsEscr: daemonSupportsEscr,
+    );
+
+    test('true: explicit escr + old relay + non-escr daemon + device '
+        'authenticates', () {
+      expect(call(), true);
+    });
+
+    test('true: 443 + non-escr daemon, even on an auto-detecting relay', () {
+      // 443 is ESCR-only end-to-end on every relay, so a non-escr daemon can
+      // never use it — reject regardless of auto-detect or explicit.
+      for (final ad in [true, false]) {
+        for (final ex in [true, false]) {
+          expect(
+            call(only443: true, autoDetect: ad, explicitEscr: ex),
+            true,
+            reason: 'only443 + non-escr daemon must reject (ad=$ad ex=$ex)',
+          );
+        }
+      }
+    });
+
+    test('false: 443 with an escr-capable daemon', () {
+      expect(call(only443: true, daemonSupportsEscr: true), false);
+    });
+
+    test('false when the relay auto-detects (non-443 escr reconciles per '
+        'socket)', () {
+      expect(call(autoDetect: true), false);
+    });
+
+    test('false when the daemon can do escr', () {
+      expect(call(daemonSupportsEscr: true), false);
+    });
+
+    test('false when escr was not explicitly requested (and not 443)', () {
+      expect(call(explicitEscr: false), false);
+    });
+
+    test('false when the device does not authenticate to the relay', () {
+      // No relay auth on side B at all, so its escr capability is moot — even
+      // for 443 (though 443 forces device auth elsewhere).
+      expect(call(authenticateDeviceToRvd: false), false);
+      expect(call(only443: true, authenticateDeviceToRvd: false), false);
     });
   });
 }

--- a/packages/dart/noports_core/test/sshnp/util/srvd_channel/srvd_channel_test.dart
+++ b/packages/dart/noports_core/test/sshnp/util/srvd_channel/srvd_channel_test.dart
@@ -611,10 +611,12 @@ void main() {
       required RelayAuthMode preference,
       required bool autoDetect,
       required bool peerSupportsEscr,
+      bool only443 = false,
     }) => SrvdChannel.effectiveRelayAuthMode(
       preference: preference,
       autoDetect: autoDetect,
       peerSupportsEscr: peerSupportsEscr,
+      only443: only443,
     );
 
     test('escr only when preference=escr AND relay auto-detects AND peer '
@@ -627,6 +629,26 @@ void main() {
         ),
         RelayAuthMode.escr,
       );
+    });
+
+    test('always escr on the 443-only path (ESCR-only on every relay), '
+        'regardless of auto-detect or preference', () {
+      for (final ad in [true, false]) {
+        for (final ps in [true, false]) {
+          for (final pref in [RelayAuthMode.escr, RelayAuthMode.payload]) {
+            expect(
+              call(
+                preference: pref,
+                autoDetect: ad,
+                peerSupportsEscr: ps,
+                only443: true,
+              ),
+              RelayAuthMode.escr,
+              reason: 'only443 must force escr (pref=$pref ad=$ad ps=$ps)',
+            );
+          }
+        }
+      }
     });
 
     test('legacy when the relay does NOT auto-detect (the regression fix)', () {

--- a/packages/dart/noports_core/test/sshnp/util/srvd_channel/srvd_channel_test.dart
+++ b/packages/dart/noports_core/test/sshnp/util/srvd_channel/srvd_channel_test.dart
@@ -612,11 +612,13 @@ void main() {
       required bool autoDetect,
       required bool peerSupportsEscr,
       bool only443 = false,
+      bool prescribed = false,
     }) => SrvdChannel.effectiveRelayAuthMode(
       preference: preference,
       autoDetect: autoDetect,
       peerSupportsEscr: peerSupportsEscr,
       only443: only443,
+      prescribed: prescribed,
     );
 
     test('escr only when preference=escr AND relay auto-detects AND peer '
@@ -688,6 +690,49 @@ void main() {
           );
         }
       }
+    });
+
+    test('prescribed mode is honoured verbatim, overriding the auto gate', () {
+      // The user explicitly chose the mode; use it on both sides regardless of
+      // whether the relay auto-detects or the peer advertises escr (an incapable
+      // daemon is caught up front by the feature-check, not silently downgraded).
+      for (final ad in [true, false]) {
+        for (final ps in [true, false]) {
+          expect(
+            call(
+              preference: RelayAuthMode.escr,
+              autoDetect: ad,
+              peerSupportsEscr: ps,
+              prescribed: true,
+            ),
+            RelayAuthMode.escr,
+            reason: 'prescribed escr must force escr (ad=$ad ps=$ps)',
+          );
+          expect(
+            call(
+              preference: RelayAuthMode.payload,
+              autoDetect: ad,
+              peerSupportsEscr: ps,
+              prescribed: true,
+            ),
+            RelayAuthMode.payload,
+            reason: 'prescribed payload must force payload (ad=$ad ps=$ps)',
+          );
+        }
+      }
+    });
+
+    test('only443 wins even over a prescribed payload mode', () {
+      expect(
+        call(
+          preference: RelayAuthMode.payload,
+          autoDetect: false,
+          peerSupportsEscr: true,
+          only443: true,
+          prescribed: true,
+        ),
+        RelayAuthMode.escr,
+      );
     });
   });
 }

--- a/packages/dart/noports_core/test/sshnp/util/srvd_channel/srvd_channel_test.dart
+++ b/packages/dart/noports_core/test/sshnp/util/srvd_channel/srvd_channel_test.dart
@@ -518,6 +518,37 @@ void main() {
       },
     );
   });
+
+  group('SrvdChannel.sideBAuthMode', () {
+    test('escr only when the client is escr AND the daemon supports it', () {
+      // The one true case.
+      expect(
+        SrvdChannel.sideBAuthMode(RelayAuthMode.escr, true),
+        RelayAuthMode.escr,
+      );
+    });
+
+    test('legacy when the client is escr but the daemon does not support it',
+        () {
+      // Prevents an "escr" hint for a daemon that would actually speak legacy —
+      // which would corrupt its stream when the relay challenged it.
+      expect(
+        SrvdChannel.sideBAuthMode(RelayAuthMode.escr, false),
+        RelayAuthMode.payload,
+      );
+    });
+
+    test('legacy when the client is not using escr, regardless of daemon', () {
+      expect(
+        SrvdChannel.sideBAuthMode(RelayAuthMode.payload, true),
+        RelayAuthMode.payload,
+      );
+      expect(
+        SrvdChannel.sideBAuthMode(RelayAuthMode.payload, false),
+        RelayAuthMode.payload,
+      );
+    });
+  });
 }
 
 class FakeNotificationParamsMatcher extends Matcher {

--- a/packages/dart/noports_core/test/sshnp/util/srvd_channel/srvd_channel_test.dart
+++ b/packages/dart/noports_core/test/sshnp/util/srvd_channel/srvd_channel_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
@@ -312,6 +313,92 @@ void main() {
         expect(srvdDartBindPortChannel.rvdNonce, 'rvd_dummy_nonce');
         expect(srvdDartBindPortChannel.fetched, true);
         expect(srvdDartBindPortChannel.srvdAck, SrvdAck.acknowledged);
+        // Legacy CSV response (older relay) does not advertise auto-detection.
+        expect(srvdDartBindPortChannel.autoDetectsRelayAuth, false);
+      },
+    );
+
+    test(
+      'getHostAndPortFromSrvd reads autoDetectsRelayAuth from a JSON relay response',
+      () async {
+        registerFallbackValue(FakeNotificationParams());
+        String sessionId = 'dummy-session-id';
+        MockAtClient mockAtClient = MockAtClient();
+        MockNotificationService mockNotificationService =
+            MockNotificationService();
+
+        when(
+          () => mockAtClient.notificationService,
+        ).thenReturn(mockNotificationService);
+
+        when(
+          () => mockNotificationService.notify(
+            any(),
+            checkForFinalDeliveryStatus: any(
+              named: 'checkForFinalDeliveryStatus',
+            ),
+            waitForFinalDeliveryStatus: any(
+              named: 'waitForFinalDeliveryStatus',
+            ),
+            onSuccess: any(named: 'onSuccess'),
+            onError: any(named: 'onError'),
+            onSentToSecondary: any(named: 'onSentToSecondary'),
+          ),
+        ).thenAnswer(
+          (_) async => Future.value(
+            NotificationResult()
+              ..notificationStatusEnum = NotificationStatusEnum.delivered,
+          ),
+        );
+
+        final streamController = StreamController<AtNotification>();
+        streamController.add(
+          AtNotification(
+            '123',
+            '$sessionId.${Srvd.namespace}',
+            '@alice',
+            '@bob',
+            123,
+            'key',
+            true,
+          )..value = jsonEncode({
+            'address': '127.0.0.1',
+            'portA': 98878,
+            'portB': 98879,
+            'rvdNonce': 'rvd_dummy_nonce',
+            'supportsEventLogging': true,
+            'autoDetectsRelayAuth': true,
+          }),
+        );
+        when(
+          () => mockNotificationService.subscribe(
+            regex: any(named: 'regex'),
+            shouldDecrypt: any(named: 'shouldDecrypt'),
+          ),
+        ).thenAnswer((_) => streamController.stream);
+
+        SrvdChannelParams srvdChannelParams = NptParams(
+          clientAtSign: '@sshnp',
+          sshnpdAtSign: '@sshnpd',
+          srvdAtSign: '@srvd',
+          remoteHost: '127.0.0.1',
+          remotePort: 9887,
+          device: 'my_device1',
+          inline: true,
+          timeout: Duration(seconds: 30),
+        );
+        SrvdDartBindPortChannel srvdDartBindPortChannel =
+            SrvdDartBindPortChannel(
+              atClient: mockAtClient,
+              params: srvdChannelParams,
+              sessionId: sessionId,
+            );
+        await srvdDartBindPortChannel.getHostAndPortFromSrvd();
+        expect(srvdDartBindPortChannel.rvdHost, '127.0.0.1');
+        expect(srvdDartBindPortChannel.clientPort, 98878);
+        expect(srvdDartBindPortChannel.daemonPort, 98879);
+        expect(srvdDartBindPortChannel.rvdNonce, 'rvd_dummy_nonce');
+        expect(srvdDartBindPortChannel.autoDetectsRelayAuth, true);
       },
     );
 
@@ -519,34 +606,66 @@ void main() {
     );
   });
 
-  group('SrvdChannel.sideBAuthMode', () {
-    test('escr only when the client is escr AND the daemon supports it', () {
-      // The one true case.
+  group('SrvdChannel.effectiveRelayAuthMode', () {
+    RelayAuthMode call({
+      required RelayAuthMode preference,
+      required bool autoDetect,
+      required bool peerSupportsEscr,
+    }) => SrvdChannel.effectiveRelayAuthMode(
+      preference: preference,
+      autoDetect: autoDetect,
+      peerSupportsEscr: peerSupportsEscr,
+    );
+
+    test('escr only when preference=escr AND relay auto-detects AND peer '
+        'supports it', () {
       expect(
-        SrvdChannel.sideBAuthMode(RelayAuthMode.escr, true),
+        call(
+          preference: RelayAuthMode.escr,
+          autoDetect: true,
+          peerSupportsEscr: true,
+        ),
         RelayAuthMode.escr,
       );
     });
 
-    test('legacy when the client is escr but the daemon does not support it',
-        () {
-      // Prevents an "escr" hint for a daemon that would actually speak legacy —
-      // which would corrupt its stream when the relay challenged it.
+    test('legacy when the relay does NOT auto-detect (the regression fix)', () {
+      // A relay that applies one session-wide mode to both sides would break a
+      // peer that cannot do ESCR, so we must fall back to legacy there.
       expect(
-        SrvdChannel.sideBAuthMode(RelayAuthMode.escr, false),
+        call(
+          preference: RelayAuthMode.escr,
+          autoDetect: false,
+          peerSupportsEscr: true,
+        ),
         RelayAuthMode.payload,
       );
     });
 
-    test('legacy when the client is not using escr, regardless of daemon', () {
+    test('legacy when the peer does not support escr', () {
       expect(
-        SrvdChannel.sideBAuthMode(RelayAuthMode.payload, true),
+        call(
+          preference: RelayAuthMode.escr,
+          autoDetect: true,
+          peerSupportsEscr: false,
+        ),
         RelayAuthMode.payload,
       );
-      expect(
-        SrvdChannel.sideBAuthMode(RelayAuthMode.payload, false),
-        RelayAuthMode.payload,
-      );
+    });
+
+    test('legacy when the client did not prefer escr, regardless', () {
+      for (final ad in [true, false]) {
+        for (final ps in [true, false]) {
+          expect(
+            call(
+              preference: RelayAuthMode.payload,
+              autoDetect: ad,
+              peerSupportsEscr: ps,
+            ),
+            RelayAuthMode.payload,
+          );
+        }
+      }
     });
   });
 }

--- a/packages/dart/sshnoports/bin/npt.dart
+++ b/packages/dart/sshnoports/bin/npt.dart
@@ -282,8 +282,10 @@ void main(List<String> args) async {
             ' relay. "escr" (encrypted signed challenge response) is strongest'
             ' and is the default; used wherever the whole path supports it, with'
             ' older relays/daemons falling back to legacy (relay auto-detects).'
-            ' Passing "escr" explicitly forces it on both sides and errors if'
-            ' the daemon cannot do ESCR. "payload" is legacy. Alias: --ram',
+            ' Passing "escr" explicitly forces it where the path supports it (the'
+            ' daemon side degrades to legacy if it cannot), erroring only when the'
+            ' relay does not auto-detect AND the daemon cannot do ESCR. "payload"'
+            ' is legacy. Alias: --ram',
         allowed: RelayAuthMode.values.map((c) => c.name).toList(),
         defaultsTo: RelayAuthMode.escr.name,
       );

--- a/packages/dart/sshnoports/bin/npt.dart
+++ b/packages/dart/sshnoports/bin/npt.dart
@@ -278,10 +278,12 @@ void main(List<String> args) async {
       parser.addOption(
         'relay-auth-mode',
         aliases: ['ram'],
-        help: 'The authentication mode to use. "ecr" is strongest.'
-            ' Alias: --ram',
+        help: 'The authentication mode to use when authenticating to the'
+            ' relay. "escr" (encrypted signed challenge response) is strongest'
+            ' and is the default; the relay auto-detects each side\'s mode.'
+            ' "payload" is the legacy mode. Alias: --ram',
         allowed: RelayAuthMode.values.map((c) => c.name).toList(),
-        defaultsTo: RelayAuthMode.payload.name,
+        defaultsTo: RelayAuthMode.escr.name,
       );
 
       parser.addFlag(

--- a/packages/dart/sshnoports/bin/npt.dart
+++ b/packages/dart/sshnoports/bin/npt.dart
@@ -280,8 +280,10 @@ void main(List<String> args) async {
         aliases: ['ram'],
         help: 'The authentication mode to use when authenticating to the'
             ' relay. "escr" (encrypted signed challenge response) is strongest'
-            ' and is the default; the relay auto-detects each side\'s mode.'
-            ' "payload" is the legacy mode. Alias: --ram',
+            ' and is the default; used wherever the whole path supports it, with'
+            ' older relays/daemons falling back to legacy (relay auto-detects).'
+            ' Passing "escr" explicitly forces it on both sides and errors if'
+            ' the daemon cannot do ESCR. "payload" is legacy. Alias: --ram',
         allowed: RelayAuthMode.values.map((c) => c.name).toList(),
         defaultsTo: RelayAuthMode.escr.name,
       );
@@ -519,6 +521,9 @@ void main(List<String> args) async {
         encryptRvdTraffic: parsedArgs['encrypt-rvd-traffic'],
         relayAuthMode:
             RelayAuthMode.values.byName(parsedArgs['relay-auth-mode']),
+        // Prescriptive only when the user actually passed the flag (this parser
+        // has a defaultsTo, so the value alone can't tell explicit from default).
+        relayAuthModeExplicit: parsedArgs.wasParsed('relay-auth-mode'),
         timeout: parseDuration(timeoutArg),
         controlChannelHeartbeat: parseDuration(parsedArgs['heartbeat']),
         localHost: resolvedLocalHost,


### PR DESCRIPTION
## What I did

- Made the relay (`srvd`) **auto-detect each connecting side's relay-auth mode**
  (ESCR vs legacy) per socket, instead of being told one session-wide mode in
  the client's request. The client and daemon now each use their strongest
  relay auth independently, so the client no longer has to learn the daemon's
  capabilities (via the daemon ping) before contacting the relay. Clients
  default to ESCR; the daemon picks ESCR when the client offers a session AES
  key, else legacy.
- Added fast paths so the detection window is only a fallback: **side A** (the
  client) is taken from its own request; **side B** (the daemon) from an
  optional definitive auth-modes notification the client sends once it has the
  ping response; and a side's mode is **memoised after its first connection**,
  so only the first connection of a session ever detects.
- **Fixed a pre-existing security bug**: the two-port relay path issued one ESCR
  challenge per session and reused it for every connection, so a
  challenge-response captured on the wire could be replayed to authenticate
  later connections of that session. The 443 single-port path already did this
  correctly (fresh verifier per socket). Now the two-port path issues a fresh
  challenge per connection, and `RelayAuthVerifierESCR` is single-use so the
  reuse cannot silently recur.

## How I did it

- **Relay:** `RelayAuthVerifierAuto` detects per socket — a leading `{` is
  legacy; silence past a window is ESCR (new `srvd --relay-auth-detect-window-ms`,
  default 500). It constructs a fresh `RelayAuthVerifierESCR` per connection
  (fresh challenge) and memoises only the *mode*. Side A's mode comes from the
  request; side B's from a new `auth_modes` notification routed to the session's
  worker isolate and gated on the selected relay's `rvdNonce` (several relay
  instances share the atSign, so only the one handling the session acts).
  `RelayAuthVerifierESCR` is now single-use (throws on reuse), which also
  retired its re-entrance TODO.
- **Client:** default relay-auth mode flipped to ESCR; removed the
  `supportsRamEscr` required-feature gate (relay auth no longer depends on
  daemon features); sends the definitive auth-modes notification after the ping
  resolves, before the daemon session request. The 443 "both sides must
  authenticate" rule is re-scoped to the 443 path only.
- **Daemon:** chooses ESCR when `req.relayAuthAesKey != null`, else legacy.

## How to verify it

- `dart analyze --fatal-warnings` and `dart test --concurrency=1` in
  `packages/dart/noports_core` — 341 tests pass, including new unit tests for
  the auto-detect verifier (detection, known-mode/hint, the "ignored after
  commit" guard, memoisation), `handleAuthModes` (the `rvdNonce` multi-relay
  gate), the ESCR single-use guard, and the client `sideB` mode decision.
- End to end via the npe2e **relay** and **core** packs under `tests/npe2e`,
  which exercise payload/escr and normal/443 relay combinations and mixed-mode
  sessions.

## Description for the changelog

- feat: the relay auto-detects each connecting side's relay-auth mode (ESCR vs
  legacy) per socket; clients and daemons each use their strongest relay auth
  independently. Clients now default to ESCR. Adds
  `srvd --relay-auth-detect-window-ms`.
- fix: the two-port relay path now issues a fresh ESCR challenge per connection
  (it previously reused one per session, allowing replay onto later
  connections); `RelayAuthVerifierESCR` is single-use.

## Compatibility / rollout note

Because new clients default to ESCR, they will **not** interoperate with relays
older than 6.5.0 (which do not understand ESCR) — including a not-yet-upgraded
production relay — until those relays are on this build. Relays >= 6.5.0 keep
working; the new auto-detecting relay handles legacy and ESCR peers in any mix.
