### PR TITLE
fix: stdin.close() srv_impl.dart

### DIFF
--- a/packages/dart/noports_core/lib/src/srv/srv_impl.dart
+++ b/packages/dart/noports_core/lib/src/srv/srv_impl.dart
@@ -152,6 +152,7 @@ class SrvImplExec implements Srv<Process> {
       includeParentEnvironment: true,
       environment: environment,
     );
+    p.stdin.close();
     Completer rvPortBound = Completer();
     p.stdout.listen((List<int> l) {
       var allLines = utf8.decode(l).trim();


### PR DESCRIPTION
**- What I did**

- added `p.stdin.close()` in `srv_impl.dart` immediately after Process.start() returns.
- We close stdin because it's not needed at all for this SRV process.

related to https://github.com/atsign-foundation/operations/issues/423

**- Description for the changelog**
fix: stdin.close() srv_impl.dart