### PR TITLE
ci: run the srv unit tests in the C unit test workflow

### DIFF
--- a/.github/workflows/c_unit_tests.yaml
+++ b/.github/workflows/c_unit_tests.yaml
@@ -22,9 +22,10 @@ jobs:
         with:
           cmake-version: "3.31.11"
 
-      - name: sshnpd Unit CTest
+      - name: sshnpd and srv Unit CTest
         working-directory: packages/c
         run: |
-          cmake -S . -B build -DSSHNPD_BUILD_TESTS=ON
+          cmake -S . -B build -DSSHNPD_BUILD_TESTS=ON -DSRV_BUILD_TESTS=ON
           cmake --build build
           ctest --test-dir build/sshnpd/tests --output-on-failure --timeout 2
+          ctest --test-dir build/_deps/srv-lib-build/tests --output-on-failure --timeout 10


### PR DESCRIPTION
## What

`c_unit_tests.yaml` only configured with `-DSSHNPD_BUILD_TESTS=ON`, so the srv test suite — including `test_twin_keys` added in #2860 — never ran in CI. It only ran when someone remembered to build it locally with `-DSRV_BUILD_TESTS=ON`.

This adds the flag to the existing configure (srv is already part of the same build via FetchContent, so no second dependency build) and a second `ctest` invocation pointing at `build/_deps/srv-lib-build/tests`.

## Why it matters

`test_twin_keys` guards the two properties of the twin-keys protocol that fail *silently* if regressed:

- direction wiring (decrypter = C2D key, encrypter = D2C key) — swapping them breaks interop with Dart clients
- the keys being genuinely distinct — if both transformers accidentally used the same key, all round-trip tests would still pass (symmetric bugs are self-consistent); only the negative assertion (D2C ciphertext must NOT decrypt with the C2D key) catches it

Without this workflow change, the one test layer cheap enough to run on every PR was the one layer CI didn't run.

## Notes

- The srv ctest line uses `--timeout 10` (vs 2 for sshnpd) because `test_stream_encrypt` logs per byte and CI runners are slower than dev machines.
- Verified locally with a fresh build dir: one configure with both flags, both ctest invocations — 5/5 sshnpd and 2/2 srv tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# csshnpd rollout & test guide (2026-08 feature set)

This PR is the first of the current C daemon PR set to merge, so the build/test/rollout instructions for the whole set live here.

## The PR set

| PR | What | Base |
|---|---|---|
| #2862 (this) | CI runs the srv unit tests | trunk |
| #2863 | manager list handling + exact `-m` authorization match | trunk |
| #2864 | `adjustableTimeout` (npt timeout honored; srv exits when idle) — fixes #2831 | trunk |
| #2865 | ESCR relay auth (`supportsRamEscr`) — daemon side of `--443` | #2864 |
| #2867 | `--policy-manager` policy service support + denial messages to clients | #2865 |
| #2870 | `proxy:` root domains (`--root-domain "proxy:host:443"`) | trunk, **requires at_c PR** atsign-foundation/at_c#702 |
| #2869 | PARKED: ephemeral tunnel key (`sshnp --no-et`) — do not merge unless the need arises | #2867 |

Combined test branch: `cconstab/c-2831-integration` = trunk + all of the above (minus #2869) + a **DO NOT MERGE** commit pinning the atsdk to the at_c #702 branch. It exists only for testing; delete it after the set merges.

## Build + unit tests (what this PR's CI now runs)

```bash
cd packages/c
cmake --preset dev && cmake --build build/dev -j
ctest --test-dir build/dev/sshnpd
ctest --test-dir build/dev/_deps/srv-lib-build/tests
```

New unit tests in the set: `test_escr` (ESCR construction round-trip; byte-compat with the Dart verifier was additionally proven 10/10 against `RelayAuthVerifierESCR`), `test_policy` (RPC response parsing + permitOpen matching), plus #2863's canonicalization tests.

## End-to-end matrix

- **#2863** — daemon starts even with a bad/unactivated atSign at the *end* of `-m`; `@Alice`/`@a.lice` match `@alice`; near-misses (`@alice1`) denied.
- **#2864** — NoPorts Desktop profile with a non-default timeout connects (the original #2831 repro); on the device, forked srv children exit ~timeout after the session ends instead of lingering.
- **#2865** — startup log shows `Published public signing key at public:_apsk.<eid>.a.__e@<atsign>`; `npt --relay-auth-mode escr` works (log: `Authenticating control channel to relay (escr)`); NoPorts Desktop with "use port 443" against a 443-bound relay; legacy (non-escr) sessions regress cleanly. Test with both a plain `.atKeys` atsign (`primary` enrollment id) and an APKAM-enrolled one.
- **#2867** — run a policy service (`dart run bin/npp_file.dart -a @policy -f bin/demo/policy_example.yaml -s /tmp/npp`), start the daemon with `-p @policy` (permit-open defaults to `*:*` in policy mode): allowed client connects; denied client is rejected; a permitted client asking for a non-permitted port receives `Connection to <host>:<port> denied based on POLICY --permit-open [...]` (npt reply, matching the Dart daemon); managers in `-m` short-circuit (no RPC in the log); killing the policy service ⇒ deny after ~10s; the `<device>.devices.policy` heartbeat reaches the policy atSign every 5 min.
- **#2870** — `--root-domain "proxy:proxy0001.atsign.org:443"` authenticates via the proxy with zero atDirectory lookups (log: `atServer connections will go via the reverse proxy ...`); monitor reconnects (idle >40s / network blip) stay on the proxy; plain root domains regress cleanly. **Requires the at_c #702 connection fix** — without it the proxy closes the connection on the bare-CRLF the old atclient sent on connect.
- **Combined smoke**: NoPorts Desktop → OpenWRT csshnpd with port 443 on, non-default timeout, `-p @policy`, and the proxy root domain — every outbound byte on 443.
- **Platform**: OpenWRT cross-build + run (ssh-keygen availability is only relevant to parked #2869); Linux valgrind/memcheck pass.

## Merge order

1. #2862 and #2863 (independent).
2. #2864 → #2865 → #2867, deleting each branch on merge so GitHub retargets the next PR to trunk. #2864 closes #2831 — confirm on the reporter's travel router first.
3. at_c #702 merges, then add a commit to #2870 bumping `GIT_TAG` in `packages/c/cmake/atsdk.cmake` to the at_c merge SHA; then merge #2870.
4. Delete `cconstab/c-2831-integration` (its atsdk pin commit must never reach trunk). #2869 stays parked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
