### PR TITLE
fix: sshnpd C daemon manager list handling and exact -m authorization match

### DIFF
--- a/packages/c/sshnpd/include/sshnpd/device_info.h
+++ b/packages/c/sshnpd/include/sshnpd/device_info.h
@@ -19,6 +19,8 @@ struct sshnpd_device_info_state {
   uint8_t attempts;
 };
 
+// Shares (or un-shares) the username with each manager atSign. Best effort:
+// per-atSign failures are logged and skipped; always returns 0.
 int handle_username_keys(atclient *atclient, const char **atsigns, size_t num_atsigns, const char *username,
                          const char *device_name, const char *device_atsign, bool make_visible);
 void send_next_device_info(atclient *atclient, sshnpd_params *params);

--- a/packages/c/sshnpd/src/device_info.c
+++ b/packages/c/sshnpd/src/device_info.c
@@ -18,6 +18,8 @@ int handle_username_keys(atclient *atclient, const char **atsigns, size_t num_at
     return 0;
   }
 
+  size_t failures = 0;
+
   for (size_t i = 0; i < num_atsigns; i++) {
     const char *atsign = atsigns[i];
     // example: @client:username.devicename.sshnp@device
@@ -30,6 +32,7 @@ int handle_username_keys(atclient *atclient, const char **atsigns, size_t num_at
     ret = atclient_atkey_from_string(&atkey, atkey_str);
     if (ret != 0) {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to build username key for %s\n", atsign);
+      failures++;
       continue;
     }
 
@@ -39,6 +42,7 @@ int handle_username_keys(atclient *atclient, const char **atsigns, size_t num_at
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set is_public on metadata for %s username key\n",
                    atsign);
       atclient_atkey_free(&atkey);
+      failures++;
       continue;
     }
 
@@ -47,18 +51,21 @@ int handle_username_keys(atclient *atclient, const char **atsigns, size_t num_at
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set is_encrypted on metadata for %s username key\n",
                    atsign);
       atclient_atkey_free(&atkey);
+      failures++;
       continue;
     }
     ret = atclient_atkey_metadata_set_ttr(metadata, -1);
     if (ret != 0) {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set ttr on metadata for %s username key\n", atsign);
       atclient_atkey_free(&atkey);
+      failures++;
       continue;
     }
     ret = atclient_atkey_metadata_set_ccd(metadata, true);
     if (ret != 0) {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set ccd on metadata for %s username key\n", atsign);
       atclient_atkey_free(&atkey);
+      failures++;
       continue;
     }
     if (make_visible) {
@@ -66,6 +73,7 @@ int handle_username_keys(atclient *atclient, const char **atsigns, size_t num_at
       atclient_atkey_free(&atkey);
       if (ret != 0) {
         atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to put username key for %s\n", atsign);
+        failures++;
         continue;
       }
     } else {
@@ -73,9 +81,20 @@ int handle_username_keys(atclient *atclient, const char **atsigns, size_t num_at
       atclient_atkey_free(&atkey);
       if (ret != 0) {
         atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to delete username key for %s\n", atsign);
+        failures++;
         continue;
       }
     }
+  }
+
+  if (failures > 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_WARN,
+                 "Could not %s username key for %zu of %zu manager atSigns (see errors above, likely not activated "
+                 "atSigns); continuing\n",
+                 make_visible ? "share" : "delete", failures, num_atsigns);
+  } else {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "%s username key for all %zu manager atSigns\n",
+                 make_visible ? "Shared" : "Deleted", num_atsigns);
   }
 
   return 0;

--- a/packages/c/sshnpd/src/device_info.c
+++ b/packages/c/sshnpd/src/device_info.c
@@ -6,6 +6,9 @@
 #include <string.h>
 #include <time.h>
 
+// Sharing the username with each manager is best effort, matching the Dart
+// daemon: a failure for one manager atSign (e.g. not yet activated) must not
+// block the remaining managers or prevent the daemon from starting.
 int handle_username_keys(atclient *atclient, const char **atsigns, size_t num_atsigns, const char *username,
                          const char *device_name, const char *device_atsign, bool make_visible) {
   int ret;
@@ -75,7 +78,7 @@ int handle_username_keys(atclient *atclient, const char **atsigns, size_t num_at
     }
   }
 
