### PR TITLE
feat: adjustableTimeout support in csshnpd

### DIFF
--- a/packages/c/srv/include/srv/params.h
+++ b/packages/c/srv/include/srv/params.h
@@ -2,6 +2,9 @@
 #define SRV_PARAMS_H
 #define SRV_VERSION "0.1.0"
 
+// Matches DefaultArgs.srvTimeoutInSeconds in the Dart noports_core package
+#define SRV_DEFAULT_TIMEOUT_SECONDS 30
+
 #include <argparse/argparse.h>
 #include <getopt.h>
 #include <stdbool.h>

--- a/packages/c/srv/include/srv/params.h
+++ b/packages/c/srv/include/srv/params.h
@@ -5,6 +5,11 @@
 // Matches DefaultArgs.srvTimeoutInSeconds in the Dart noports_core package
 #define SRV_DEFAULT_TIMEOUT_SECONDS 30
 
+// Matches the npt client's "never" timeout (-T 0 -> neverTimeoutDays = 365
+// days in npt.dart); also keeps the double -> int conversion of the requested
+// timeout in range
+#define SRV_MAX_TIMEOUT_SECONDS (365 * 24 * 60 * 60)
+
 #include <argparse/argparse.h>
 #include <getopt.h>
 #include <stdbool.h>

