### PR TITLE
build(deps): Ensure CA certificates are present

### DIFF
--- a/tests/e2e_all/dockerfiles/Dockerfile.base.runtime
+++ b/tests/e2e_all/dockerfiles/Dockerfile.base.runtime
@@ -8,7 +8,7 @@ ENV GROUP_ID=1024
 
 RUN set -eux ; \
     apt-get update ; \
-    apt-get install -y openssh-server sudo; \
+    apt-get install -y ca-certificates openssh-server sudo; \
     groupadd --gid ${GROUP_ID} ${USER} ; \
     useradd --system --shell /bin/bash --home ${HOMEDIR} --uid ${USER_ID} --gid ${GROUP_ID} ${USER} ; \
     usermod -aG sudo ${USER} ; \


### PR DESCRIPTION
CA certificates are missing from e2e test base image, and Dart 3.13 no longer carries its own fallback cacerts.

:bulb: https://github.com/dart-lang/sdk/issues/64060 (and thanks to @julemand101 for [this note](https://github.com/dart-lang/sdk/issues/64060#issuecomment-5315850465))

**- What I did**

Added `ca-certificates` to the `apt-get install` line

**- How to verify it**

Rebuild the base image and rerun tests

**- Description for the changelog**

build(deps): Ensure CA certificates are present
