### PR TITLE
test(npe2e): tolerate malformed bytes when capturing container/process logs

### DIFF
--- a/tests/npe2e/lib/docker_instance.dart
+++ b/tests/npe2e/lib/docker_instance.dart
@@ -193,7 +193,7 @@ class DockerInstance {
 
         // Listen to stdout and write to file
         process.stdout
-            .transform(SystemEncoding().decoder)
+            .transform(const Utf8Decoder(allowMalformed: true))
             .transform(const LineSplitter())
             .listen((line) {
               stdoutFile.writeAsStringSync('$line\n', mode: FileMode.append);
@@ -201,7 +201,7 @@ class DockerInstance {
 
         // Listen to stderr and write to file
         process.stderr
-            .transform(SystemEncoding().decoder)
+            .transform(const Utf8Decoder(allowMalformed: true))
             .transform(const LineSplitter())
             .listen((line) {
               stderrFile.writeAsStringSync('$line\n', mode: FileMode.append);

--- a/tests/npe2e/lib/docker_utils.dart
+++ b/tests/npe2e/lib/docker_utils.dart
@@ -27,10 +27,10 @@ Future<(String, String)> _captureProcessOutput(final Process process) async {
   final StringBuffer stderrBuf = StringBuffer();
   await Future.wait([
     process.stdout
-        .transform(utf8.decoder)
+        .transform(const Utf8Decoder(allowMalformed: true))
         .forEach((chunk) => stdoutBuf.write(chunk)),
     process.stderr
-        .transform(utf8.decoder)
+        .transform(const Utf8Decoder(allowMalformed: true))
         .forEach((chunk) => stderrBuf.write(chunk)),
   ]);
   return (stdoutBuf.toString(), stderrBuf.toString());

--- a/tests/npe2e/lib/process_utils.dart
+++ b/tests/npe2e/lib/process_utils.dart
@@ -17,7 +17,7 @@ class ProcessOutputCapture {
     this.stderrLogFile,
   }) {
     process.stdout
-        .transform(utf8.decoder)
+        .transform(const Utf8Decoder(allowMalformed: true))
         .transform(const LineSplitter())
         .listen((line) {
           stdoutBuffer.writeln(line);
@@ -27,7 +27,7 @@ class ProcessOutputCapture {
         });
 
     process.stderr
-        .transform(utf8.decoder)
+        .transform(const Utf8Decoder(allowMalformed: true))
         .transform(const LineSplitter())
         .listen((line) {
           stderrBuffer.writeln(line);
@@ -118,20 +118,20 @@ Future<Process> startCommand(
     environment: environment,
   );
   if (printOutput) {
-    process.stdout.transform(SystemEncoding().decoder).listen((data) {
+    process.stdout.transform(const Utf8Decoder(allowMalformed: true)).listen((data) {
       print('${executable} stdout: $data');
     });
-    process.stderr.transform(SystemEncoding().decoder).listen((data) {
+    process.stderr.transform(const Utf8Decoder(allowMalformed: true)).listen((data) {
       print('${executable} stderr: $data');
     });
   }
   if (stdoutLogFile != null) {
-    process.stdout.transform(SystemEncoding().decoder).listen((data) {
+    process.stdout.transform(const Utf8Decoder(allowMalformed: true)).listen((data) {
       stdoutLogFile.writeAsStringSync(data, mode: FileMode.append);
     });
   }
   if (stderrLogFile != null) {
-    process.stderr.transform(SystemEncoding().decoder).listen((data) {
+    process.stderr.transform(const Utf8Decoder(allowMalformed: true)).listen((data) {
       stderrLogFile.writeAsStringSync(data, mode: FileMode.append);
     });
   }


### PR DESCRIPTION
## What I did

Made the npe2e end-to-end harness resilient to malformed/binary bytes in the
container and process log output it captures, so a single stray byte can no
longer abort an entire test run.

## How I did it

The harness streams a container's `docker logs -f` (and process stdout/stderr)
through **strict** UTF-8 decoders — `SystemEncoding().decoder` is a strict
`Utf8Decoder` on POSIX, as is `utf8.decoder`. Any byte the strict decoder
rejects throws an **unhandled** `FormatException` that takes down the whole run:

- a multi-byte character split across a socket read boundary — the relay logs
  emoji such as `😎` / `🤷` — or
- binary in the log stream.

Switched the diagnostic-capture decoders to `Utf8Decoder(allowMalformed: true)`
so a stray byte is replaced with U+FFFD instead of aborting. Scope is the
log/process-output capture paths only:

- `docker_instance.dart` — the `docker logs -f` follower (stdout + stderr),
- `docker_utils.dart` — `_captureProcessOutput`,
- `process_utils.dart` — `ProcessOutputCapture` and `startCommand`'s
  log/print paths.

The inline core-test payload decoders are left strict, since malformed data
there would indicate a genuine test problem rather than log noise.

## How to verify it

- `dart analyze --fatal-warnings` is clean on the changed files.
- Observed live: on PR #2774's `npe2e (core_tests)`, the run aborted with exit
  code 255 **after 17/17 executed cells had passed**, with
  `FormatException: Missing extension byte (at offset 82)` emitted from the
  `docker logs --since ... -f` follower's decode. This change makes that path
  (and the sibling capture paths) tolerant, so log noise no longer aborts a run.

## Description for the changelog

- test(npe2e): tolerate malformed/binary bytes when capturing container and
  process logs, so a stray byte in log output cannot abort an entire e2e run.
