### PR TITLE
ci: Correct environment specification

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -52,6 +52,7 @@ jobs:
     permissions:
       id-token: write # For OIDC token used by Azure signing
     runs-on: ${{ matrix.os }}
+    environment: ${{ matrix.environment }}
     defaults:
       run:
         working-directory: ./packages/dart/sshnoports


### PR DESCRIPTION
Environment isn't being correctly set by the matrix causing windows signing to fail for a tagged build

**- What I did**

Added a specific reference to the matrix element

**- How I did it**

Added debug output from failed workflow run to earlier [Gemini conversation](https://share.gemini.google/kfKMA3wue7KJ)

**- How to verify it**

Redo the v5.15.2 release

**- Description for the changelog**

ci: Correct environment specification