--- a/packages/c/srv/src/params.c
+++ b/packages/c/srv/src/params.c
@@ -8,6 +8,7 @@ void apply_default_values_to_srv_params(srv_params_t *params) {
   params->local_port = 22;
   params->bind_local_port = 0;
   params->multi = 0;
+  params->timeout = SRV_DEFAULT_TIMEOUT_SECONDS;
   params->rv_auth = 0;
   params->rv_e2ee = 0;
   params->rvd_auth_string = NULL;

--- a/packages/c/srv/src/srv.c
+++ b/packages/c/srv/src/srv.c
@@ -3,15 +3,50 @@
 #include "srv/side.h"
 #include <atchops/base64.h>
 #include <atlogger/atlogger.h>
+#include <mbedtls/net_sockets.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 
 #define TAG "srv - run"
 
+// How often the multi-mode control channel wakes up from recv to check the
+// connection timeout
+#define SRV_CONTROL_POLL_MS 1000
+
 static void *run_socket_to_socket(void *args);
+
+// Connection timeout state for multi mode: the srv exits once there have been
+// no active socket-to-socket sessions for params->timeout seconds (matching
+// the SocketConnector timeout semantics of the Dart srv). One process runs at
+// most one run_srv_daemon_side_multi, so process-wide state is safe here.
+static pthread_mutex_t session_mutex = PTHREAD_MUTEX_INITIALIZER;
+static int active_sessions = 0;
+static time_t idle_since = 0;
+
+static void session_started(void) {
+  pthread_mutex_lock(&session_mutex);
+  active_sessions++;
+  pthread_mutex_unlock(&session_mutex);
+}
+
+static void session_ended(void) {
+  pthread_mutex_lock(&session_mutex);
+  if (--active_sessions == 0) {
+    idle_since = time(NULL);
+  }
+  pthread_mutex_unlock(&session_mutex);
+}
+
+static bool connection_timeout_expired(int timeout_seconds) {
+  pthread_mutex_lock(&session_mutex);
+  bool expired = active_sessions == 0 && difftime(time(NULL), idle_since) >= timeout_seconds;
+  pthread_mutex_unlock(&session_mutex);
+  return expired;
+}
 
 static int process_multiple_requests(char *original, char **requests[], size_t *num_out_requests);
 
@@ -135,14 +170,30 @@ int run_srv_daemon_side_multi(srv_params_t *params) {
   }
   memset(buffer, 0, 4096 * sizeof(unsigned char));
 
+  int timeout_seconds = params->timeout > 0 ? params->timeout : SRV_DEFAULT_TIMEOUT_SECONDS;
+  pthread_mutex_lock(&session_mutex);
+  idle_since = time(NULL);
+  pthread_mutex_unlock(&session_mutex);
+
   size_t len;
-  while ((res = mbedtls_net_recv(&control_side.socket, buffer, 4096)) > 0) {
-    if (res < 0) {
-      atlogger_log("srv - control (side b)", ERROR, "Error reading data: %zu", len);
+  for (;;) {
+    if (connection_timeout_expired(timeout_seconds)) {
+      atlogger_log(TAG, INFO, "No connections for %d seconds - closing srv\n", timeout_seconds);
+      res = 0;
       goto exit;
-    } else {
-      len = res;
     }
+
+    res = mbedtls_net_recv_timeout(&control_side.socket, buffer, 4096, SRV_CONTROL_POLL_MS);
+    if (res == MBEDTLS_ERR_SSL_TIMEOUT) {
+      continue;
+    }
+    if (res <= 0) {
+      if (res < 0) {
+        atlogger_log("srv - control (side b)", ERROR, "Error reading data from control socket: %d\n", res);
+      }
+      goto exit;
+    }
+    len = res;
 
     if (control_side.transformer != NULL) {
       unsigned char *output = malloc(4096 * sizeof(unsigned char));
@@ -242,9 +293,15 @@ int run_srv_daemon_side_multi(srv_params_t *params) {
         sts_thread_params->decrypter = new_socket_decrypter;
         sts_thread_params->is_srv_ready = true;
 
+        // Count the session before the thread exists so the timeout check
+        // can't fire in the gap between accepting the request and the
+        // session becoming active
+        session_started();
+
         res = pthread_create(&sts_thread, NULL, run_socket_to_socket, (void *)sts_thread_params);
         if (res != 0) {
           atlogger_log(TAG, ERROR, "Failed to create thread: %d\n", res);
+          session_ended();
           if (!no_encrypt) {
             free(new_socket_encrypter);
             free(new_socket_decrypter);
@@ -591,6 +648,8 @@ static void *run_socket_to_socket(void *args) {
   free(sts_thread_params->encrypter);
   free(sts_thread_params->decrypter);
   free(sts_thread_params);
+
+  session_ended();
 
   return NULL;
 }

--- a/packages/c/sshnpd/include/sshnpd/run_srv_process.h
+++ b/packages/c/sshnpd/include/sshnpd/run_srv_process.h
@@ -7,8 +7,11 @@
 
 // The d2c key and iv may be NULL, in which case the session uses a single key
 // (the c2d key) for both directions of traffic.
+// timeout_seconds: how long the srv stays alive with no active connections
+// before exiting (multi mode only); pass SRV_DEFAULT_TIMEOUT_SECONDS when the
+// request doesn't specify one.
 int run_srv_process(const char *srvd_host, uint16_t srvd_port, const char *requested_host, uint16_t requested_port,
                     bool authenticate_to_rvd, char *rvd_auth_string, bool encrypt_rvd_traffic, bool multi,
-                    unsigned char *session_aes_key_c2d, unsigned char *session_iv_c2d, unsigned char *session_aes_key_d2c,
-                    unsigned char *session_iv_d2c);
+                    int timeout_seconds, unsigned char *session_aes_key_c2d, unsigned char *session_iv_c2d,
+                    unsigned char *session_aes_key_d2c, unsigned char *session_iv_d2c);
 #endif

--- a/packages/c/sshnpd/src/handle_npt_request.c
+++ b/packages/c/sshnpd/src/handle_npt_request.c
@@ -13,6 +13,7 @@
 #include <sshnpd/handle_ssh_request.h>
 #include <sshnpd/handler_commons.h>
 #include <sshnpd/run_srv_process.h>
+#include <srv/params.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/wait.h>
@@ -161,9 +162,20 @@ void handle_npt_request(atclient *atclient, sshnpd_params *params, bool *is_chil
 
     const bool multi = true;
 
+    // The npt session request carries the timeout in milliseconds; the srv
+    // works in whole seconds, so round up (DaemonFeature.adjustableTimeout)
+    int timeout_seconds = SRV_DEFAULT_TIMEOUT_SECONDS;
+    cJSON *timeout_json = cJSON_GetObjectItem(payload, "timeout");
+    if (cJSON_IsNumber(timeout_json) && cJSON_GetNumberValue(timeout_json) > 0) {
+      timeout_seconds = (int)((cJSON_GetNumberValue(timeout_json) + 999) / 1000);
+      if (timeout_seconds < 1) {
+        timeout_seconds = 1;
+      }
+    }
+
     run_srv_process(rvd_host_str, rvd_port_int, requested_host_str, requested_port_int, authenticate_to_rvd,
-                    rvd_auth_string, encrypt_rvd_traffic, multi, session_aes_key_c2d, session_iv_c2d, session_aes_key_d2c,
-                    session_iv_d2c);
+                    rvd_auth_string, encrypt_rvd_traffic, multi, timeout_seconds, session_aes_key_c2d, session_iv_c2d,
+                    session_aes_key_d2c, session_iv_d2c);
 
     *is_child_process = true;
 

--- a/packages/c/sshnpd/src/handle_npt_request.c
+++ b/packages/c/sshnpd/src/handle_npt_request.c
@@ -167,7 +167,14 @@ void handle_npt_request(atclient *atclient, sshnpd_params *params, bool *is_chil
     int timeout_seconds = SRV_DEFAULT_TIMEOUT_SECONDS;
     cJSON *timeout_json = cJSON_GetObjectItem(payload, "timeout");
     if (cJSON_IsNumber(timeout_json) && cJSON_GetNumberValue(timeout_json) > 0) {
-      timeout_seconds = (int)((cJSON_GetNumberValue(timeout_json) + 999) / 1000);
+      double timeout_ms = cJSON_GetNumberValue(timeout_json);
+      // Clamp before the cast: an out-of-range double -> int conversion is UB.
+      // The cap matches the npt client's "never" timeout (-T 0 -> 365 days),
+      // the largest value a well-behaved client sends.
+      if (timeout_ms > (double)SRV_MAX_TIMEOUT_SECONDS * 1000.0) {
+        timeout_ms = (double)SRV_MAX_TIMEOUT_SECONDS * 1000.0;
+      }
+      timeout_seconds = (int)((timeout_ms + 999) / 1000);
       if (timeout_seconds < 1) {
         timeout_seconds = 1;
       }

--- a/packages/c/sshnpd/src/handle_npt_request.c
+++ b/packages/c/sshnpd/src/handle_npt_request.c
@@ -10,10 +10,10 @@
 #include <atclient/string_utils.h>
 #include <atlogger/atlogger.h>
 #include <errno.h>
+#include <srv/params.h>
 #include <sshnpd/handle_ssh_request.h>
 #include <sshnpd/handler_commons.h>
 #include <sshnpd/run_srv_process.h>
-#include <srv/params.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/wait.h>

--- a/packages/c/sshnpd/src/handle_ssh_request.c
+++ b/packages/c/sshnpd/src/handle_ssh_request.c
@@ -9,10 +9,10 @@
 #include <atclient/string_utils.h>
 #include <atlogger/atlogger.h>
 #include <errno.h>
+#include <srv/params.h>
 #include <sshnpd/handle_ssh_request.h>
 #include <sshnpd/handler_commons.h>
 #include <sshnpd/run_srv_process.h>
-#include <srv/params.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/wait.h>

--- a/packages/c/sshnpd/src/handle_ssh_request.c
+++ b/packages/c/sshnpd/src/handle_ssh_request.c
@@ -12,6 +12,7 @@
 #include <sshnpd/handle_ssh_request.h>
 #include <sshnpd/handler_commons.h>
 #include <sshnpd/run_srv_process.h>
+#include <srv/params.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/wait.h>
@@ -142,9 +143,10 @@ void handle_ssh_request(atclient *atclient, sshnpd_params *params, bool *is_chil
 
     const bool multi = false;
 
+    // ssh_request payloads don't carry a timeout - only npt session requests do
     int res = run_srv_process(rvd_host_str, rvd_port_int, requested_host_str, requested_port_int, authenticate_to_rvd,
-                              rvd_auth_string, encrypt_rvd_traffic, multi, session_aes_key_c2d, session_iv_c2d,
-                              session_aes_key_d2c, session_iv_d2c);
+                              rvd_auth_string, encrypt_rvd_traffic, multi, SRV_DEFAULT_TIMEOUT_SECONDS,
+                              session_aes_key_c2d, session_iv_c2d, session_aes_key_d2c, session_iv_d2c);
     if (res != 0) {
       atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "srv process exited with code: %d\n", res);
     }

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -330,6 +330,7 @@ int main(int argc, char **argv) {
   cJSON_bool acceptsPublicKeys = params.sshpublickey;
   cJSON_AddItemToObject(supported_features, "acceptsPublicKeys", cJSON_CreateBool(acceptsPublicKeys));
   cJSON_AddItemToObject(supported_features, "supportsPortChoice", cJSON_CreateBool(true));
+  cJSON_AddItemToObject(supported_features, "adjustableTimeout", cJSON_CreateBool(true));
   cJSON_AddItemToObject(supported_features, "twinKeys", cJSON_CreateBool(true));
   cJSON_AddItemToObject(ping_response_json, "supportedFeatures", supported_features);
 

--- a/packages/c/sshnpd/src/run_srv_process.c
+++ b/packages/c/sshnpd/src/run_srv_process.c
@@ -12,8 +12,8 @@
 
 int run_srv_process(const char *srvd_host, uint16_t srvd_port, const char *requested_host, uint16_t requested_port,
                     bool authenticate_to_rvd, char *rvd_auth_string, bool encrypt_rvd_traffic, bool multi,
-                    unsigned char *session_aes_key_c2d, unsigned char *session_iv_c2d, unsigned char *session_aes_key_d2c,
-                    unsigned char *session_iv_d2c) {
+                    int timeout_seconds, unsigned char *session_aes_key_c2d, unsigned char *session_iv_c2d,
+                    unsigned char *session_aes_key_d2c, unsigned char *session_iv_d2c) {
 
   int res = 0;
   srv_params_t srv_params;
@@ -38,6 +38,7 @@ int run_srv_process(const char *srvd_host, uint16_t srvd_port, const char *reque
   srv_params.session_aes_key_d2c_string = (char *)session_aes_key_d2c;
   srv_params.session_aes_iv_d2c_string = (char *)session_iv_d2c;
   srv_params.multi = multi;
+  srv_params.timeout = timeout_seconds > 0 ? timeout_seconds : SRV_DEFAULT_TIMEOUT_SECONDS;
 
   atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Starting srv\n");
   atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "relay: %s:%d\n", srvd_host, srvd_port);
@@ -45,6 +46,7 @@ int run_srv_process(const char *srvd_host, uint16_t srvd_port, const char *reque
   atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "rv_auth: %d\n", authenticate_to_rvd);
   atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "rv_e2ee: %d\n", encrypt_rvd_traffic);
   atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "multi: %d\n", multi);
+  atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "timeout: %d\n", srv_params.timeout);
   fflush(stdout);
 
   atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_INFO);


### PR DESCRIPTION
> [!NOTE]
> **Ready for review.** First of the stacked chain #2864 → #2865 → #2867 (merge in that order; GitHub retargets each PR as its base merges). CI is green. End-to-end verification of the whole feature set is being run on the `cconstab/c-2831-integration` branch, which merges this stack plus #2870.

## What this does

Fixes #2831 (option 3, as agreed in the issue discussion): csshnpd now honors the `timeout` value from npt session requests and advertises the `adjustableTimeout` daemon feature, so clients that send a non-default timeout (e.g. NoPorts Desktop) pass the pre-flight feature check and can connect.

## Key insight

The issue discussion estimated 1–2 days because it assumed "supporting timeout" meant per-byte idle tracking across the srv relay threads. Checking the Dart reference implementation shows the actual semantics are much simpler: `SocketConnector`'s timeout is a **no-connections grace timer** — close the srv if no session is established within the timeout, and close after the last session ends. There is no idle-byte enforcement anywhere in the Dart implementation either.

## Changes

- **`packages/c/srv/src/srv.c`** — the real work. Multi-mode control channel now polls with `mbedtls_net_recv_timeout` (1s interval) instead of blocking forever in `mbedtls_net_recv`, tracks active socket-to-socket sessions with a mutex-protected counter, and exits once there have been no active sessions for `params->timeout` seconds. Slightly gentler than Dart (which closes the instant the last session ends) to avoid killing the srv between a client's back-to-back reconnects, but still an honest implementation of the feature.
- **`packages/c/srv/src/params.c` / `params.h`** — `timeout` now has a default (30s, matching `DefaultArgs.srvTimeoutInSeconds`); previously it was uninitialized stack memory in the sshnpd path (harmless only because nothing read it).
- **`packages/c/sshnpd/src/handle_npt_request.c`** — parses `timeout` (milliseconds) from the npt payload, rounds up to whole seconds, defaults to 30s when absent.
- **`packages/c/sshnpd/src/run_srv_process.c` / `.h`, `handle_ssh_request.c`** — thread the timeout through; the ssh flow passes the default since ssh_request payloads don't carry a timeout.
- **`packages/c/sshnpd/src/main.c`** — advertise `adjustableTimeout: true` in the ping response.

## Side benefit

This also fixes a real resource leak: every abandoned or completed npt session previously left a forked srv process blocked forever on the control-channel recv (the process only died if the relay closed the socket). On long-running OpenWRT devices those accumulate. Now they exit on their own.

## Testing so far

- `cmake --build` clean, all 5 existing unit tests pass.
- Smoke test: standalone `srv --multi --timeout 3` against a local listener connects its control channel and exits cleanly with `No connections for 3 seconds - closing srv` after exactly 3.0s (previously: blocked forever).

## Remaining end-to-end verification (tracked on the `cconstab/c-2831-integration` branch)

- [ ] End-to-end test: NoPorts Desktop / `npt` client with a non-default timeout against this daemon via a real relay
- [ ] Verify sessions survive longer than the timeout while traffic is flowing, and that back-to-back reconnects within the timeout work
- [ ] Test on an OpenWRT target
- [ ] Consider whether `handle_npt_request` should cap absurdly large timeout values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