-  return ret;
+  return 0;
 }
 
 void send_next_device_info(atclient *atclient, sshnpd_params *params) {

--- a/packages/c/sshnpd/src/handler_commons.c
+++ b/packages/c/sshnpd/src/handler_commons.c
@@ -4,6 +4,7 @@
 #include "atchops/rsa.h"
 #include "atclient/notify.h"
 #include "atclient/notify_params.h"
+#include "sshnpd/authorization.h"
 #include "sshnpd/params.h"
 #include "sshnpd/sshnpd.h"
 #include <atchops/constants.h>
@@ -30,11 +31,19 @@ bool is_manager_atsign(const sshnpd_params *params, const char *atsign) {
     return false;
   }
 
+  // The manager list was canonicalized at startup; canonicalize the requesting
+  // atSign the same way so the comparison is always exact (case, dots, '@'
+  // prefix). Anything that isn't a valid atSign fails closed.
+  char normalized[SSHNPD_ATSIGN_BUFFER_LEN];
+  if (sshnpd_normalize_atsign(atsign, normalized, sizeof(normalized)) != 0) {
+    return false;
+  }
+
   for (size_t i = 0; i < params->manager_list_len; i++) {
     if (params->manager_list[i] == NULL) {
       continue;
     }
-    if (strcmp(atsign, params->manager_list[i]) == 0) {
+    if (strcmp(normalized, params->manager_list[i]) == 0) {
       return true;
     }
   }

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -363,13 +363,12 @@ int main(int argc, char **argv) {
     return res;
   }
 
-  // 9. Start the device refresh loop - if hide is off
-  res = handle_username_keys(&worker, (const char **)params.manager_list, params.manager_list_len, username,
-                             params.device, params.atsign, !params.hide);
-  if (res != 0) {
-    atcommons_memlist_failure_free(&memlist);
-    return res;
-  }
+  // 9. Share the username with each manager atSign - if hide is off.
+  // Best effort (matches the Dart daemon): failures for individual manager
+  // atSigns are logged inside handle_username_keys and must not prevent
+  // daemon startup.
+  handle_username_keys(&worker, (const char **)params.manager_list, params.manager_list_len, username, params.device,
+                       params.atsign, !params.hide);
 
   // 10. Start monitor
   size_t regexlen = strlen(params.device) + strlen(SSHNP_NS) + 3;

--- a/packages/c/sshnpd/tests/test_manager_auth.c
+++ b/packages/c/sshnpd/tests/test_manager_auth.c
@@ -15,6 +15,9 @@ int null_sender_test();
 int null_manager_list_test();
 int case_and_prefix_normalization_test();
 int policy_manager_denies_everyone_test();
+int sender_canonical_equivalence_test();
+int sender_near_miss_denied_test();
+int sender_malformed_fails_closed_test();
 
 int main() {
   int ret = 0;
@@ -53,6 +56,18 @@ int main() {
   }
   if (policy_manager_denies_everyone_test()) {
     printf("policy_manager_denies_everyone_test failed\n");
+    ret++;
+  }
+  if (sender_canonical_equivalence_test()) {
+    printf("sender_canonical_equivalence_test failed\n");
+    ret++;
+  }
+  if (sender_near_miss_denied_test()) {
+    printf("sender_near_miss_denied_test failed\n");
+    ret++;
+  }
+  if (sender_malformed_fails_closed_test()) {
+    printf("sender_malformed_fails_closed_test failed\n");
     ret++;
   }
 
@@ -207,6 +222,75 @@ int policy_manager_denies_everyone_test() {
   }
   if (is_manager_atsign(&params, "@eve")) {
     return 1;
+  }
+  return 0;
+}
+
+// The atProtocol treats atSigns as case-insensitive and ignores dots
+// (AtUtils.fixAtSign in at_utils): @Alice, @a.lice and @alice are the same
+// identity. The sender must be canonicalized before comparison so that every
+// spelling of an authorized atSign is accepted.
+int sender_canonical_equivalence_test() {
+  sshnpd_params params;
+  apply_default_values_to_sshnpd_params(&params);
+  char *managers[] = {"@alice", "@colinconstable"};
+  params.manager_list = managers;
+  params.manager_list_len = 2;
+
+  if (!is_manager_atsign(&params, "@Alice")) {
+    return 1;
+  }
+  if (!is_manager_atsign(&params, "@a.lice")) {
+    return 1;
+  }
+  if (!is_manager_atsign(&params, "@colin.constable")) {
+    return 1;
+  }
+  if (!is_manager_atsign(&params, "@Colin.Constable")) {
+    return 1;
+  }
+  return 0;
+}
+
+// A requesting atSign must be a perfect (canonical) match for a -m entry:
+// prefixes, suffixes and lookalikes of an authorized atSign are all denied.
+int sender_near_miss_denied_test() {
+  sshnpd_params params;
+  apply_default_values_to_sshnpd_params(&params);
+  char *managers[] = {"@alice"};
+  params.manager_list = managers;
+  params.manager_list_len = 1;
+
+  const char *near_misses[] = {"@alice1", "@alic", "@aalice", "@malice", "@lice", "alice1"};
+  for (size_t i = 0; i < sizeof(near_misses) / sizeof(near_misses[0]); i++) {
+    if (is_manager_atsign(&params, near_misses[i])) {
+      printf("  near miss \"%s\" was wrongly authorized\n", near_misses[i]);
+      return 1;
+    }
+  }
+  return 0;
+}
+
+// Anything that is not a valid atSign must fail closed, never match.
+int sender_malformed_fails_closed_test() {
+  sshnpd_params params;
+  apply_default_values_to_sshnpd_params(&params);
+  char *managers[] = {"@alice"};
+  params.manager_list = managers;
+  params.manager_list_len = 1;
+
+  // 60 x 'a' exceeds SSHNPD_ATSIGN_MAX_LEN (55)
+  char too_long[63];
+  too_long[0] = '@';
+  memset(too_long + 1, 'a', 60);
+  too_long[61] = '\0';
+
+  const char *malformed[] = {"@ali@ce", "@ali:ce", "@ali ce", "@alice,", "@alice\n", "@", "@..", too_long};
+  for (size_t i = 0; i < sizeof(malformed) / sizeof(malformed[0]); i++) {
+    if (is_manager_atsign(&params, malformed[i])) {
+      printf("  malformed sender at index %zu was wrongly authorized\n", i);
+      return 1;
+    }
   }
   return 0;
 }


### PR DESCRIPTION
## Problem

A user reported that `sshnpd -m` "works but seems to have a maximum limit of atSigns, then breaks."

Investigation showed the `-m` parser itself has no limit (verified under ASan/UBSan up to 1000 comma-separated atSigns). The real cause is in the C daemon's startup: `handle_username_keys` loops over all manager atSigns sharing the `username.<device>.sshnp` record, but returns the status of only the **last** iteration. `main()` treated any nonzero return as fatal. So:

- a bad atSign (unactivated / typo / unreachable) at the **end** of the `-m` list killed the daemon at startup, while
- the same bad atSign in the **middle** of the list was silently swallowed.

Appending one more atSign to a working list is exactly how you hit the first case, which presents as a "maximum limit."

## Fix

1. **`handle_username_keys` is now best effort, matching the Dart daemon** (`_shareUsername` / `_refreshDeviceEntry` wrap each share in try/catch): per-atSign failures are logged and skipped, and can never prevent daemon startup. `main()` no longer treats the call as fatal.

2. **`is_manager_atsign` now guarantees an exact canonical match.** The `-m` list is canonicalized at startup with `sshnpd_normalize_atsign` (same rules as `AtUtils.fixAtSign`: lowercase, dots stripped, single leading `@`, reserved/whitespace/control characters rejected). The requesting atSign from the notification is now passed through the same canonicalizer before comparison, so:
   - every valid spelling of an authorized atSign (`@Alice`, `@a.lice`) matches, per atProtocol identity rules;
   - near-misses (`@alice1`, `@malice`, `@alic`, ...) never match;
   - anything that is not a valid atSign fails closed.

## Security review

- The authorization gate in `daemon.c` runs before any handler dispatch and uses the server-authenticated `notification->from`; handlers never take the requester identity from the payload.
- Fail-closed behavior preserved: NULL/empty sender, empty/NULL manager list, and policy-mode all still deny.
- Canonicalization is identity-preserving per protocol (parity with `AtUtils.fixAtSign`), bounds-checked into a fixed buffer, and rejects over-length input.
- Envelope signature verification (`publickey@<from>`) is untouched.
- The best-effort change affects only outbound sharing of the username record, not authorization.

## Tests

- New unit tests in `test_manager_auth.c`: canonical equivalence, near-miss denial, malformed/over-length senders fail closed.
- Full C test suite passes (5/5 via ctest).
- Parser separately fuzzed with 1–1000 atSigns under AddressSanitizer/UBSan: no errors.

## Note (not in this PR)

`device_info_last_sent` is declared and NULL-checked but never allocated, so `send_next_device_info` has been dead code since fc9b307a8 — the C daemon never proactively refreshes `device_info` entries. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)