### PR TITLE
feat: ESCR relay auth in csshnpd + c srv (daemon-side support for --443)

### DIFF
--- a/packages/c/srv/CMakeLists.txt
+++ b/packages/c/srv/CMakeLists.txt
@@ -10,6 +10,7 @@ project(srv VERSION 1.0.20 LANGUAGES C)
 # globs are known as bad practice, so we do not use them here
 set(
   SRV_SRCS
+  ${CMAKE_CURRENT_LIST_DIR}/src/escr.c
   ${CMAKE_CURRENT_LIST_DIR}/src/params.c
   ${CMAKE_CURRENT_LIST_DIR}/src/side.c
   ${CMAKE_CURRENT_LIST_DIR}/src/srv.c

--- a/packages/c/srv/include/srv/escr.h
+++ b/packages/c/srv/include/srv/escr.h
@@ -36,8 +36,8 @@
  * @return int 0 on success, non-zero on error
  */
 int srv_escr_build_response(const char *session_id, const char *challenge, const char *aes_key_base64,
-                            const char *signing_key_uri, const atchops_rsa_key_private_key *signing_key,
-                            bool is_side_a, const unsigned char iv[16], char **out_line);
+                            const char *signing_key_uri, const atchops_rsa_key_private_key *signing_key, bool is_side_a,
+                            const unsigned char iv[16], char **out_line);
 
 /**
  * @brief Run the ESCR authentication exchange on a freshly connected relay

--- a/packages/c/srv/include/srv/escr.h
+++ b/packages/c/srv/include/srv/escr.h
@@ -1,0 +1,54 @@
+#ifndef SRV_ESCR_H
+#define SRV_ESCR_H
+
+#include "srv/params.h"
+#include <atchops/rsa_key.h>
+#include <mbedtls/net_sockets.h>
+#include <stdbool.h>
+
+/**
+ * @brief Build the response line for an ESCR (Encrypted Signed Challenge
+ * Response) relay authentication challenge.
+ *
+ * The line has the form `<session_id>:<base64 payload>` (no trailing
+ * newline). The construction matches RelayAuthenticatorESCR in the Dart
+ * noports_core package byte for byte:
+ * - sign the compact JSON `{"sid":...,"c":...,"side":...}` with
+ *   RSASSA-PKCS1-v1_5 / SHA-256
+ * - wrap payload, signature, algorithm names and the public signing key uri
+ *   in an envelope, base64 encode it
+ * - PKCS#7 pad and AES-256-CTR encrypt the base64 envelope with the
+ *   session's relay auth key and the given iv
+ * - wrap iv and ciphertext (both base64) in `{"iv":...,"e":...}` and base64
+ *   encode that as the payload
+ *
+ * This function is deterministic for a given iv, which is what makes it unit
+ * testable; callers must generate a fresh random 16 byte iv per socket.
+ *
+ * @param session_id the session id (uuid) this socket belongs to
+ * @param challenge the challenge line received from the relay (no newline)
+ * @param aes_key_base64 the base64 encoded 32 byte relay auth AES key
+ * @param signing_key_uri the atProtocol uri of the public signing key
+ * @param signing_key the RSA-2048 private signing key
+ * @param is_side_a true for client sockets, false for daemon sockets
+ * @param iv 16 random bytes, freshly generated per authentication
+ * @param out_line receives a malloc'd NUL terminated response line
+ * @return int 0 on success, non-zero on error
+ */
+int srv_escr_build_response(const char *session_id, const char *challenge, const char *aes_key_base64,
+                            const char *signing_key_uri, const atchops_rsa_key_private_key *signing_key,
+                            bool is_side_a, const unsigned char iv[16], char **out_line);
+
+/**
+ * @brief Run the ESCR authentication exchange on a freshly connected relay
+ * socket: read the challenge line, send the response line, wait for "ok".
+ *
+ * Must complete before any session traffic is sent on the socket.
+ *
+ * @param socket the connected relay socket
+ * @param params srv params carrying the escr_* fields
+ * @return int 0 on success (relay replied "ok"), non-zero otherwise
+ */
+int srv_escr_authenticate(mbedtls_net_context *socket, const srv_params_t *params);
+
+#endif

--- a/packages/c/srv/include/srv/params.h
+++ b/packages/c/srv/include/srv/params.h
@@ -6,6 +6,7 @@
 #define SRV_DEFAULT_TIMEOUT_SECONDS 30
 
 #include <argparse/argparse.h>
+#include <atchops/rsa_key.h>
 #include <getopt.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -36,6 +37,17 @@ typedef struct {
   int timeout;
 
   char *rvd_auth_string;
+
+  // ESCR relay authentication (RelayAuthMode.escr). When escr_auth is true
+  // every socket to the relay runs an encrypted signed challenge response
+  // exchange (see srv/escr.h) instead of writing rvd_auth_string. The signing
+  // key is borrowed, not owned, by this struct.
+  bool escr_auth;
+  bool escr_is_side_a;
+  char *escr_session_id;
+  char *escr_aes_key_base64;
+  char *escr_signing_key_uri;
+  atchops_rsa_key_private_key *escr_signing_key;
 
   // Session encryption keys (base64). When twinned keys are in use, the C2D
   // (client to daemon) key decrypts inbound traffic and the D2C (daemon to

