### PR TITLE
fix(windows-installer): stale versioning

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -228,9 +228,10 @@ jobs:
           wix extension add -g WixToolset.Util.wixext/6.0.2
           wix extension add -g WixToolset.UI.wixext/6.0.2
           mkdir bin
-          cp ../../packages/dart/sshnoports/sshnp/{sshnpd,at_activate,sshnp,npp,npp_atserver,npp_file,npt,srv,sshnpdService}.exe ./bin/
+          cp ../../packages/dart/sshnoports/sshnp/{sshnpd,at_activate,noports,sshnp,npp,npp_atserver,npp_file,npt,srv,sshnpdService}.exe ./bin/
           cp ../../packages/dart/sshnoports/bundles/core/config/sshnpd.yaml ./bin/
           wix build -ext WixToolset.Util.wixext -ext WixToolset.UI.wixext \
+              -d ProductVersion="${VERSION}" \
               -arch x64 -o build/NoPorts.msi noports.wxs
           cp build/NoPorts.msi ../../packages/dart/sshnoports/tarball/NoPorts-${VERSION}-x64.msi
           cp build/NoPorts.msi ../../packages/dart/sshnoports/tarball/NoPorts-x64.msi

--- a/packages/dart/sshnoports/bundles/windows/README.md
+++ b/packages/dart/sshnoports/bundles/windows/README.md
@@ -9,6 +9,37 @@ or optionally run this command in powershell.
 msiexec /i ".\NoPorts.msi"
 ```
 
+## Upgrading
+
+Installing a newer MSI over an existing install performs a major upgrade: the old version is
+uninstalled and the new one installed in its place. Two things to know:
+
+- **The `sshnpd` service is restarted for you.** The upgrade stops and removes the old service and
+  starts the new one. If it does not come back up, check the Event Viewer under `Application` and
+  start it manually with `Start-Service sshnpd`. (On a *fresh* install the service is installed but
+  left stopped, because it has no config yet — see Post-Installation below.)
+- **`PATH` is rewritten**, so already-open terminals need restarting before they see the new
+  binaries.
+
+Your config at `%PROGRAMDATA%\NoPorts\sshnpd.yaml` and your keys in
+`C:\Users\<USER>\.atsign\keys\` are left untouched by the upgrade.
+
+## Troubleshooting
+
+### The installer takes a long time before prompting for admin rights
+
+Windows validates the installer's code signature before showing the UAC prompt. If the machine's
+trusted root certificates are stale, or it cannot reach the certificate revocation servers, that
+check can block for tens of seconds. `certupdater.ps1` is installed alongside the binaries in
+`C:\Program Files\NoPorts\` and refreshes the trusted root store from Windows Update:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "C:\Program Files\NoPorts\certupdater.ps1"
+```
+
+It self-elevates, so run it from any shell. This is also worth trying if the NoPorts binaries
+themselves fail to establish TLS connections.
+
 ## Post-Installation
 
 ### Device Side

--- a/tools/windows-msi/README.md
+++ b/tools/windows-msi/README.md
@@ -1,4 +1,4 @@
-# SSH No Ports - Windows MSI Build using WiX v5
+# SSH No Ports - Windows MSI Build using WiX v6
 
 Usage of this tool is to create a Window MSI for sshnoports binaries.
 
@@ -24,4 +24,9 @@ Binaries are expected to be in windows-msi/bin
     - example config file (sshnpd.yaml)
 
 2. Run the following command to build the MSI installer:
-    - `wix build -ext WixToolset.Util.wixext -ext WixToolset.UI.wixext -arch x64 -o build\NoPorts.msi noports.wxs`
+    - `wix build -ext WixToolset.Util.wixext -ext WixToolset.UI.wixext -d ProductVersion=5.15.2 -arch x64 -o build\NoPorts.msi noports.wxs`
+
+    `-d ProductVersion=<x.y.z>` stamps the MSI's `ProductVersion`, which is what Windows
+    shows as the version in Apps & Features and what drives major-upgrade detection. CI
+    passes the version from `packages/dart/sshnoports/pubspec.yaml`. Omit the flag and the
+    build falls back to `0.0.1`, which marks it unmistakably as a local build.

--- a/tools/windows-msi/noports.wxs
+++ b/tools/windows-msi/noports.wxs
@@ -2,17 +2,26 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
      xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui"
      xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util" >
-  <Package Name="NoPorts" Language="1033" Version="5.13.1.0" 
-           Manufacturer="NoPorts" UpgradeCode="d0fde95b-ae6c-40d0-8192-82f755f32dde"
+  <!-- CI passes the real version via `wix build -d ProductVersion=x.y.z`.
+       The fallback marks a build as local; it must stay below any real release. -->
+  <?ifndef ProductVersion?>
+    <?define ProductVersion = "0.0.1"?>
+  <?endif?>
+  <Package Name="NoPorts" Language="1033" Version="$(var.ProductVersion)"
+           Manufacturer="Atsign" UpgradeCode="d0fde95b-ae6c-40d0-8192-82f755f32dde"
            InstallerVersion="500" Compressed="yes" Scope="perMachine" >
