### PR TITLE
chore(melos): run `melos bootstrap`

### DIFF
--- a/packages/dart/npt_flutter/lib/features/onboarding/cubit/multi_activation_cubit.dart
+++ b/packages/dart/npt_flutter/lib/features/onboarding/cubit/multi_activation_cubit.dart
@@ -215,7 +215,7 @@ class MultiActivationCubit extends Cubit<MultiActivationState> {
 
         // 5. Execute Onboard
         var onboardingRequest = AtOnboardingRequest(atsign)
-          ..rootDomain = 'root.atsign.org';
+          ..rootDomain = AtRootDomain.atsignDomain;
 
         bool success = await onboardingService.onboard(
           cramSecret: cramSecret,

--- a/packages/dart/npt_flutter/lib/features/onboarding/widgets/onboarding_apkam_dialog.dart
+++ b/packages/dart/npt_flutter/lib/features/onboarding/widgets/onboarding_apkam_dialog.dart
@@ -181,7 +181,8 @@ class OnboardingApkamDialogState extends State<OnboardingApkamDialog> {
     final deviceName = (await getDeviceName()).replaceAll(regExp, '');
     App.log('Device Name: $deviceName'.loggable);
 
-    final enrollmentRequest = EnrollmentRequest(
+    final AtEnrollmentRequest enrollmentRequest = AtEnrollmentRequest(
+      atSign: atsign,
       appName: Constants.namespace,
       deviceName: deviceName,
       otp: otp,

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -166,10 +166,10 @@ packages:
     dependency: "direct overridden"
     description:
       name: at_onboarding_cli
-      sha256: "9e8317662dffb447e5dd41e82d5825eea0d44460e01c106570902224a97abd44"
+      sha256: "40b9b40ff88bbfba50412bbc6fe4d5991958e6ccab9a1f434bba0eaa9af115b9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.2"
+    version: "1.15.0"
   at_onboarding_flutter:
     dependency: "direct main"
     description:

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -1004,7 +1004,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.12.0"
+    version: "6.12.1"
   objective_c:
     dependency: transitive
     description:
@@ -1550,26 +1550,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   toml:
     dependency: "direct main"
     description:

--- a/packages/dart/npt_flutter/pubspec.yaml
+++ b/packages/dart/npt_flutter/pubspec.yaml
@@ -100,7 +100,7 @@ dev_dependencies:
 dependency_overrides:
   at_auth: ^3.0.1
   at_chops: ^3.0.0
-  at_onboarding_cli: 1.14.2
+  at_onboarding_cli: ^1.15.0
   archive: ^4.0.7
   file_picker: ^10.3.3
   intl: 0.20.2

--- a/packages/dart/npt_flutter/test/features/profile/repository/profile_repository_test.mocks.dart
+++ b/packages/dart/npt_flutter/test/features/profile/repository/profile_repository_test.mocks.dart
@@ -219,9 +219,16 @@ class MockAtClient extends _i1.Mock implements _i2.AtClient {
           as _i6.Future<_i3.AtResponse>);
 
   @override
-  _i6.Future<bool> putMeta(_i2.AtKey? key) =>
+  _i6.Future<bool> putMeta(
+    _i2.AtKey? key, {
+    _i2.PutRequestOptions? putRequestOptions,
+  }) =>
       (super.noSuchMethod(
-            Invocation.method(#putMeta, [key]),
+            Invocation.method(
+              #putMeta,
+              [key],
+              {#putRequestOptions: putRequestOptions},
+            ),
             returnValue: _i6.Future<bool>.value(false),
           )
           as _i6.Future<bool>);


### PR DESCRIPTION
**- What I did**

- I ran `melos bootstrap` 
- It updated `pubspec.lock` 
- It also updated a `mocks.dart`, which I assume is a generated file
- Updated `npt_flutter`'s `at_onboarding_cli: 1.14.1` dependency to `at_onboarding_cli: ^1.15.0`

**- Description for the changelog**
chore(melos): run `melos bootstrap`