--- a/packages/c/srv/include/srv/params.h
+++ b/packages/c/srv/include/srv/params.h
@@ -45,8 +45,10 @@ typedef struct {
 
   // ESCR relay authentication (RelayAuthMode.escr). When escr_auth is true
   // every socket to the relay runs an encrypted signed challenge response
-  // exchange (see srv/escr.h) instead of writing rvd_auth_string. The signing
-  // key is borrowed, not owned, by this struct.
+  // exchange (see srv/escr.h) instead of writing rvd_auth_string. Ownership
+  // of the signing key depends on the caller: when sshnpd runs srv in-process
+  // it is borrowed from the daemon's atkeys, but the standalone srv binary's
+  // parse_srv_params allocates it (owned for the lifetime of the process).
   bool escr_auth;
   bool escr_is_side_a;
   char *escr_session_id;

--- a/packages/c/srv/src/escr.c
+++ b/packages/c/srv/src/escr.c
@@ -38,13 +38,14 @@ static bool json_safe(const char *s) {
 }
 
 static char *base64_encode_alloc(const unsigned char *src, size_t len) {
-  size_t dstsize = (len / 3 + 2) * 4 + 4;
-  char *dst = malloc(dstsize);
+  // Base64 encodes every 3 input bytes as exactly 4 output characters
+  size_t b64_len = ((len + 2) / 3) * 4;
+  char *dst = malloc(b64_len + 1);
   if (dst == NULL) {
     return NULL;
   }
   size_t dstlen = 0;
-  if (atchops_base64_encode(src, len, dst, dstsize, &dstlen) != 0) {
+  if (atchops_base64_encode(src, len, dst, b64_len + 1, &dstlen) != 0 || dstlen > b64_len) {
     free(dst);
     return NULL;
   }

--- a/packages/c/srv/src/escr.c
+++ b/packages/c/srv/src/escr.c
@@ -37,20 +37,15 @@ static bool json_safe(const char *s) {
   return true;
 }
 
-static char *base64_encode_alloc(const unsigned char *src, size_t len) {
-  // Base64 encodes every 3 input bytes as exactly 4 output characters
-  size_t b64_len = ((len + 2) / 3) * 4;
-  char *dst = malloc(b64_len + 1);
-  if (dst == NULL) {
-    return NULL;
-  }
+// Base64 encode src into the caller's buffer and null-terminate. dstsize
+// must include room for the terminator. Returns 0 on success.
+static int base64_encode_str(const unsigned char *src, size_t len, char *dst, size_t dstsize) {
   size_t dstlen = 0;
-  if (atchops_base64_encode(src, len, dst, b64_len + 1, &dstlen) != 0 || dstlen > b64_len) {
-    free(dst);
-    return NULL;
+  if (dstsize == 0 || atchops_base64_encode(src, len, dst, dstsize - 1, &dstlen) != 0) {
+    return 1;
   }
   dst[dstlen] = '\0';
-  return dst;
+  return 0;
 }
 
 int srv_escr_build_response(const char *session_id, const char *challenge, const char *aes_key_base64,
@@ -58,15 +53,21 @@ int srv_escr_build_response(const char *session_id, const char *challenge, const
                             const unsigned char iv[16], char **out_line) {
   int ret = 1;
 
-  char *p_json = NULL;
-  char *sig_b64 = NULL;
-  char *env_json = NULL;
-  char *env64 = NULL;
-  unsigned char *padded = NULL;
-  unsigned char *encrypted = NULL;
-  char *enc_b64 = NULL;
-  char *outer_json = NULL;
-  char *auth_payload64 = NULL;
+  // The relay rejects lines longer than ESCR_MAX_LINE, so every intermediate
+  // stage is bounded by it too (each later stage only grows the data). All
+  // buffers are fixed-size and stack-owned; snprintf truncation at any stage
+  // is caught and reported as the same over-limit error the final check gives.
+  char p_json[ESCR_MAX_LINE];
+  char sig_b64[512]; // RSA-2048 signature is 256 bytes -> 344 base64 chars
+  char env_json[ESCR_MAX_LINE];
+  char env64[ESCR_MAX_LINE];
+  unsigned char padded[ESCR_MAX_LINE + 16];
+  unsigned char encrypted[ESCR_MAX_LINE + 16];
+  char enc_b64[ESCR_MAX_LINE];
+  char iv_b64[32];
+  char outer_json[ESCR_MAX_LINE];
+  char auth_payload64[ESCR_MAX_LINE];
+  int n;
 
   *out_line = NULL;
 
@@ -78,13 +79,11 @@ int srv_escr_build_response(const char *session_id, const char *challenge, const
   // Inner signed payload. The relay re-serializes this map with Dart's
   // jsonEncode and verifies the signature against that, so the bytes must be
   // compact JSON in exactly this key order.
-  size_t p_size = strlen(session_id) + strlen(challenge) + 32;
-  p_json = malloc(p_size);
-  if (p_json == NULL) {
-    goto exit;
+  n = snprintf(p_json, sizeof(p_json), "{\"sid\":\"%s\",\"c\":\"%s\",\"side\":\"%s\"}", session_id, challenge,
+               is_side_a ? "a" : "b");
+  if (n < 0 || (size_t)n >= sizeof(p_json)) {
+    goto too_long;
   }
-  snprintf(p_json, p_size, "{\"sid\":\"%s\",\"c\":\"%s\",\"side\":\"%s\"}", session_id, challenge,
-           is_side_a ? "a" : "b");
 
   // Sign the payload bytes: RSASSA-PKCS1-v1_5 over SHA-256
   unsigned char sig[ESCR_RSA_SIG_BYTES];
@@ -92,23 +91,19 @@ int srv_escr_build_response(const char *session_id, const char *challenge, const
     atlogger_log(TAG, ERROR, "Failed to sign escr challenge payload\n");
     goto exit;
   }
-  sig_b64 = base64_encode_alloc(sig, ESCR_RSA_SIG_BYTES);
-  if (sig_b64 == NULL) {
+  if (base64_encode_str(sig, ESCR_RSA_SIG_BYTES, sig_b64, sizeof(sig_b64)) != 0) {
     goto exit;
   }
 
   // Envelope: payload, signature, algorithm names and the signing key uri
-  size_t env_size = strlen(p_json) + strlen(sig_b64) + strlen(signing_key_uri) + 64;
-  env_json = malloc(env_size);
-  if (env_json == NULL) {
-    goto exit;
+  n = snprintf(env_json, sizeof(env_json), "{\"p\":%s,\"s\":\"%s\",\"ha\":\"sha256\",\"sa\":\"rsa2048\",\"sk\":\"%s\"}",
+               p_json, sig_b64, signing_key_uri);
+  if (n < 0 || (size_t)n >= sizeof(env_json)) {
+    goto too_long;
   }
-  snprintf(env_json, env_size, "{\"p\":%s,\"s\":\"%s\",\"ha\":\"sha256\",\"sa\":\"rsa2048\",\"sk\":\"%s\"}", p_json,
-           sig_b64, signing_key_uri);
 
-  env64 = base64_encode_alloc((unsigned char *)env_json, strlen(env_json));
-  if (env64 == NULL) {
-    goto exit;
+  if (base64_encode_str((unsigned char *)env_json, strlen(env_json), env64, sizeof(env64)) != 0) {
+    goto too_long;
   }
 
   // Decode the relay auth AES key
@@ -126,11 +121,6 @@ int srv_escr_build_response(const char *session_id, const char *challenge, const
   size_t env64_len = strlen(env64);
   size_t pad = 16 - (env64_len % 16); // always 1..16
   size_t padded_len = env64_len + pad;
-  padded = malloc(padded_len);
-  encrypted = malloc(padded_len);
-  if (padded == NULL || encrypted == NULL) {
-    goto exit;
-  }
   memcpy(padded, env64, env64_len);
   memset(padded + env64_len, (unsigned char)pad, pad);
 
@@ -152,30 +142,25 @@ int srv_escr_build_response(const char *session_id, const char *challenge, const
     }
   }
 
-  char iv_b64[32];
-  size_t iv_b64_len = 0;
-  if (atchops_base64_encode(iv, 16, iv_b64, sizeof(iv_b64), &iv_b64_len) != 0) {
-    goto exit;
-  }
-  iv_b64[iv_b64_len] = '\0';
-
-  enc_b64 = base64_encode_alloc(encrypted, padded_len);
-  if (enc_b64 == NULL) {
+  if (base64_encode_str(iv, 16, iv_b64, sizeof(iv_b64)) != 0) {
     goto exit;
   }
 
-  size_t outer_size = strlen(iv_b64) + strlen(enc_b64) + 24;
-  outer_json = malloc(outer_size);
-  if (outer_json == NULL) {
-    goto exit;
-  }
-  snprintf(outer_json, outer_size, "{\"iv\":\"%s\",\"e\":\"%s\"}", iv_b64, enc_b64);
-
-  auth_payload64 = base64_encode_alloc((unsigned char *)outer_json, strlen(outer_json));
-  if (auth_payload64 == NULL) {
-    goto exit;
+  if (base64_encode_str(encrypted, padded_len, enc_b64, sizeof(enc_b64)) != 0) {
+    goto too_long;
   }
 
+  n = snprintf(outer_json, sizeof(outer_json), "{\"iv\":\"%s\",\"e\":\"%s\"}", iv_b64, enc_b64);
+  if (n < 0 || (size_t)n >= sizeof(outer_json)) {
+    goto too_long;
+  }
+
+  if (base64_encode_str((unsigned char *)outer_json, strlen(outer_json), auth_payload64, sizeof(auth_payload64)) != 0) {
+    goto too_long;
+  }
+
+  // The out line is the only heap allocation: it outlives this function and
+  // is freed by the caller.
   size_t line_size = strlen(session_id) + strlen(auth_payload64) + 2;
   *out_line = malloc(line_size);
   if (*out_line == NULL) {
@@ -184,24 +169,18 @@ int srv_escr_build_response(const char *session_id, const char *challenge, const
   snprintf(*out_line, line_size, "%s:%s", session_id, auth_payload64);
 
   if (strlen(*out_line) > ESCR_MAX_LINE - 1) {
-    atlogger_log(TAG, ERROR, "escr response line exceeds the relay's %d byte limit\n", ESCR_MAX_LINE);
     free(*out_line);
     *out_line = NULL;
-    goto exit;
+    goto too_long;
   }
 
   ret = 0;
+  goto exit;
+
+too_long:
+  atlogger_log(TAG, ERROR, "escr response line exceeds the relay's %d byte limit\n", ESCR_MAX_LINE);
 
 exit:
-  free(p_json);
-  free(sig_b64);
-  free(env_json);
-  free(env64);
-  free(padded);
-  free(encrypted);
-  free(enc_b64);
-  free(outer_json);
-  free(auth_payload64);
   return ret;
 }
 

--- a/packages/c/srv/src/escr.c
+++ b/packages/c/srv/src/escr.c
@@ -1,0 +1,292 @@
+#include "srv/escr.h"
+#include "srv/srv.h"
+#include <atchops/base64.h>
+#include <atchops/iv.h>
+#include <atchops/rsa.h>
+#include <atlogger/atlogger.h>
+#include <mbedtls/aes.h>
+#include <mbedtls/net_sockets.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define TAG "srv - escr"
+
+// The relay writes the challenge immediately on accept and answers the
+// response promptly; anything slower than this is a dead connection
+#define ESCR_IO_TIMEOUT_MS 10000
+
+// RSA-2048 signature size; the PKAM signing key is always RSA-2048
+#define ESCR_RSA_SIG_BYTES 256
+
+// The relay rejects auth lines longer than 4096 bytes, and its own challenge
+// is a 44 char base64 string; be generous on the read side regardless
+#define ESCR_MAX_LINE 4096
+
+// The JSON in the auth exchange is built with snprintf rather than a JSON
+// library, which is only byte-compatible with Dart's jsonEncode when none of
+// the embedded strings need escaping. Everything we embed is base64, a uuid,
+// or an atProtocol key uri, so restricting to printable ASCII minus the two
+// JSON specials is both safe and byte-exact.
+static bool json_safe(const char *s) {
+  for (const unsigned char *p = (const unsigned char *)s; *p != '\0'; p++) {
+    if (*p < 32 || *p > 126 || *p == '"' || *p == '\\') {
+      return false;
+    }
+  }
+  return true;
+}
+
+static char *base64_encode_alloc(const unsigned char *src, size_t len) {
+  size_t dstsize = (len / 3 + 2) * 4 + 4;
+  char *dst = malloc(dstsize);
+  if (dst == NULL) {
+    return NULL;
+  }
+  size_t dstlen = 0;
+  if (atchops_base64_encode(src, len, dst, dstsize, &dstlen) != 0) {
+    free(dst);
+    return NULL;
+  }
+  dst[dstlen] = '\0';
+  return dst;
+}
+
+int srv_escr_build_response(const char *session_id, const char *challenge, const char *aes_key_base64,
+                            const char *signing_key_uri, const atchops_rsa_key_private_key *signing_key,
+                            bool is_side_a, const unsigned char iv[16], char **out_line) {
+  int ret = 1;
+
+  char *p_json = NULL;
+  char *sig_b64 = NULL;
+  char *env_json = NULL;
+  char *env64 = NULL;
+  unsigned char *padded = NULL;
+  unsigned char *encrypted = NULL;
+  char *enc_b64 = NULL;
+  char *outer_json = NULL;
+  char *auth_payload64 = NULL;
+
+  *out_line = NULL;
+
+  if (!json_safe(session_id) || !json_safe(challenge) || !json_safe(signing_key_uri)) {
+    atlogger_log(TAG, ERROR, "Refusing to build escr response: input contains characters that need JSON escaping\n");
+    return 1;
+  }
+
+  // Inner signed payload. The relay re-serializes this map with Dart's
+  // jsonEncode and verifies the signature against that, so the bytes must be
+  // compact JSON in exactly this key order.
+  size_t p_size = strlen(session_id) + strlen(challenge) + 32;
+  p_json = malloc(p_size);
+  if (p_json == NULL) {
+    goto exit;
+  }
+  snprintf(p_json, p_size, "{\"sid\":\"%s\",\"c\":\"%s\",\"side\":\"%s\"}", session_id, challenge,
+           is_side_a ? "a" : "b");
+
+  // Sign the payload bytes: RSASSA-PKCS1-v1_5 over SHA-256
+  unsigned char sig[ESCR_RSA_SIG_BYTES];
+  if (atchops_rsa_sign(signing_key, ATCHOPS_MD_SHA256, (unsigned char *)p_json, strlen(p_json), sig) != 0) {
+    atlogger_log(TAG, ERROR, "Failed to sign escr challenge payload\n");
+    goto exit;
+  }
+  sig_b64 = base64_encode_alloc(sig, ESCR_RSA_SIG_BYTES);
+  if (sig_b64 == NULL) {
+    goto exit;
+  }
+
+  // Envelope: payload, signature, algorithm names and the signing key uri
+  size_t env_size = strlen(p_json) + strlen(sig_b64) + strlen(signing_key_uri) + 64;
+  env_json = malloc(env_size);
+  if (env_json == NULL) {
+    goto exit;
+  }
+  snprintf(env_json, env_size, "{\"p\":%s,\"s\":\"%s\",\"ha\":\"sha256\",\"sa\":\"rsa2048\",\"sk\":\"%s\"}", p_json,
+           sig_b64, signing_key_uri);
+
+  env64 = base64_encode_alloc((unsigned char *)env_json, strlen(env_json));
+  if (env64 == NULL) {
+    goto exit;
+  }
+
+  // Decode the relay auth AES key
+  unsigned char aes_key[32];
+  size_t aes_key_len = 0;
+  if (atchops_base64_decode(aes_key_base64, strlen(aes_key_base64), aes_key, sizeof(aes_key), &aes_key_len) != 0 ||
+      aes_key_len != 32) {
+    atlogger_log(TAG, ERROR, "relay auth AES key is not a base64 encoded 32 byte key\n");
+    goto exit;
+  }
+
+  // PKCS#7 pad the base64 envelope, then AES-256-CTR encrypt it. The padding
+  // is redundant for a stream mode, but the relay's decrypt path removes and
+  // validates it, so it is part of the wire format.
+  size_t env64_len = strlen(env64);
+  size_t pad = 16 - (env64_len % 16); // always 1..16
+  size_t padded_len = env64_len + pad;
+  padded = malloc(padded_len);
+  encrypted = malloc(padded_len);
+  if (padded == NULL || encrypted == NULL) {
+    goto exit;
+  }
+  memcpy(padded, env64, env64_len);
+  memset(padded + env64_len, (unsigned char)pad, pad);
+
+  {
+    mbedtls_aes_context aes_ctx;
+    mbedtls_aes_init(&aes_ctx);
+    int res = mbedtls_aes_setkey_enc(&aes_ctx, aes_key, 256);
+    if (res == 0) {
+      size_t nc_off = 0;
+      unsigned char stream_block[16] = {0};
+      unsigned char nonce_counter[16];
+      memcpy(nonce_counter, iv, 16);
+      res = mbedtls_aes_crypt_ctr(&aes_ctx, padded_len, &nc_off, nonce_counter, stream_block, padded, encrypted);
+    }
+    mbedtls_aes_free(&aes_ctx);
+    if (res != 0) {
+      atlogger_log(TAG, ERROR, "Failed to encrypt escr envelope: %d\n", res);
+      goto exit;
+    }
+  }
+
+  char iv_b64[32];
+  size_t iv_b64_len = 0;
+  if (atchops_base64_encode(iv, 16, iv_b64, sizeof(iv_b64), &iv_b64_len) != 0) {
+    goto exit;
+  }
+  iv_b64[iv_b64_len] = '\0';
+
+  enc_b64 = base64_encode_alloc(encrypted, padded_len);
+  if (enc_b64 == NULL) {
+    goto exit;
+  }
+
+  size_t outer_size = strlen(iv_b64) + strlen(enc_b64) + 24;
+  outer_json = malloc(outer_size);
+  if (outer_json == NULL) {
+    goto exit;
+  }
+  snprintf(outer_json, outer_size, "{\"iv\":\"%s\",\"e\":\"%s\"}", iv_b64, enc_b64);
+
+  auth_payload64 = base64_encode_alloc((unsigned char *)outer_json, strlen(outer_json));
+  if (auth_payload64 == NULL) {
+    goto exit;
+  }
+
+  size_t line_size = strlen(session_id) + strlen(auth_payload64) + 2;
+  *out_line = malloc(line_size);
+  if (*out_line == NULL) {
+    goto exit;
+  }
+  snprintf(*out_line, line_size, "%s:%s", session_id, auth_payload64);
+
+  if (strlen(*out_line) > ESCR_MAX_LINE - 1) {
+    atlogger_log(TAG, ERROR, "escr response line exceeds the relay's %d byte limit\n", ESCR_MAX_LINE);
+    free(*out_line);
+    *out_line = NULL;
+    goto exit;
+  }
+
+  ret = 0;
+
+exit:
+  free(p_json);
+  free(sig_b64);
+  free(env_json);
+  free(env64);
+  free(padded);
+  free(encrypted);
+  free(enc_b64);
+  free(outer_json);
+  free(auth_payload64);
+  return ret;
+}
+
+// Read one newline-terminated line, a byte at a time (the handshake is tiny,
+// and byte-wise reads mean no bytes past the newline are consumed - anything
+// after the relay's "ok" already belongs to the session)
+static int escr_read_line(mbedtls_net_context *socket, char *buf, size_t buflen) {
+  size_t pos = 0;
+  while (pos < buflen - 1) {
+    unsigned char b;
+    int res = mbedtls_net_recv_timeout(socket, &b, 1, ESCR_IO_TIMEOUT_MS);
+    if (res == MBEDTLS_ERR_SSL_TIMEOUT) {
+      atlogger_log(TAG, ERROR, "Timed out waiting for relay during escr auth\n");
+      return 1;
+    }
+    if (res <= 0) {
+      atlogger_log(TAG, ERROR, "Connection error during escr auth: %d\n", res);
+      return 1;
+    }
+    if (b == '\n') {
+      buf[pos] = '\0';
+      return 0;
+    }
+    buf[pos++] = (char)b;
+  }
+  atlogger_log(TAG, ERROR, "Line from relay exceeded %zu bytes during escr auth\n", buflen);
+  return 1;
+}
+
+static int escr_send_all(mbedtls_net_context *socket, const unsigned char *buf, size_t len) {
+  size_t sent = 0;
+  while (sent < len) {
+    int res = mbedtls_net_send(socket, buf + sent, len - sent);
+    if (res < 0) {
+      atlogger_log(TAG, ERROR, "Failed to send escr response: %d\n", res);
+      return 1;
+    }
+    sent += res;
+  }
+  return 0;
+}
+
+int srv_escr_authenticate(mbedtls_net_context *socket, const srv_params_t *params) {
+  if (params->escr_session_id == NULL || params->escr_aes_key_base64 == NULL || params->escr_signing_key_uri == NULL ||
+      params->escr_signing_key == NULL) {
+    atlogger_log(TAG, ERROR, "escr auth requested but escr parameters are incomplete\n");
+    return 1;
+  }
+
+  char challenge[ESCR_MAX_LINE];
+  if (escr_read_line(socket, challenge, sizeof(challenge)) != 0) {
+    return 1;
+  }
+
+  unsigned char iv[16];
+  if (atchops_iv_generate(iv) != 0) {
+    atlogger_log(TAG, ERROR, "Failed to generate iv for escr auth\n");
+    return 1;
+  }
+
+  char *line = NULL;
+  int res = srv_escr_build_response(params->escr_session_id, challenge, params->escr_aes_key_base64,
+                                    params->escr_signing_key_uri, params->escr_signing_key, params->escr_is_side_a, iv,
+                                    &line);
+  if (res != 0) {
+    return res;
+  }
+
+  res = escr_send_all(socket, (unsigned char *)line, strlen(line));
+  free(line);
+  if (res == 0) {
+    res = escr_send_all(socket, (const unsigned char *)"\n", 1);
+  }
+  if (res != 0) {
+    return res;
+  }
+
+  char reply[64];
+  if (escr_read_line(socket, reply, sizeof(reply)) != 0) {
+    return 1;
+  }
+  if (strcmp(reply, "ok") != 0) {
+    atlogger_log(TAG, ERROR, "Relay rejected escr auth: %s\n", reply);
+    return 1;
+  }
+
+  atlogger_log(TAG, DEBUG, "escr auth succeeded\n");
+  return 0;
+}

--- a/packages/c/srv/src/escr.c
+++ b/packages/c/srv/src/escr.c
@@ -53,8 +53,8 @@ static char *base64_encode_alloc(const unsigned char *src, size_t len) {
 }
 
 int srv_escr_build_response(const char *session_id, const char *challenge, const char *aes_key_base64,
-                            const char *signing_key_uri, const atchops_rsa_key_private_key *signing_key,
-                            bool is_side_a, const unsigned char iv[16], char **out_line) {
+                            const char *signing_key_uri, const atchops_rsa_key_private_key *signing_key, bool is_side_a,
+                            const unsigned char iv[16], char **out_line) {
   int ret = 1;
 
   char *p_json = NULL;

--- a/packages/c/srv/src/escr.c
+++ b/packages/c/srv/src/escr.c
@@ -234,7 +234,9 @@ static int escr_send_all(mbedtls_net_context *socket, const unsigned char *buf, 
   size_t sent = 0;
   while (sent < len) {
     int res = mbedtls_net_send(socket, buf + sent, len - sent);
-    if (res < 0) {
+    // 0 means the peer is gone (closed/failed connection); treating it as
+    // progress would spin this loop forever
+    if (res <= 0) {
       atlogger_log(TAG, ERROR, "Failed to send escr response: %d\n", res);
       return 1;
     }

--- a/packages/c/srv/src/params.c
+++ b/packages/c/srv/src/params.c
@@ -16,9 +16,17 @@ void apply_default_values_to_srv_params(srv_params_t *params) {
   params->session_aes_iv_c2d_string = NULL;
   params->session_aes_key_d2c_string = NULL;
   params->session_aes_iv_d2c_string = NULL;
+  params->escr_auth = false;
+  params->escr_is_side_a = false;
+  params->escr_session_id = NULL;
+  params->escr_aes_key_base64 = NULL;
+  params->escr_signing_key_uri = NULL;
+  params->escr_signing_key = NULL;
 }
 
 int parse_srv_params(srv_params_t *params, int argc, const char **argv, srv_env_t *environment) {
+
+  char *relay_auth_mode = NULL;
 
 // pragma GCC works for both gcc and clang
 #pragma GCC diagnostic push
@@ -35,6 +43,10 @@ int parse_srv_params(srv_params_t *params, int argc, const char **argv, srv_env_
                   "Set this flag when we are bridging from a local sender"),
 #endif
       OPT_BOOLEAN(0, "rv-auth", &params->rv_auth, "Whether this rv process will authenticate to rvd"),
+      OPT_STRING('a', "relay-auth-mode", &relay_auth_mode,
+                 "Relay authentication mode: 'payload' (use --rv-auth instead) or 'escr'. escr reads "
+                 "REMOTE_AUTH_ESCR_SESSION_ID, REMOTE_AUTH_ESCR_AES_KEY, REMOTE_AUTH_ESCR_PUB_KEY_URI, "
+                 "REMOTE_AUTH_ESCR_SIGNING_PRIVKEY and REMOTE_AUTH_ESCR_IS_SIDE_A from the environment"),
       OPT_BOOLEAN(0, "rv-e2ee", &params->rv_e2ee,
                   "Whether this rv process will encrypt/decrypt all rvd socket "
                   "traffic"),
@@ -61,6 +73,57 @@ int parse_srv_params(srv_params_t *params, int argc, const char **argv, srv_env_
   } else if (params->port == 0) {
     argparse_usage(&argparse);
     printf("Invalid Argument(s) Option port is mandatory\n");
+    return 1;
+  }
+
+  // ESCR relay auth (standalone binary path). The sshnpd in-process path
+  // fills the escr_* fields directly and never comes through here.
+  if (relay_auth_mode != NULL && strcmp(relay_auth_mode, "escr") == 0) {
+    if (params->rv_auth == 1) {
+      argparse_usage(&argparse);
+      printf("--rv-auth and --relay-auth-mode escr are mutually exclusive\n");
+      return 1;
+    }
+    params->escr_session_id = getenv("REMOTE_AUTH_ESCR_SESSION_ID");
+    params->escr_aes_key_base64 = getenv("REMOTE_AUTH_ESCR_AES_KEY");
+    params->escr_signing_key_uri = getenv("REMOTE_AUTH_ESCR_PUB_KEY_URI");
+    char *escr_signing_privkey_base64 = getenv("REMOTE_AUTH_ESCR_SIGNING_PRIVKEY");
+    char *escr_is_side_a = getenv("REMOTE_AUTH_ESCR_IS_SIDE_A");
+    if (params->escr_session_id == NULL || params->escr_aes_key_base64 == NULL ||
+        params->escr_signing_key_uri == NULL || escr_signing_privkey_base64 == NULL || escr_is_side_a == NULL) {
+      argparse_usage(&argparse);
+      printf("--relay-auth-mode escr requires REMOTE_AUTH_ESCR_SESSION_ID, REMOTE_AUTH_ESCR_AES_KEY, "
+             "REMOTE_AUTH_ESCR_PUB_KEY_URI, REMOTE_AUTH_ESCR_SIGNING_PRIVKEY and REMOTE_AUTH_ESCR_IS_SIDE_A in the "
+             "environment\n");
+      return 1;
+    }
+    if (strcmp(escr_is_side_a, "true") == 0) {
+      params->escr_is_side_a = true;
+    } else if (strcmp(escr_is_side_a, "false") == 0) {
+      params->escr_is_side_a = false;
+    } else {
+      printf("REMOTE_AUTH_ESCR_IS_SIDE_A must be 'true' or 'false'\n");
+      return 1;
+    }
+
+    // Owned by this params struct for the lifetime of the process
+    params->escr_signing_key = malloc(sizeof(atchops_rsa_key_private_key));
+    if (params->escr_signing_key == NULL) {
+      return 1;
+    }
+    atchops_rsa_key_private_key_init(params->escr_signing_key);
+    if (atchops_rsa_key_populate_private_key(params->escr_signing_key, escr_signing_privkey_base64,
+                                             strlen(escr_signing_privkey_base64)) != 0) {
+      printf("Failed to parse REMOTE_AUTH_ESCR_SIGNING_PRIVKEY\n");
+      atchops_rsa_key_private_key_free(params->escr_signing_key);
+      free(params->escr_signing_key);
+      params->escr_signing_key = NULL;
+      return 1;
+    }
+    params->escr_auth = true;
+  } else if (relay_auth_mode != NULL && strcmp(relay_auth_mode, "payload") != 0) {
+    argparse_usage(&argparse);
+    printf("Unknown --relay-auth-mode: %s\n", relay_auth_mode);
     return 1;
   }
 

--- a/packages/c/srv/src/srv.c
+++ b/packages/c/srv/src/srv.c
@@ -1,4 +1,5 @@
 #include "srv/srv.h"
+#include "srv/escr.h"
 #include "srv/params.h"
 #include "srv/side.h"
 #include <atchops/base64.h>
@@ -145,8 +146,16 @@ int run_srv_daemon_side_multi(srv_params_t *params) {
     return res;
   }
 
-  // send the auth string to the other side
-  if (params->rv_auth == 1) {
+  // Authenticate the control channel to the relay
+  if (params->escr_auth) {
+    atlogger_log(TAG, INFO, "Authenticating control channel to relay (escr)\n");
+    res = srv_escr_authenticate(&control_side.socket, params);
+    if (res != 0) {
+      atlogger_log(TAG, ERROR, "Failed to authenticate control channel to relay\n");
+      mbedtls_net_close(&control_side.socket);
+      return res;
+    }
+  } else if (params->rv_auth == 1) {
     atlogger_log(TAG, DEBUG, "Sending auth string: %s\n", (unsigned char *)params->rvd_auth_string);
     int len = strlen(params->rvd_auth_string);
 
@@ -370,8 +379,17 @@ int socket_to_socket(const srv_params_t *params, const char *auth_string, chunke
   srv_link_sides(&sides[0], &sides[1], fds);
 
   atlogger_log(TAG, INFO, "Starting threads\n");
-  // send the auth string to side b
-  if (params->rv_auth == 1) {
+  // Authenticate side b (the relay side) - every socket to the relay
+  // authenticates individually
+  if (params->escr_auth) {
+    atlogger_log(TAG, INFO, "Authenticating session socket to relay (escr)\n");
+    res = srv_escr_authenticate(&sides[1].socket, params);
+    if (res != 0) {
+      atlogger_log(TAG, ERROR, "Failed to authenticate session socket to relay\n");
+      exit_res = res;
+      goto exit;
+    }
+  } else if (params->rv_auth == 1) {
     atlogger_log(TAG, INFO, "Sending auth string\n");
     int len = strlen(auth_string);
 

--- a/packages/c/sshnpd/include/sshnpd/handler_commons.h
+++ b/packages/c/sshnpd/include/sshnpd/handler_commons.h
@@ -1,6 +1,7 @@
 #ifndef HANDLER_COMMONS_H
 #define HANDLER_COMMONS_H
 #include "sshnpd/params.h"
+#include <atclient/atkeys.h>
 #include <atclient/json.h>
 #include <atclient/monitor.h>
 
@@ -19,6 +20,11 @@ int verify_envelope_contents(cJSON *envelope, enum payload_type type);
 int verify_payload_contents(cJSON *payload, enum payload_type type);
 
 int create_rvd_auth_string(cJSON *payload, atchops_rsa_key_private_key *signing_key, char **rvd_auth_string);
+
+// Returns the malloc'd atProtocol uri of the daemon's public signing key,
+// 'public:_apsk.<enrollmentId>.a.__e<atsign>', used for escr relay auth. The
+// enrollment id falls back to 'primary' when the atkeys carry none.
+char *public_signing_key_uri(const atclient_atkeys *atkeys, const char *atsign);
 
 // Generates a fresh session AES key and iv, returning the base64 encoded
 // plaintext values (session_aes_key / session_iv) alongside copies encrypted

--- a/packages/c/sshnpd/include/sshnpd/run_srv_process.h
+++ b/packages/c/sshnpd/include/sshnpd/run_srv_process.h
@@ -1,17 +1,29 @@
 #ifndef RUN_SRV_H
 #define RUN_SRV_H
 
+#include <atchops/rsa_key.h>
 #include <atclient/json.h>
 #include <stdbool.h>
 #include <stdint.h>
+
+// Everything the srv needs to run ESCR (encrypted signed challenge response)
+// relay authentication for one session. All pointers are borrowed.
+typedef struct {
+  const char *session_id;
+  const char *aes_key_base64;   // the session's relayAuthAesKey
+  const char *signing_key_uri;  // public:_apsk.<enrollmentId>.a.__e<atsign>
+  atchops_rsa_key_private_key *signing_key; // the daemon's PKAM private key
+} sshnpd_escr_context;
 
 // The d2c key and iv may be NULL, in which case the session uses a single key
 // (the c2d key) for both directions of traffic.
 // timeout_seconds: how long the srv stays alive with no active connections
 // before exiting (multi mode only); pass SRV_DEFAULT_TIMEOUT_SECONDS when the
 // request doesn't specify one.
+// escr: non-NULL to authenticate to the relay with ESCR instead of the legacy
+// rvd_auth_string.
 int run_srv_process(const char *srvd_host, uint16_t srvd_port, const char *requested_host, uint16_t requested_port,
-                    bool authenticate_to_rvd, char *rvd_auth_string, bool encrypt_rvd_traffic, bool multi,
-                    int timeout_seconds, unsigned char *session_aes_key_c2d, unsigned char *session_iv_c2d,
-                    unsigned char *session_aes_key_d2c, unsigned char *session_iv_d2c);
+                    bool authenticate_to_rvd, char *rvd_auth_string, const sshnpd_escr_context *escr,
+                    bool encrypt_rvd_traffic, bool multi, int timeout_seconds, unsigned char *session_aes_key_c2d,
+                    unsigned char *session_iv_c2d, unsigned char *session_aes_key_d2c, unsigned char *session_iv_d2c);
 #endif

--- a/packages/c/sshnpd/include/sshnpd/run_srv_process.h
+++ b/packages/c/sshnpd/include/sshnpd/run_srv_process.h
@@ -10,8 +10,8 @@
 // relay authentication for one session. All pointers are borrowed.
 typedef struct {
   const char *session_id;
-  const char *aes_key_base64;   // the session's relayAuthAesKey
-  const char *signing_key_uri;  // public:_apsk.<enrollmentId>.a.__e<atsign>
+  const char *aes_key_base64;               // the session's relayAuthAesKey
+  const char *signing_key_uri;              // public:_apsk.<enrollmentId>.a.__e<atsign>
   atchops_rsa_key_private_key *signing_key; // the daemon's PKAM private key
 } sshnpd_escr_context;
 

--- a/packages/c/sshnpd/src/handle_npt_request.c
+++ b/packages/c/sshnpd/src/handle_npt_request.c
@@ -10,6 +10,7 @@
 #include <atclient/string_utils.h>
 #include <atlogger/atlogger.h>
 #include <errno.h>
+#include <sshnpd/daemon.h>
 #include <sshnpd/handle_ssh_request.h>
 #include <sshnpd/handler_commons.h>
 #include <sshnpd/run_srv_process.h>
@@ -75,15 +76,43 @@ void handle_npt_request(atclient *atclient, sshnpd_params *params, bool *is_chil
   }
 
   bool authenticate_to_rvd = cJSON_IsTrue(cJSON_GetObjectItem(payload, "authenticateToRvd"));
-  char *rvd_auth_string;
+  char *rvd_auth_string = NULL;
+  char *escr_signing_key_uri = NULL;
+  sshnpd_escr_context escr_context;
+  bool use_escr = false;
 
   if (authenticate_to_rvd) {
-    res = create_rvd_auth_string(payload, &signing_key, &rvd_auth_string);
-    if (res != 0) {
-      cJSON_Delete(envelope);
-      return;
+    // RelayAuthMode: absent or "payload" means the legacy signed auth string,
+    // "escr" means encrypted signed challenge response (required for relays
+    // running on a single shared port, e.g. 443)
+    char *relay_auth_mode = cJSON_GetStringValue(cJSON_GetObjectItem(payload, "relayAuthMode"));
+    if (relay_auth_mode != NULL && strcmp(relay_auth_mode, "escr") == 0) {
+      char *relay_auth_aes_key = cJSON_GetStringValue(cJSON_GetObjectItem(payload, "relayAuthAesKey"));
+      char *session_id_str = cJSON_GetStringValue(cJSON_GetObjectItem(payload, "sessionId"));
+      if (relay_auth_aes_key != NULL && session_id_str != NULL) {
+        escr_signing_key_uri = public_signing_key_uri(&atkeys, params->atsign);
+      }
+      if (escr_signing_key_uri != NULL) {
+        escr_context.session_id = session_id_str;
+        escr_context.aes_key_base64 = relay_auth_aes_key;
+        escr_context.signing_key_uri = escr_signing_key_uri;
+        escr_context.signing_key = &atkeys.pkam_private_key;
+        use_escr = true;
+        atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Session will use escr relay auth\n");
+      } else {
+        atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN,
+                     "escr relay auth requested but request is missing relayAuthAesKey or sessionId - falling back to "
+                     "legacy relay auth\n");
+      }
     }
-    // allocated: rvd_auth_string
+    if (!use_escr) {
+      res = create_rvd_auth_string(payload, &signing_key, &rvd_auth_string);
+      if (res != 0) {
+        cJSON_Delete(envelope);
+        return;
+      }
+      // allocated: rvd_auth_string
+    }
   }
 
   bool encrypt_rvd_traffic = cJSON_IsTrue(cJSON_GetObjectItem(payload, "encryptRvdTraffic"));
@@ -103,9 +132,10 @@ void handle_npt_request(atclient *atclient, sshnpd_params *params, bool *is_chil
     if (res != 0) {
       atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to setup rvd session encryption\n");
       cJSON_Delete(envelope);
-      if (authenticate_to_rvd) {
+      if (rvd_auth_string != NULL) {
         free(rvd_auth_string);
       }
+      free(escr_signing_key_uri);
       return;
     }
   }
@@ -122,9 +152,10 @@ void handle_npt_request(atclient *atclient, sshnpd_params *params, bool *is_chil
       free(session_aes_key_c2d_base64);
       free(session_iv_c2d_base64);
       cJSON_Delete(envelope);
-      if (authenticate_to_rvd) {
+      if (rvd_auth_string != NULL) {
         free(rvd_auth_string);
       }
+      free(escr_signing_key_uri);
       return;
     }
   }
@@ -174,8 +205,8 @@ void handle_npt_request(atclient *atclient, sshnpd_params *params, bool *is_chil
     }
 
     run_srv_process(rvd_host_str, rvd_port_int, requested_host_str, requested_port_int, authenticate_to_rvd,
-                    rvd_auth_string, encrypt_rvd_traffic, multi, timeout_seconds, session_aes_key_c2d, session_iv_c2d,
-                    session_aes_key_d2c, session_iv_d2c);
+                    rvd_auth_string, use_escr ? &escr_context : NULL, encrypt_rvd_traffic, multi, timeout_seconds,
+                    session_aes_key_c2d, session_iv_c2d, session_aes_key_d2c, session_iv_d2c);
 
     *is_child_process = true;
 
@@ -187,9 +218,10 @@ void handle_npt_request(atclient *atclient, sshnpd_params *params, bool *is_chil
       free(session_aes_key_d2c);
       free(session_iv_d2c);
     }
-    if (authenticate_to_rvd) {
+    if (rvd_auth_string != NULL) {
       cJSON_free(rvd_auth_string);
     }
+    free(escr_signing_key_uri);
     cJSON_Delete(envelope);
     return;
 
@@ -229,9 +261,10 @@ void handle_npt_request(atclient *atclient, sshnpd_params *params, bool *is_chil
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to fork the srv process: %s\n", strerror(errno));
   }
 cancel:
-  if (authenticate_to_rvd) {
+  if (rvd_auth_string != NULL) {
     cJSON_free(rvd_auth_string);
   }
+  free(escr_signing_key_uri);
   if (encrypt_rvd_traffic) {
     free(session_iv_c2d);
     free(session_aes_key_c2d);

--- a/packages/c/sshnpd/src/handle_ssh_request.c
+++ b/packages/c/sshnpd/src/handle_ssh_request.c
@@ -9,6 +9,7 @@
 #include <atclient/string_utils.h>
 #include <atlogger/atlogger.h>
 #include <errno.h>
+#include <sshnpd/daemon.h>
 #include <sshnpd/handle_ssh_request.h>
 #include <sshnpd/handler_commons.h>
 #include <sshnpd/run_srv_process.h>
@@ -56,15 +57,43 @@ void handle_ssh_request(atclient *atclient, sshnpd_params *params, bool *is_chil
   cJSON *payload = cJSON_GetObjectItem(envelope, "payload");
 
   bool authenticate_to_rvd = cJSON_IsTrue(cJSON_GetObjectItem(payload, "authenticateToRvd"));
-  char *rvd_auth_string;
+  char *rvd_auth_string = NULL;
+  char *escr_signing_key_uri = NULL;
+  sshnpd_escr_context escr_context;
+  bool use_escr = false;
 
   if (authenticate_to_rvd) {
-    res = create_rvd_auth_string(payload, &signing_key, &rvd_auth_string);
-    if (res != 0) {
-      cJSON_Delete(envelope);
-      return;
+    // RelayAuthMode: absent or "payload" means the legacy signed auth string,
+    // "escr" means encrypted signed challenge response (required for relays
+    // running on a single shared port, e.g. 443)
+    char *relay_auth_mode = cJSON_GetStringValue(cJSON_GetObjectItem(payload, "relayAuthMode"));
+    if (relay_auth_mode != NULL && strcmp(relay_auth_mode, "escr") == 0) {
+      char *relay_auth_aes_key = cJSON_GetStringValue(cJSON_GetObjectItem(payload, "relayAuthAesKey"));
+      char *session_id_str = cJSON_GetStringValue(cJSON_GetObjectItem(payload, "sessionId"));
+      if (relay_auth_aes_key != NULL && session_id_str != NULL) {
+        escr_signing_key_uri = public_signing_key_uri(&atkeys, params->atsign);
+      }
+      if (escr_signing_key_uri != NULL) {
+        escr_context.session_id = session_id_str;
+        escr_context.aes_key_base64 = relay_auth_aes_key;
+        escr_context.signing_key_uri = escr_signing_key_uri;
+        escr_context.signing_key = &atkeys.pkam_private_key;
+        use_escr = true;
+        atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Session will use escr relay auth\n");
+      } else {
+        atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN,
+                     "escr relay auth requested but request is missing relayAuthAesKey or sessionId - falling back to "
+                     "legacy relay auth\n");
+      }
     }
-    // allocated: rvd_auth_string
+    if (!use_escr) {
+      res = create_rvd_auth_string(payload, &signing_key, &rvd_auth_string);
+      if (res != 0) {
+        cJSON_Delete(envelope);
+        return;
+      }
+      // allocated: rvd_auth_string
+    }
   }
 
   bool encrypt_rvd_traffic = cJSON_IsTrue(cJSON_GetObjectItem(payload, "encryptRvdTraffic"));
@@ -84,9 +113,10 @@ void handle_ssh_request(atclient *atclient, sshnpd_params *params, bool *is_chil
     if (res != 0) {
       atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to setup rvd session encryption\n");
       cJSON_Delete(envelope);
-      if (authenticate_to_rvd) {
+      if (rvd_auth_string != NULL) {
         free(rvd_auth_string);
       }
+      free(escr_signing_key_uri);
       return;
     }
   }
@@ -103,9 +133,10 @@ void handle_ssh_request(atclient *atclient, sshnpd_params *params, bool *is_chil
       free(session_aes_key_c2d_base64);
       free(session_iv_c2d_base64);
       cJSON_Delete(envelope);
-      if (authenticate_to_rvd) {
+      if (rvd_auth_string != NULL) {
         free(rvd_auth_string);
       }
+      free(escr_signing_key_uri);
       return;
     }
   }
@@ -145,8 +176,9 @@ void handle_ssh_request(atclient *atclient, sshnpd_params *params, bool *is_chil
 
     // ssh_request payloads don't carry a timeout - only npt session requests do
     int res = run_srv_process(rvd_host_str, rvd_port_int, requested_host_str, requested_port_int, authenticate_to_rvd,
-                              rvd_auth_string, encrypt_rvd_traffic, multi, SRV_DEFAULT_TIMEOUT_SECONDS,
-                              session_aes_key_c2d, session_iv_c2d, session_aes_key_d2c, session_iv_d2c);
+                              rvd_auth_string, use_escr ? &escr_context : NULL, encrypt_rvd_traffic, multi,
+                              SRV_DEFAULT_TIMEOUT_SECONDS, session_aes_key_c2d, session_iv_c2d, session_aes_key_d2c,
+                              session_iv_d2c);
     if (res != 0) {
       atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "srv process exited with code: %d\n", res);
     }
@@ -160,9 +192,10 @@ void handle_ssh_request(atclient *atclient, sshnpd_params *params, bool *is_chil
       free(session_aes_key_d2c);
       free(session_iv_d2c);
     }
-    if (authenticate_to_rvd) {
+    if (rvd_auth_string != NULL) {
       cJSON_free(rvd_auth_string);
     }
+    free(escr_signing_key_uri);
     cJSON_Delete(envelope);
     return;
     // end of child process
@@ -202,9 +235,10 @@ void handle_ssh_request(atclient *atclient, sshnpd_params *params, bool *is_chil
   }
 cancel:
   if (!*is_child_process) {
-    if (authenticate_to_rvd) {
+    if (rvd_auth_string != NULL) {
       cJSON_free(rvd_auth_string);
     }
+    free(escr_signing_key_uri);
     if (encrypt_rvd_traffic) {
       free(session_iv_c2d);
       free(session_aes_key_c2d);

--- a/packages/c/sshnpd/src/handler_commons.c
+++ b/packages/c/sshnpd/src/handler_commons.c
@@ -11,10 +11,26 @@
 #include <atclient/json.h>
 #include <atlogger/atlogger.h>
 #include <sshnpd/handler_commons.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #define LOGGER_TAG "HANDLER_COMMONS"
+
+char *public_signing_key_uri(const atclient_atkeys *atkeys, const char *atsign) {
+  // 'primary' is the Dart at_client fallback when the atkeys file carries no
+  // APKAM enrollment id
+  const char *enrollment_id = "primary";
+  if (atkeys->enrollment_id != NULL && atkeys->enrollment_id[0] != '\0') {
+    enrollment_id = atkeys->enrollment_id;
+  }
+  size_t size = strlen("public:_apsk.") + strlen(enrollment_id) + strlen(".a.__e") + strlen(atsign) + 1;
+  char *uri = malloc(size);
+  if (uri != NULL) {
+    snprintf(uri, size, "public:_apsk.%s.a.__e%s", enrollment_id, atsign);
+  }
+  return uri;
+}
 
 bool is_manager_atsign(const sshnpd_params *params, const char *atsign) {
   if (params == NULL || atsign == NULL || atsign[0] == '\0') {

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -25,6 +25,7 @@
 #include <signal.h>
 #include <sshnpd/daemon.h>
 #include <sshnpd/file_utils.h>
+#include <sshnpd/handler_commons.h>
 #include <sshnpd/run_srv_process.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -331,8 +332,29 @@ int main(int argc, char **argv) {
   cJSON_AddItemToObject(supported_features, "acceptsPublicKeys", cJSON_CreateBool(acceptsPublicKeys));
   cJSON_AddItemToObject(supported_features, "supportsPortChoice", cJSON_CreateBool(true));
   cJSON_AddItemToObject(supported_features, "adjustableTimeout", cJSON_CreateBool(true));
+  cJSON_AddItemToObject(supported_features, "supportsRamEscr", cJSON_CreateBool(true));
   cJSON_AddItemToObject(supported_features, "twinKeys", cJSON_CreateBool(true));
   cJSON_AddItemToObject(ping_response_json, "supportedFeatures", supported_features);
+
+  cJSON *auth_modes = cJSON_CreateArray();
+  cJSON_AddItemToArray(auth_modes, cJSON_CreateString("payload"));
+  cJSON_AddItemToArray(auth_modes, cJSON_CreateString("escr"));
+  cJSON_AddItemToObject(ping_response_json, "authModes", auth_modes);
+
+  // Clients pre-fetch this uri via the relay so the relay can verify our escr
+  // auth signatures
+  char *signing_key_uri = public_signing_key_uri(&atkeys, params.atsign);
+  if (signing_key_uri == NULL) {
+    atcommons_memlist_failure_free(&memlist);
+    return 1;
+  }
+  res = atcommons_memlist_add(&memlist, signing_key_uri, true, free_if_not_null);
+  if (res != 0) {
+    free(signing_key_uri);
+    atcommons_memlist_failure_free(&memlist);
+    return res;
+  }
+  cJSON_AddItemToObject(ping_response_json, "publicSigningKeyUri", cJSON_CreateString(signing_key_uri));
 
   cJSON *allowed_services = cJSON_CreateArray();
   char *buf = malloc(sizeof(char) * 1024);
@@ -362,6 +384,42 @@ int main(int argc, char **argv) {
   if (!should_run) {
     atcommons_memlist_failure_free(&memlist);
     return res;
+  }
+
+  // 8.b Publish the public signing key (the PKAM public key) at the uri
+  // advertised in the ping response, so relays can verify escr auth
+  // signatures. Failure is not fatal: legacy relay auth still works.
+  {
+    const char *enrollment_id = "primary";
+    if (atkeys.enrollment_id != NULL && atkeys.enrollment_id[0] != '\0') {
+      enrollment_id = atkeys.enrollment_id;
+    }
+    char sk_keyname[128];
+    snprintf(sk_keyname, sizeof(sk_keyname), "_apsk.%s", enrollment_id);
+
+    atclient_atkey sk_key;
+    atclient_atkey_init(&sk_key);
+    res = atclient_atkey_create_public_key(&sk_key, sk_keyname, params.atsign, "a.__e");
+    if (res == 0) {
+      char *existing = NULL;
+      if (atclient_get_public_key(&worker, &sk_key, &existing, NULL) == 0 && existing != NULL) {
+        atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Public signing key already published at %s\n",
+                     signing_key_uri);
+        free(existing);
+      } else {
+        res = atclient_put_public_key(&worker, &sk_key, atkeys.pkam_public_key_base64, NULL, NULL);
+        if (res == 0) {
+          atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Published public signing key at %s\n",
+                       signing_key_uri);
+        }
+      }
+    }
+    if (res != 0) {
+      atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN,
+                   "Failed to publish the public signing key (%d) - escr relay auth will not work this session\n", res);
+      res = 0;
+    }
+    atclient_atkey_free(&sk_key);
   }
 
   // 9. Start the device refresh loop - if hide is off

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -402,7 +402,15 @@ int main(int argc, char **argv) {
     res = atclient_atkey_create_public_key(&sk_key, sk_keyname, params.atsign, "a.__e");
     if (res == 0) {
       char *existing = NULL;
-      if (atclient_get_public_key(&worker, &sk_key, &existing, NULL) == 0 && existing != NULL) {
+      // The key legitimately doesn't exist on the very first run (e.g. a
+      // freshly enrolled atsign), so mute the SDK's error logging around the
+      // existence probe - same pattern atauth's wait_for_enrollment uses for
+      // expected failures
+      enum atlogger_logging_level log_level = atlogger_get_logging_level();
+      atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_NONE);
+      int get_res = atclient_get_public_key(&worker, &sk_key, &existing, NULL);
+      atlogger_set_logging_level(log_level);
+      if (get_res == 0 && existing != NULL) {
         atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Public signing key already published at %s\n",
                      signing_key_uri);
         free(existing);

--- a/packages/c/sshnpd/src/run_srv_process.c
+++ b/packages/c/sshnpd/src/run_srv_process.c
@@ -1,10 +1,10 @@
 #include "srv/params.h"
 #include "srv/srv.h"
 #include <atclient/json.h>
-#include <sshnpd/run_srv_process.h>
 #include <atclient/string_utils.h>
 #include <atlogger/atlogger.h>
 #include <errno.h>
+#include <sshnpd/run_srv_process.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>

--- a/packages/c/sshnpd/src/run_srv_process.c
+++ b/packages/c/sshnpd/src/run_srv_process.c
@@ -1,6 +1,7 @@
 #include "srv/params.h"
 #include "srv/srv.h"
 #include <atclient/json.h>
+#include <sshnpd/run_srv_process.h>
 #include <atclient/string_utils.h>
 #include <atlogger/atlogger.h>
 #include <errno.h>
@@ -11,9 +12,9 @@
 #define LOGGER_TAG "RUN SRV"
 
 int run_srv_process(const char *srvd_host, uint16_t srvd_port, const char *requested_host, uint16_t requested_port,
-                    bool authenticate_to_rvd, char *rvd_auth_string, bool encrypt_rvd_traffic, bool multi,
-                    int timeout_seconds, unsigned char *session_aes_key_c2d, unsigned char *session_iv_c2d,
-                    unsigned char *session_aes_key_d2c, unsigned char *session_iv_d2c) {
+                    bool authenticate_to_rvd, char *rvd_auth_string, const sshnpd_escr_context *escr,
+                    bool encrypt_rvd_traffic, bool multi, int timeout_seconds, unsigned char *session_aes_key_c2d,
+                    unsigned char *session_iv_c2d, unsigned char *session_aes_key_d2c, unsigned char *session_iv_d2c) {
 
   int res = 0;
   srv_params_t srv_params;
@@ -29,8 +30,19 @@ int run_srv_process(const char *srvd_host, uint16_t srvd_port, const char *reque
     srv_params.local_port = requested_port;
   }
 
-  srv_params.rv_auth = authenticate_to_rvd;
-  srv_params.rvd_auth_string = rvd_auth_string;
+  if (escr != NULL) {
+    // ESCR replaces the legacy auth string entirely; the daemon side is
+    // always side b of the session
+    srv_params.escr_auth = true;
+    srv_params.escr_is_side_a = false;
+    srv_params.escr_session_id = (char *)escr->session_id;
+    srv_params.escr_aes_key_base64 = (char *)escr->aes_key_base64;
+    srv_params.escr_signing_key_uri = (char *)escr->signing_key_uri;
+    srv_params.escr_signing_key = escr->signing_key;
+  } else {
+    srv_params.rv_auth = authenticate_to_rvd;
+    srv_params.rvd_auth_string = rvd_auth_string;
+  }
 
   srv_params.rv_e2ee = encrypt_rvd_traffic;
   srv_params.session_aes_key_c2d_string = (char *)session_aes_key_c2d;

--- a/packages/c/sshnpd/tests/CMakeLists.txt
+++ b/packages/c/sshnpd/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ foreach(file ${files})
   add_executable(${filename} ${file})
   target_link_libraries(
     ${filename}
-    PRIVATE sshnpd-lib argparse::argparse-static atlogger atclient
+    PRIVATE sshnpd-lib srv-lib argparse::argparse-static atlogger atclient
   )
   add_test(NAME ${filename} COMMAND $<TARGET_FILE:${filename}>)
 endforeach()

--- a/packages/c/sshnpd/tests/test_escr.c
+++ b/packages/c/sshnpd/tests/test_escr.c
@@ -1,0 +1,221 @@
+// Round-trip test for the srv ESCR response builder: build a response line,
+// then take it apart the way the relay's RelayAuthVerifierESCR does - split,
+// base64 decode, AES-256-CTR decrypt, PKCS#7 unpad, parse the envelope and
+// verify the RSA signature over the inner payload.
+//
+// Byte-level compatibility with the Dart verifier is additionally covered by
+// a manual interop check (see the PR description); this test keeps the C
+// construction honest without needing a Dart runtime.
+#include <atchops/base64.h>
+#include <atchops/rsa.h>
+#include <atchops/rsa_key.h>
+#include <atclient/json.h>
+#include <mbedtls/aes.h>
+#include <srv/escr.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Throwaway RSA-2048 keypair generated for this test only
+static const char *TEST_PRIVATE_KEY_B64 =
+    "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCWkE9G3HhNcsSi1z1R0N3z0ep1shnlQooP96l09sa5TnJk"
+    "yBj21M5RCgMmqVVWWeYTI6fUh80d4ImCZrygaR52vSV9nfMPomBxsWRLImgbB6Hvudlf8TWkpMIfF4SBqC97aqG9eXsfrEiU"
+    "jPCj6xPJG3D4cBjsZGbmnn67wiXe3EV+eHDXO6leQ+lEaWN6vFm4ddCJ6d1f6S9Wiyy3nCL95xxzkYSiSUYTTvv2Kn+qcFX9"
+    "PA0P5MF68/zTKXw4WJy9xDlK75hBrkvddnYXwu3qKJzisUelsWUiDy8xzvksor23QxnU1NL0KcFpkuFN3bMY/zd8+gPfL65K"
+    "nbGbbi4RAgMBAAECggEABiN8F/eFMCMtwTXlWiCZ7Aby+Dl6tM4xstT2I76r+4InR9Sgr++dOdCesETXJd4kc0NQ5GllA4LU"
+    "GGz349JlW5H6pVR7RHfqVrhUzntoozF8eLmrEy5ScZQGFh5vWJny1aVTUtZRHsl3bBcS+JvtApYL1RU87uZpC54KrL0Nrjhc"
+    "2ImQ4ZmsUMHcx+9hS/QXGkuyCRbKkkIKYIRKf5Lem7ECY/eSh3uXOMkKuoOcysDAhTqsxploaIS6l+j+JUI6NJRFVXuKwUnq"
+    "kyYvT3/cka++QBTXgGlpTZzQyrMNuy42N7UXMJU6KMGwcDepkqqou8KzyliR/Bpw8/YTmPS8AQKBgQDKvTrbfe+cpMzkkR7m"
+    "DVOU1tnD/GA+La2UnK6q+Vau51+PHvZ0WLt7LHnovvTbcHPa5dvhGRLwe3dBSy76k4QtfBGGb8HXmmGFd7uWtA0QF+DO0u9/"
+    "Vr///hoMqgF3+A0gASwei55g7K62pM7VHxVNkgQWTuzwxTJzumN2Y3RoCQKBgQC+HiKfAnEKMTVWikUBtPDoSx0qwM/JQFqV"
+    "4dhittva7rW5Tw1pSbvnm7F7HU8AW/I0ANeMarrq35HlPg3auLjko/OqQc0nqesQQmZTWQ8nQQFLx2mtvsJ57bf4a9dtckpe"
+    "SzvgrrrIERN0W8ALMXF1xkTA40k16UcXdX59Oj5HyQKBgCmbkFq/i89wGwTFq7u2/HJNbb/FKdNY+IjJZyd7qIiYv4nV5uqV"
+    "01RCGnrjxcjLWVuRVQDrbnGgRSdHUMroP3Y+QjJ++R9Qdbc4jW0uYofs/pwzuic+HIVjFuGGemquo7LvyqgyKzzlFi4xwKkI"
+    "igyzbNdPN11qeyI5HHSNkLRRAoGAew9cj5pv+w3xHYwwsLMjgOkl/weBOB6MxBnFC9ibJPKA9GsEHlPY6kkwL6W//laFxz2I"
+    "SF7JkMCYWk+5fgs1uuGZFmqzVeo5unOQcoDiOyFrqlZwxEMG9Q93lriPYEurca+3GW9gfaH3+shs3ZHqhDaLSGOWfuv51Wh7"
+    "MKnjqGkCgYEAlJzJeoBIoyC4jZ1Vmm3kaJKQ/Q3L/KsnNnHH8ajEXHI6wdy5oD2CsF7VnodduHwVpNkVZMp15IXClr/KbYWL"
+    "y+cpsyRBeiGoglreO2lxAuqP51FjQriaT5E/ox7nvy2jATAjX8i6BDLk69F0+6QL1cuHTHhz4Y6bkDCJrocSNfY=";
+
+static const char *TEST_PUBLIC_KEY_B64 =
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlpBPRtx4TXLEotc9UdDd89HqdbIZ5UKKD/epdPbGuU5yZMgY9tTO"
+    "UQoDJqlVVlnmEyOn1IfNHeCJgma8oGkedr0lfZ3zD6JgcbFkSyJoGweh77nZX/E1pKTCHxeEgagve2qhvXl7H6xIlIzwo+sT"
+    "yRtw+HAY7GRm5p5+u8Il3txFfnhw1zupXkPpRGljerxZuHXQiendX+kvVosst5wi/eccc5GEoklGE0779ip/qnBV/TwND+TB"
+    "evP80yl8OFicvcQ5Su+YQa5L3XZ2F8Lt6iic4rFHpbFlIg8vMc75LKK9t0MZ1NTS9CnBaZLhTd2zGP83fPoD3y+uSp2xm24u"
+    "EQIDAQAB";
+
+// base64 of bytes 0x00..0x1f - a fixed 32 byte AES key
+static const char *TEST_AES_KEY_B64 = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=";
+
+static const char *TEST_SESSION_ID = "9b6350cd-3ac6-4d47-9d43-a1d5bbcbe553";
+static const char *TEST_CHALLENGE = "dGhpcyBpcyBhIHRlc3QgY2hhbGxlbmdlLCA0NCBjaGFycw==";
+static const char *TEST_SK_URI = "public:_apsk.primary.a.__e@test_daemon";
+
+static int failures = 0;
+
+static void check(bool ok, const char *what) {
+  if (!ok) {
+    printf("FAIL: %s\n", what);
+    failures++;
+  } else {
+    printf("ok: %s\n", what);
+  }
+}
+
+static unsigned char *b64_decode_alloc(const char *src, size_t *out_len) {
+  size_t dstsize = strlen(src) + 1;
+  unsigned char *dst = malloc(dstsize);
+  if (dst == NULL) {
+    return NULL;
+  }
+  if (atchops_base64_decode(src, strlen(src), dst, dstsize, out_len) != 0) {
+    free(dst);
+    return NULL;
+  }
+  return dst;
+}
+
+int main() {
+  atchops_rsa_key_private_key private_key;
+  atchops_rsa_key_private_key_init(&private_key);
+  check(atchops_rsa_key_populate_private_key(&private_key, TEST_PRIVATE_KEY_B64, strlen(TEST_PRIVATE_KEY_B64)) == 0,
+        "populate private key");
+
+  atchops_rsa_key_public_key public_key;
+  atchops_rsa_key_public_key_init(&public_key);
+  check(atchops_rsa_key_populate_public_key(&public_key, TEST_PUBLIC_KEY_B64, strlen(TEST_PUBLIC_KEY_B64)) == 0,
+        "populate public key");
+
+  unsigned char iv[16];
+  for (int i = 0; i < 16; i++) {
+    iv[i] = (unsigned char)i;
+  }
+
+  char *line = NULL;
+  check(srv_escr_build_response(TEST_SESSION_ID, TEST_CHALLENGE, TEST_AES_KEY_B64, TEST_SK_URI, &private_key, false, iv,
+                                &line) == 0 &&
+            line != NULL,
+        "build response");
+  if (line == NULL) {
+    return 1;
+  }
+
+  // Determinism: same inputs and iv produce the same line
+  char *line2 = NULL;
+  check(srv_escr_build_response(TEST_SESSION_ID, TEST_CHALLENGE, TEST_AES_KEY_B64, TEST_SK_URI, &private_key, false, iv,
+                                &line2) == 0 &&
+            line2 != NULL && strcmp(line, line2) == 0,
+        "deterministic for fixed iv");
+  free(line2);
+
+  // A challenge needing JSON escaping must be refused, not mis-encoded
+  char *bad_line = NULL;
+  check(srv_escr_build_response(TEST_SESSION_ID, "chal\"lenge", TEST_AES_KEY_B64, TEST_SK_URI, &private_key, false, iv,
+                                &bad_line) != 0 &&
+            bad_line == NULL,
+        "reject challenge containing a quote");
+
+  // ---- Take the line apart the way the relay does ----
+  char *colon = strchr(line, ':');
+  check(colon != NULL && strchr(colon + 1, ':') == NULL, "line has exactly one colon");
+  check(colon != NULL && strncmp(line, TEST_SESSION_ID, colon - line) == 0, "session id prefix");
+
+  size_t outer_len = 0;
+  unsigned char *outer_bytes = b64_decode_alloc(colon + 1, &outer_len);
+  check(outer_bytes != NULL, "decode outer payload");
+  outer_bytes[outer_len] = '\0';
+
+  cJSON *outer = cJSON_Parse((char *)outer_bytes);
+  check(outer != NULL, "parse outer json");
+  char *iv_b64 = cJSON_GetStringValue(cJSON_GetObjectItem(outer, "iv"));
+  char *e_b64 = cJSON_GetStringValue(cJSON_GetObjectItem(outer, "e"));
+  check(iv_b64 != NULL && e_b64 != NULL, "outer json has iv and e");
+
+  size_t iv_len = 0;
+  unsigned char *iv_bytes = b64_decode_alloc(iv_b64, &iv_len);
+  check(iv_bytes != NULL && iv_len == 16 && memcmp(iv_bytes, iv, 16) == 0, "iv round trips");
+
+  size_t cipher_len = 0;
+  unsigned char *cipher = b64_decode_alloc(e_b64, &cipher_len);
+  check(cipher != NULL && cipher_len > 0 && cipher_len % 16 == 0, "ciphertext is block aligned");
+
+  // Decrypt (CTR decrypt == CTR encrypt)
+  unsigned char *plain = malloc(cipher_len + 1);
+  {
+    size_t aes_key_len = 0;
+    unsigned char aes_key[32];
+    atchops_base64_decode(TEST_AES_KEY_B64, strlen(TEST_AES_KEY_B64), aes_key, sizeof(aes_key), &aes_key_len);
+    mbedtls_aes_context aes_ctx;
+    mbedtls_aes_init(&aes_ctx);
+    mbedtls_aes_setkey_enc(&aes_ctx, aes_key, 256);
+    size_t nc_off = 0;
+    unsigned char stream_block[16] = {0};
+    unsigned char nonce_counter[16];
+    memcpy(nonce_counter, iv, 16);
+    check(mbedtls_aes_crypt_ctr(&aes_ctx, cipher_len, &nc_off, nonce_counter, stream_block, cipher, plain) == 0,
+          "decrypt");
+    mbedtls_aes_free(&aes_ctx);
+  }
+
+  // PKCS#7 unpad
+  unsigned char pad = plain[cipher_len - 1];
+  check(pad >= 1 && pad <= 16, "padding byte in range");
+  bool pad_ok = true;
+  for (size_t i = cipher_len - pad; i < cipher_len; i++) {
+    if (plain[i] != pad) {
+      pad_ok = false;
+    }
+  }
+  check(pad_ok, "PKCS#7 padding is consistent");
+  size_t env64_len = cipher_len - pad;
+  plain[env64_len] = '\0';
+
+  size_t env_len = 0;
+  unsigned char *env_bytes = b64_decode_alloc((char *)plain, &env_len);
+  check(env_bytes != NULL, "decode envelope");
+  env_bytes[env_len] = '\0';
+
+  cJSON *envelope = cJSON_Parse((char *)env_bytes);
+  check(envelope != NULL, "parse envelope json");
+  cJSON *p = cJSON_GetObjectItem(envelope, "p");
+  check(cJSON_IsObject(p), "envelope has payload object");
+  check(strcmp(cJSON_GetStringValue(cJSON_GetObjectItem(envelope, "ha")), "sha256") == 0, "ha is sha256");
+  check(strcmp(cJSON_GetStringValue(cJSON_GetObjectItem(envelope, "sa")), "rsa2048") == 0, "sa is rsa2048");
+  check(strcmp(cJSON_GetStringValue(cJSON_GetObjectItem(envelope, "sk")), TEST_SK_URI) == 0, "sk uri matches");
+  check(strcmp(cJSON_GetStringValue(cJSON_GetObjectItem(p, "sid")), TEST_SESSION_ID) == 0, "sid matches");
+  check(strcmp(cJSON_GetStringValue(cJSON_GetObjectItem(p, "c")), TEST_CHALLENGE) == 0, "challenge matches");
+  check(strcmp(cJSON_GetStringValue(cJSON_GetObjectItem(p, "side")), "b") == 0, "side is b");
+
+  // The relay verifies the signature over the compact re-serialization of p;
+  // it must also be byte-identical to what the builder signed
+  char *p_compact = cJSON_PrintUnformatted(p);
+  char expected_p[512];
+  snprintf(expected_p, sizeof(expected_p), "{\"sid\":\"%s\",\"c\":\"%s\",\"side\":\"b\"}", TEST_SESSION_ID,
+           TEST_CHALLENGE);
+  check(p_compact != NULL && strcmp(p_compact, expected_p) == 0, "payload serialization is compact and ordered");
+
+  size_t sig_len = 0;
+  unsigned char *sig = b64_decode_alloc(cJSON_GetStringValue(cJSON_GetObjectItem(envelope, "s")), &sig_len);
+  check(sig != NULL && sig_len == 256, "signature is 256 bytes");
+  check(atchops_rsa_verify(&public_key, ATCHOPS_MD_SHA256, (unsigned char *)p_compact, strlen(p_compact), sig) == 0,
+        "signature verifies over compact payload");
+
+  free(sig);
+  cJSON_free(p_compact);
+  cJSON_Delete(envelope);
+  free(env_bytes);
+  free(plain);
+  free(cipher);
+  free(iv_bytes);
+  cJSON_Delete(outer);
+  free(outer_bytes);
+  free(line);
+  atchops_rsa_key_private_key_free(&private_key);
+  atchops_rsa_key_public_key_free(&public_key);
+
+  if (failures > 0) {
+    printf("%d failures\n", failures);
+    return 1;
+  }
+  printf("all passed\n");
+  return 0;
+}

--- a/packages/c/sshnpd/tests/test_escr.c
+++ b/packages/c/sshnpd/tests/test_escr.c
@@ -12,6 +12,7 @@
 #include <atclient/json.h>
 #include <mbedtls/aes.h>
 #include <srv/escr.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
> [!NOTE]
> **Ready for review.** Stacked on #2864 (`cconstab/c-adjustable-timeout`) — merge that first; this PR’s diff is clean against it. Full CI runs once the base merges and this retargets to trunk. End-to-end verification of the whole feature set is being run on the `cconstab/c-2831-integration` branch.

## What this does

Part 2 of 3 for #2831: implements **ESCR (Encrypted Signed Challenge Response) relay authentication** in csshnpd and the C srv, and advertises `supportsRamEscr`.

This is what daemon-side "`--443` support" actually means: when NoPorts Desktop enables port 443, the client forces `relayAuthMode: escr` (`sshnp_params.dart` requires it), and the pre-flight feature check then requires `supportsRamEscr` from the daemon. On a shared single relay port there is no per-session port pair, so the ESCR auth line (`sessionId` + `side`) is the only way the relay can bind an incoming socket to a session. There is no other daemon-side 443 logic — the daemon just connects to whatever `rvdHost:rvdPort` the request names.

## The protocol (matches Dart byte-for-byte)

Per socket to the relay (control channel **and** every session socket):
1. Relay sends a challenge line on accept.
2. Daemon signs the compact JSON `{"sid":"<sessionId>","c":"<challenge>","side":"b"}` with its **PKAM private key** (RSASSA-PKCS1-v1_5 / SHA-256).
3. Envelope `{"p":…,"s":…,"ha":"sha256","sa":"rsa2048","sk":"public:_apsk.<enrollmentId>.a.__e<atsign>"}` is base64d, PKCS#7-padded (required by the verifier even though CTR needs no padding), AES-256-CTR-encrypted with the session's `relayAuthAesKey`, and sent as `<sessionId>:<base64({"iv","e"})>\n`.
4. Daemon waits for `ok`.

The JSON is built with `snprintf` after validating inputs are escape-free ASCII (they're base64/uuid/key-uri by construction), which keeps the signed bytes identical to Dart's `jsonEncode` without adding a JSON dependency to srv.

## Changes

- **`packages/c/srv/src/escr.c` (new)** — `srv_escr_build_response` (deterministic given the IV, unit-testable) + `srv_escr_authenticate` (socket exchange, byte-wise line reads so no post-`ok` session bytes are swallowed).
- **`srv.c`** — control channel and per-session sockets branch to ESCR when enabled; legacy `rvd_auth_string` path unchanged.
- **`params.c/.h`** — standalone srv accepts `-a/--relay-auth-mode escr` with the same `REMOTE_AUTH_ESCR_*` env contract as the Dart srv binary.
- **`handle_npt_request.c` / `handle_ssh_request.c`** — honor `relayAuthMode: "escr"` (fall back to legacy with a warning if `relayAuthAesKey`/`sessionId` are missing), pass an ESCR context through `run_srv_process`.
- **`main.c`** — ping response now includes `supportsRamEscr: true`, `authModes: ["payload","escr"]`, and top-level `publicSigningKeyUri`; at startup the PKAM public key is published at `public:_apsk.<enrollmentId>.a.__e@<atsign>` (get-then-put, idempotent; enrollment id falls back to `primary` like the Dart at_client).

## Testing so far

- New `test_escr` unit test: round-trips the response the way the relay verifier does — decodes all three base64 layers, AES-CTR decrypts, validates PKCS#7 padding, checks every envelope field, and verifies the RSA signature over the compact payload re-serialization. Also covers determinism and rejection of unescapable challenges. `leaks --atExit`: 0 leaks.
- **Interop against the real Dart verifier**: a throwaway harness fed C-generated response lines (fresh random challenge + IV each time) into `RelayAuthVerifierESCR.verifyChallengeResponse` — **10/10 verified**, with `side=b`, `sessionId` and `atSign` extracted correctly.
- All 6 csshnpd unit tests pass; full build clean.

## Remaining end-to-end verification (tracked on the `cconstab/c-2831-integration` branch)

- [ ] End-to-end: NoPorts Desktop with "use port 443" against this daemon via a real relay bound to 443 (shared-single-port mode)
- [ ] End-to-end: escr in port-pair mode (non-443) and legacy-mode regression
- [ ] Verify the startup key publish against a real atServer (and with an APKAM-enrolled atsign, not just `primary`)
- [ ] OpenWRT target build/test
- [ ] Consider per-session-socket auth retry (Dart retries up to 4×, 1s apart; C currently fails the session on first auth failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