-    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+    <MajorUpgrade AllowSameVersionUpgrades="yes"
+                  DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
     <MediaTemplate EmbedCab="yes" />
+    <!-- Apps & Features metadata -->
+    <Property Id="ARPHELPLINK" Value="https://docs.noports.com" />
+    <Property Id="ARPURLINFOABOUT" Value="https://noports.com" />
     <!-- Main Feature - Core Tools (always installed) -->
     <Feature Id="CoreTools" Title="NoPorts Core Tools" Level="1" 
             Description="Core NoPorts command-line tools">
       <ComponentGroupRef Id="ProductComponents" />
     </Feature>
-    <!-- Optional Feature - Service (default off) -->
+    <!-- Optional Feature - Service (selected by default, installed stopped) -->
     <Feature Id="ServiceFeature" Title="NoPorts Daemon Service" Level="1" 
             Description="Install NoPorts Daemon as a Windows service (sshnpd)">
       <ComponentGroupRef Id="sshnpdComponents" />
@@ -45,6 +54,14 @@
         <File Id="at_activatefile" Source="bin\at_activate.exe" 
               Name="at_activate.exe" KeyPath="yes" />
       </Component>
+      <Component Id="noports" Guid="*">
+        <File Id="noportsfile" Source="bin\noports.exe" 
+              Name="noports.exe" KeyPath="yes" />
+      </Component>
+      <Component Id="npp" Guid="*">
+        <File Id="nppfile" Source="bin\npp.exe" 
+              Name="npp.exe" KeyPath="yes" />
+      </Component>
       <Component Id="npp_atserver" Guid="*">
         <File Id="npp_atserverfile" Source="bin\npp_atserver.exe" 
               Name="npp_atserver.exe" KeyPath="yes" />
@@ -68,7 +85,7 @@
       <!-- Environment PATH -->
       <Component Id="UpdatePath" Guid="d7a87a7f-1bcc-4eba-b089-6c2ab0e0f0bd">
         <Environment Id="PATH" Name="PATH" Value="[INSTALLFOLDER]" 
-                     Permanent="no" Part="last" Action="set" System="no" />
+                     Permanent="no" Part="last" Action="set" System="yes" />
       </Component>
       <Component Id="CertUpdaterScript" Guid="*">
         <File Id="certupdaterfile" Source="certupdater.ps1" Name="certupdater.ps1" />
@@ -93,15 +110,31 @@
                         ErrorControl="normal"
                         Vital="yes"
                         Account="LocalSystem"/>
+        <!-- Deliberately not started on a fresh install: the daemon has no atsign or
+             keys configured yet, so it would start and immediately exit. See the
+             sshnpdServiceUpgradeStart component for the upgrade case. -->
         <ServiceControl Id="sshnpdServiceStart"
                         Name="[SERVICE_NAME]"
-                        Start="no"
                         Stop="both"
                         Remove="uninstall"
                         Wait="yes" />
         <util:EventSource Name="[SERVICE_DISPLAYNAME]"
                           Log="Application"
                           EventMessageFile="[#sshnpdServiceExeFile]"/>
+      </Component>
+      <!-- A major upgrade uninstalls the old product, which stops and removes the
+           service. Without this the new service is registered for auto-start but stays
+           stopped until the next reboot. Only fires when upgrading an existing install. -->
+      <Component Id="sshnpdServiceUpgradeStart"
+                 Guid="1ecb19e0-5ceb-4cf9-aa6b-5532154c2b9c"
+                 Condition="WIX_UPGRADE_DETECTED">
+        <RegistryValue Root="HKLM" Key="SOFTWARE\Atsign\NoPorts"
+                       Name="ServiceStartedByUpgrade" Type="integer" Value="1" KeyPath="yes" />
+        <!-- Wait="no" so a daemon that fails to come up cannot fail the upgrade. -->
+        <ServiceControl Id="sshnpdServiceUpgradeStartControl"
+                        Name="[SERVICE_NAME]"
+                        Start="install"
+                        Wait="no" />
       </Component>
     </ComponentGroup>
   </Fragment>


### PR DESCRIPTION
**- What I did**
- fixes #2755 
- fixes #2769 

**- How I did it**
 - pull version from mulitbuild for wix so it we don't have to deal with the stale version in the wix file (we will 100% forget about the version)
 - tried to fix some weird startup time things wix and windows are so weird I don't think it's going to help.
 - the UAC takes a long time cause it has to verify the signing and the certs also need updating I honestly need to look into this more deeply.
 
**- How to verify it**
- let it ride

**- Description for the changelog**
fix(windows-installer): stale versioning and odd bits ands bobs
