### PR TITLE
fix(csshnpd): handle_sshpublickey bugs

### DIFF
--- a/packages/c/sshnpd/include/sshnpd/file_utils.h
+++ b/packages/c/sshnpd/include/sshnpd/file_utils.h
@@ -21,4 +21,8 @@ typedef struct {
 } authkeys_params;
 
 int authorize_ssh_public_key(authkeys_params *params);
+
+#include <stdbool.h>
+bool is_valid_ssh_public_key_prefix(const char *ssh_key);
+
 #endif

--- a/packages/c/sshnpd/include/sshnpd/file_utils.h
+++ b/packages/c/sshnpd/include/sshnpd/file_utils.h
@@ -23,6 +23,4 @@ typedef struct {
 
 int authorize_ssh_public_key(authkeys_params *params);
 
-bool is_valid_ssh_public_key_prefix(const char *ssh_key);
-
 #endif

--- a/packages/c/sshnpd/include/sshnpd/file_utils.h
+++ b/packages/c/sshnpd/include/sshnpd/file_utils.h
@@ -2,6 +2,7 @@
 #define SSH_KEY_UTIL_H
 
 #include <stdio.h>
+#include <stdbool.h>
 
 enum supported_key_prefix {
   SKP_NONE,
@@ -22,7 +23,6 @@ typedef struct {
 
 int authorize_ssh_public_key(authkeys_params *params);
 
-#include <stdbool.h>
 bool is_valid_ssh_public_key_prefix(const char *ssh_key);
 
 #endif

--- a/packages/c/sshnpd/include/sshnpd/handle_sshpublickey.h
+++ b/packages/c/sshnpd/include/sshnpd/handle_sshpublickey.h
@@ -2,6 +2,11 @@
 #define HANDLE_SSHPUBLICKEY_H
 #include "sshnpd/params.h"
 #include <atclient/monitor.h>
+#include <stdbool.h>
+
 void handle_sshpublickey(sshnpd_params *params, atclient_monitor_message *message, FILE *authkeys_file,
                          char *authkeys_filename);
+
+bool is_valid_ssh_public_key_prefix(const char *ssh_key);
+
 #endif

--- a/packages/c/sshnpd/src/handle_sshpublickey.c
+++ b/packages/c/sshnpd/src/handle_sshpublickey.c
@@ -11,6 +11,26 @@ static char *supported_key_prefix_map[] = {
     [SKP_RSA] = "ssh-rsa", [SKP_ED9] = "ssh-ed25519",
 };
 
+bool is_valid_ssh_public_key_prefix(const char *ssh_key) {
+  if (ssh_key == NULL) {
+    return false;
+  }
+  size_t ssh_key_len = strlen(ssh_key);
+  for (int i = 1; i < SUPPORTED_KEY_PREFIX_LEN; i++) {
+    char *prefix = supported_key_prefix_map[i];
+    size_t prefix_len = strlen(prefix);
+
+    if (prefix_len > ssh_key_len) {
+      continue;
+    }
+
+    if (strncmp(ssh_key, prefix, prefix_len) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void handle_sshpublickey(sshnpd_params *params, atclient_monitor_message *message, FILE *authkeys_file,
                          char *authkeys_filename) {
   if (!params->sshpublickey) {
@@ -20,24 +40,8 @@ void handle_sshpublickey(sshnpd_params *params, atclient_monitor_message *messag
   }
 
   char *ssh_key = (char *)message->notification->decrypted_value;
-  // size_t ssh_key_len = strlen(ssh_key);
 
-  bool is_valid_prefix = false;
-  for (int i = 1; i < SUPPORTED_KEY_PREFIX_LEN; i++) {
-    char *prefix = supported_key_prefix_map[i];
-    size_t prefix_len = strlen(message->notification->decrypted_value);
-
-    if (prefix_len < strlen(ssh_key)) {
-      continue;
-    }
-
-    if (strncmp(ssh_key, prefix, prefix_len)) {
-      is_valid_prefix = true;
-      break;
-    }
-  }
-
-  if (!is_valid_prefix) {
+  if (!is_valid_ssh_public_key_prefix(ssh_key)) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Ssh public key does not look like a public key\n");
     return;
   }

--- a/packages/c/sshnpd/src/handle_sshpublickey.c
+++ b/packages/c/sshnpd/src/handle_sshpublickey.c
@@ -16,6 +16,13 @@ bool is_valid_ssh_public_key_prefix(const char *ssh_key) {
     return false;
   }
   size_t ssh_key_len = strlen(ssh_key);
+
+  // reject embedded newlines to prevent authorized_keys injection
+  if (memchr(ssh_key, '\n', ssh_key_len) != NULL || memchr(ssh_key, '\r', ssh_key_len) != NULL) {
+    return false;
+  }
+
+  // i = 1: skip SKP_NONE whose empty-string prefix would match any key
   for (int i = 1; i < SUPPORTED_KEY_PREFIX_LEN; i++) {
     char *prefix = supported_key_prefix_map[i];
     size_t prefix_len = strlen(prefix);

--- a/packages/c/sshnpd/tests/CMakeLists.txt
+++ b/packages/c/sshnpd/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ foreach(file ${files})
   add_executable(${filename} ${file})
   target_link_libraries(
     ${filename}
-    PRIVATE sshnpd-lib argparse::argparse-static atlogger
+    PRIVATE sshnpd-lib argparse::argparse-static atlogger atclient
   )
   add_test(NAME ${filename} COMMAND $<TARGET_FILE:${filename}>)
 endforeach()

--- a/packages/c/sshnpd/tests/test_sshpublickey.c
+++ b/packages/c/sshnpd/tests/test_sshpublickey.c
@@ -85,6 +85,9 @@ int test_valid_rsa_e2e();
 int test_valid_ecdsa_e2e();
 int test_invalid_garbage_e2e();
 int test_invalid_empty_e2e();
+int test_newline_injection_e2e();
+int test_carriage_return_injection_e2e();
+int test_empty_prefix_does_not_match_e2e();
 
 int main() {
   int ret = 0;
@@ -114,6 +117,21 @@ int main() {
     ret++;
   }
 
+  if (test_newline_injection_e2e()) {
+    printf("e2e: newline-injected key WAS written to authorized_keys\n");
+    ret++;
+  }
+
+  if (test_carriage_return_injection_e2e()) {
+    printf("e2e: carriage-return-injected key WAS written to authorized_keys\n");
+    ret++;
+  }
+
+  if (test_empty_prefix_does_not_match_e2e()) {
+    printf("e2e: key with no recognized prefix WAS written to authorized_keys\n");
+    ret++;
+  }
+
   printf("Tests failed: %d\n", ret);
   return ret;
 }
@@ -136,4 +154,16 @@ int test_invalid_garbage_e2e() {
 
 int test_invalid_empty_e2e() {
   return run_e2e_test("", false);
+}
+
+int test_newline_injection_e2e() {
+  return run_e2e_test("ssh-rsa AAAA_legit\nssh-rsa AAAA_attacker attacker@evil", false);
+}
+
+int test_carriage_return_injection_e2e() {
+  return run_e2e_test("ssh-ed25519 AAAA_legit\rssh-ed25519 AAAA_attacker attacker@evil", false);
+}
+
+int test_empty_prefix_does_not_match_e2e() {
+  return run_e2e_test("unknown-keytype AAAA_something test@host", false);
 }

--- a/packages/c/sshnpd/tests/test_sshpublickey.c
+++ b/packages/c/sshnpd/tests/test_sshpublickey.c
@@ -1,0 +1,139 @@
+#include "sshnpd/file_utils.h"
+#include "sshnpd/params.h"
+#include <atclient/atnotification.h>
+#include <atclient/monitor.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+void handle_sshpublickey(sshnpd_params *params, atclient_monitor_message *message, FILE *authkeys_file,
+                         char *authkeys_filename);
+
+static char authkeys_path[256];
+
+static int setup_authkeys_file(FILE **file) {
+  snprintf(authkeys_path, sizeof(authkeys_path), "/tmp/test_sshpublickey_%d", getpid());
+  *file = fopen(authkeys_path, "w+");
+  if (*file == NULL) {
+    return 1;
+  }
+  return 0;
+}
+
+static void cleanup_authkeys_file(FILE *file) {
+  if (file != NULL) {
+    fclose(file);
+  }
+  unlink(authkeys_path);
+}
+
+static bool file_contains(const char *needle) {
+  FILE *f = fopen(authkeys_path, "r");
+  if (f == NULL) {
+    return false;
+  }
+  fseek(f, 0, SEEK_END);
+  long size = ftell(f);
+  fseek(f, 0, SEEK_SET);
+  if (size <= 0) {
+    fclose(f);
+    return false;
+  }
+  char *buf = malloc(size + 1);
+  fread(buf, 1, size, f);
+  buf[size] = '\0';
+  fclose(f);
+  bool found = strstr(buf, needle) != NULL;
+  free(buf);
+  return found;
+}
+
+static int run_e2e_test(const char *ssh_key, bool should_be_authorized) {
+  FILE *authkeys_file = NULL;
+  if (setup_authkeys_file(&authkeys_file)) {
+    return 1;
+  }
+
+  sshnpd_params params;
+  apply_default_values_to_sshnpd_params(&params);
+  params.sshpublickey = true;
+
+  atclient_atnotification notification;
+  atclient_atnotification_init(&notification);
+  atclient_atnotification_set_decrypted_value(&notification, ssh_key);
+  atclient_atnotification_set_from(&notification, "@testatsign");
+
+  atclient_monitor_message message;
+  atclient_monitor_message_init(&message);
+  message.type = ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION;
+  message.notification = &notification;
+
+  handle_sshpublickey(&params, &message, authkeys_file, authkeys_path);
+
+  bool found = file_contains(ssh_key);
+  int result = (found == should_be_authorized) ? 0 : 1;
+
+  cleanup_authkeys_file(authkeys_file);
+  atclient_atnotification_free(&notification);
+  return result;
+}
+
+int test_valid_ed25519_e2e();
+int test_valid_rsa_e2e();
+int test_valid_ecdsa_e2e();
+int test_invalid_garbage_e2e();
+int test_invalid_empty_e2e();
+
+int main() {
+  int ret = 0;
+
+  if (test_valid_ed25519_e2e()) {
+    printf("e2e: valid ed25519 key was NOT written to authorized_keys\n");
+    ret++;
+  }
+
+  if (test_valid_rsa_e2e()) {
+    printf("e2e: valid rsa key was NOT written to authorized_keys\n");
+    ret++;
+  }
+
+  if (test_valid_ecdsa_e2e()) {
+    printf("e2e: valid ecdsa key was NOT written to authorized_keys\n");
+    ret++;
+  }
+
+  if (test_invalid_garbage_e2e()) {
+    printf("e2e: invalid garbage key WAS written to authorized_keys\n");
+    ret++;
+  }
+
+  if (test_invalid_empty_e2e()) {
+    printf("e2e: invalid empty key WAS written to authorized_keys\n");
+    ret++;
+  }
+
+  printf("Tests failed: %d\n", ret);
+  return ret;
+}
+
+int test_valid_ed25519_e2e() {
+  return run_e2e_test("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample test@host", true);
+}
+
+int test_valid_rsa_e2e() {
+  return run_e2e_test("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgExample test@host", true);
+}
+
+int test_valid_ecdsa_e2e() {
+  return run_e2e_test("ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHA test@host", true);
+}
+
+int test_invalid_garbage_e2e() {
+  return run_e2e_test("not-a-real-ssh-key malicious-payload", false);
+}
+
+int test_invalid_empty_e2e() {
+  return run_e2e_test("", false);
+}

--- a/packages/c/sshnpd/tests/test_sshpublickey.c
+++ b/packages/c/sshnpd/tests/test_sshpublickey.c
@@ -1,4 +1,5 @@
 #include "sshnpd/file_utils.h"
+#include "sshnpd/handle_sshpublickey.h"
 #include "sshnpd/params.h"
 #include <atclient/atnotification.h>
 #include <atclient/monitor.h>
@@ -7,9 +8,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
-void handle_sshpublickey(sshnpd_params *params, atclient_monitor_message *message, FILE *authkeys_file,
-                         char *authkeys_filename);
 
 static char authkeys_path[256];
 


### PR DESCRIPTION
**- What I did**

From Claude:

```
The SSH public key prefix check in handle_sshpublickey.c had three compounding bugs that caused every string to pass validation and get written to authorized_keys, regardless of format:

1. strlen(message->notification->decrypted_value) measured the full SSH key instead of strlen(prefix) — so prefix_len was always the key length
2. prefix_len < strlen(ssh_key) was comparing the key's length to itself — always false, so the continue never triggered
3. strncmp returns 0 on match, but the check if (strncmp(...)) treated non-zero (mismatch) as valid — inverted logic
```

**- How I did it**

- Claude Opus 4.6 [1m] high

**- How to verify it**

- New unit test

**- Description for the changelog**
fix(csshnpd): handle_sshpublickey bugs