### PR TITLE
fix(noports_core): implement SSHSocket.flush + pin sshnoports to dartssh2 2.22.2

### DIFF
--- a/packages/dart/noports_core/lib/src/srv/srv_impl.dart
+++ b/packages/dart/noports_core/lib/src/srv/srv_impl.dart
@@ -394,6 +394,14 @@ class WrappedSSHSocket implements SSHSocket {
     onDestroy();
   }
 
+  // Added in dartssh2 2.22.2's SSHSocket interface. Because we `implements`
+  // SSHSocket (interface only, not the default body), we must supply it.
+  // Mirror the package's native socket: flush the underlying sink.
+  @override
+  Future<void> flush() async {
+    await underlyingSink.flush();
+  }
+
   @override
   Future<void> get done => sink.done;
 

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -373,10 +373,10 @@ packages:
     dependency: "direct main"
     description:
       name: dartssh2
-      sha256: c139babed0d6851449100010639115e1ed88decf0db7eb714ce13935c7eb590c
+      sha256: "68b066d130d0dd322018f5fa69ea919927f082d7062ef613b200c5f01e0c7636"
       url: "https://pub.dev"
     source: hosted
-    version: "2.17.1"
+    version: "2.22.2"
   duration:
     dependency: "direct main"
     description:

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -15,7 +15,10 @@ dependencies:
   at_client: ^3.11.0
   args: 2.7.0
   socket_connector: 2.4.1
-  dartssh2: ^2.17.1
+  # Pinned: dartssh2 added SSHSocket.flush in the 2.22.2 minor release (a semver
+  # slip that breaks `implements SSHSocket`), so pin it here rather than let this
+  # app float to a surprise-breaking release.
+  dartssh2: 2.22.2
   duration: 4.0.3
   at_utils: 3.4.0
   logging: 1.3.0


### PR DESCRIPTION
## What I did

Fix the `noports_core` build break introduced by `dartssh2` 2.22.2 (published
2026-07-15) and pin the application to that version.

Its `dart analyze` step began failing on trunk and every open PR with:

```
error - lib/src/srv/srv_impl.dart:351:7 - Missing concrete implementation of
'SSHSocket.flush'. - non_abstract_class_inherits_abstract_member
```

## How I did it

1. **noports_core** — `dartssh2` 2.22.2 added `Future<void> flush()` to the
   `SSHSocket` interface. `WrappedSSHSocket` uses `implements SSHSocket`, which
   inherits only the interface (not the default no-op body), so it must supply
   `flush()`. `noports_core` doesn't pin `dartssh2` (`^2.17.1`) and commits no
   lockfile, so every fresh CI `pub get` resolves 2.22.2 and breaks the analyze
   step (stable and beta). Implemented `WrappedSSHSocket.flush()` mirroring
   `dartssh2`'s own native socket (`await _socket.flush()`) by flushing the
   underlying sink. `WrappedSSHSocket` is the only `implements SSHSocket` in the
   tree.

2. **sshnoports** — pinned `dartssh2: 2.22.2` (exact) in the application's
   pubspec. The library stays unpinned (`^2.17.1`) as a publishable package, but
   the app should not float to a surprise-breaking `dartssh2` release; this
   matches the app's existing exact-pin convention (`args`, `socket_connector`,
   …). The `noports_core` path dependency is preserved (`source: path`).


## How to verify it

Checks pass

## Description for the changelog

Fix build against dartssh2 2.22.2 by implementing the new `SSHSocket.flush`, and
pin the sshnoports app to dartssh2 2.22.2.
