### PR TITLE
feat: policy service (--policy-manager) support in csshnpd

### DIFF
--- a/packages/c/sshnpd/CMakeLists.txt
+++ b/packages/c/sshnpd/CMakeLists.txt
@@ -22,6 +22,7 @@ set(
   ${CMAKE_CURRENT_LIST_DIR}/src/main.c
   ${CMAKE_CURRENT_LIST_DIR}/src/params.c
   ${CMAKE_CURRENT_LIST_DIR}/src/permitopen.c
+  ${CMAKE_CURRENT_LIST_DIR}/src/policy.c
   ${CMAKE_CURRENT_LIST_DIR}/src/run_srv_process.c
 )
 

--- a/packages/c/sshnpd/include/sshnpd/handle_npt_request.h
+++ b/packages/c/sshnpd/include/sshnpd/handle_npt_request.h
@@ -1,8 +1,13 @@
 #ifndef HANDLE_NPT_REQUEST_H
 #define HANDLE_NPT_REQUEST_H
 #include "sshnpd/params.h"
+#include "sshnpd/policy.h"
 #include <atclient/monitor.h>
 
+// policy is the policy service's decision for this request, or NULL when the
+// requester was approved without a policy check (manager atsign, or no
+// policy service configured)
 void handle_npt_request(atclient *atclient, sshnpd_params *params, bool *is_child_process,
-                        atclient_monitor_message *message, atchops_rsa_key_private_key signing_key);
+                        atclient_monitor_message *message, atchops_rsa_key_private_key signing_key,
+                        const sshnpd_policy_decision *policy);
 #endif

--- a/packages/c/sshnpd/include/sshnpd/handle_ssh_request.h
+++ b/packages/c/sshnpd/include/sshnpd/handle_ssh_request.h
@@ -1,9 +1,14 @@
 #ifndef HANDLE_SSH_REQUEST_H
 #define HANDLE_SSH_REQUEST_H
 #include "sshnpd/params.h"
+#include "sshnpd/policy.h"
 #include <atclient/monitor.h>
 
+// policy is the policy service's decision for this request, or NULL when the
+// requester was approved without a policy check (manager atsign, or no
+// policy service configured)
 void handle_ssh_request(atclient *atclient, sshnpd_params *params, bool *is_child_process,
-                        atclient_monitor_message *message, atchops_rsa_key_private_key signing_key);
+                        atclient_monitor_message *message, atchops_rsa_key_private_key signing_key,
+                        const sshnpd_policy_decision *policy);
 
 #endif

--- a/packages/c/sshnpd/include/sshnpd/handler_commons.h
+++ b/packages/c/sshnpd/include/sshnpd/handler_commons.h
@@ -21,6 +21,19 @@ int verify_payload_contents(cJSON *payload, enum payload_type type);
 
 int create_rvd_auth_string(cJSON *payload, atchops_rsa_key_private_key *signing_key, char **rvd_auth_string);
 
+// Notify the requesting client that its session request was denied and why.
+// The value is a plain string, deliberately not json: the client treats a
+// payload starting with '{' as a signed envelope carrying session keys.
+int send_session_error(atclient *atclient, sshnpd_params *params, char *requesting_atsign, const char *session_id,
+                       const char *message);
+
+// Format the daemon's permit-open list the way Dart prints a List:
+// '[localhost:22, localhost:3389]' (a port of 0 prints as '*')
+void format_permitopen_list(char **hosts, const uint16_t *ports, size_t len, char *buf, size_t bufsize);
+
+// Format a list of strings the way Dart prints a List: '[a, b]'
+void format_string_list(char **items, size_t len, char *buf, size_t bufsize);
+
 // Returns the malloc'd atProtocol uri of the daemon's public signing key,
 // 'public:_apsk.<enrollmentId>.a.__e<atsign>', used for escr relay auth. The
 // enrollment id falls back to 'primary' when the atkeys carry none.

--- a/packages/c/sshnpd/include/sshnpd/policy.h
+++ b/packages/c/sshnpd/include/sshnpd/policy.h
@@ -1,0 +1,76 @@
+#ifndef SSHNPD_POLICY_H
+#define SSHNPD_POLICY_H
+
+#include <atclient/atclient.h>
+#include <atclient/monitor.h>
+#include <sshnpd/params.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+// The outcome of one auth check against the policy service
+typedef struct {
+  bool authorized;
+  char **permit_open; // owned; free with policy_decision_free
+  size_t permit_open_len;
+} sshnpd_policy_decision;
+
+/**
+ * @brief Ask the policy service (params->policy) whether client_atsign may
+ * connect, and wait for its decision.
+ *
+ * Sends an NPAAuthCheckRequest rpc notification and reads the monitor until
+ * the matching response arrives or 10 seconds pass without progress (an ack
+ * from the policy service resets the clock). Fails closed: on timeout, nack,
+ * error, send failure or malformed response the decision is unauthorized.
+ *
+ * Notifications which arrive while waiting and are not the rpc response are
+ * logged and dropped, matching the single in-flight check of the other
+ * NoPorts daemons.
+ *
+ * @param worker the authenticated worker atclient (used to notify)
+ * @param monitor the monitor atclient (used to read the response)
+ * @param params daemon params; params->policy must be non-NULL
+ * @param client_atsign the atsign asking to connect
+ * @param decision receives the decision; call policy_decision_free after use
+ * @return int 0 if a definite decision was reached (including deny),
+ * non-zero on internal error (decision is deny in every case)
+ */
+int policy_auth_check(atclient *worker, atclient *monitor, const sshnpd_params *params, const char *client_atsign,
+                      sshnpd_policy_decision *decision);
+
+/**
+ * @brief Parse the json value of an rpc response notification into a
+ * decision. Exposed for unit testing.
+ *
+ * @param json the decrypted notification value
+ * @param expected_req_id the reqId this daemon sent
+ * @param decision filled on a "success" response
+ * @param resp_type_out receives the respType string ("ack", "success", ...)
+ * @param resp_type_size size of resp_type_out
+ * @return int 0 when the value parsed and reqId matched, non-zero otherwise
+ */
+int policy_parse_response_value(const char *json, int64_t expected_req_id, sshnpd_policy_decision *decision,
+                                char *resp_type_out, size_t resp_type_size);
+
+/**
+ * @brief Whether the policy decision's permitOpen list permits host:port.
+ *
+ * Entries are 'host:port' with '*' as a wildcard for either part (a port of
+ * 0 also matches anything). An empty list permits nothing.
+ */
+bool policy_permits_open(const sshnpd_policy_decision *decision, const char *host, uint16_t port);
+
+/**
+ * @brief Free a decision's permit_open list and zero the struct. Safe to
+ * call on a zeroed struct and safe to call twice.
+ */
+void policy_decision_free(sshnpd_policy_decision *decision);
+
+/**
+ * @brief Send the ping response payload to the policy service as a device
+ * heartbeat ('<device>.devices.policy'), at most once every 5 minutes.
+ * No-op when no policy service is configured.
+ */
+void policy_send_heartbeat(atclient *worker, const sshnpd_params *params, const char *ping_response);
+
+#endif

--- a/packages/c/sshnpd/include/sshnpd/policy.h
+++ b/packages/c/sshnpd/include/sshnpd/policy.h
@@ -53,6 +53,16 @@ int policy_parse_response_value(const char *json, int64_t expected_req_id, sshnp
                                 char *resp_type_out, size_t resp_type_size);
 
 /**
+ * @brief Whether this notification is policy service traffic rather than a
+ * session request: an auth-check rpc response (one that arrived outside a
+ * policy_auth_check wait window, e.g. after a timeout) or a
+ * '<device>.devices.policy' config push the policy service sends in reply to
+ * heartbeats. Such messages must be ignored by the main loop - in particular
+ * they must never be treated as a request needing an auth check of their own.
+ */
+bool policy_is_policy_service_message(const atclient_atnotification *notification, const sshnpd_params *params);
+
+/**
  * @brief Whether the policy decision's permitOpen list permits host:port.
  *
  * Entries are 'host:port' with '*' as a wildcard for either part (a port of

--- a/packages/c/sshnpd/src/daemon.c
+++ b/packages/c/sshnpd/src/daemon.c
@@ -27,6 +27,7 @@
 #include <mbedtls/psa_util.h>
 #include <sshnpd/daemon.h>
 #include <sshnpd/file_utils.h>
+#include <sshnpd/policy.h>
 #include <sshnpd/run_srv_process.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -78,11 +79,19 @@ void main_loop() {
   permitopen.permitopen_hosts = params.permitopen_hosts;
   permitopen.permitopen_ports = params.permitopen_ports;
 
+  // The policy service's decision for the request currently being handled;
+  // policy_checked is true only when the decision came from the policy
+  // service (manager atsigns bypass it)
+  sshnpd_policy_decision policy_decision;
+  memset(&policy_decision, 0, sizeof(policy_decision));
+  bool policy_checked = false;
+
   size_t timeout_counter = 0;
 
   while (should_run == 1) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Sending next device info\n");
     send_next_device_info(&worker, &params);
+    policy_send_heartbeat(&worker, &params, ping_response);
 
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Waiting for next monitor thread message\n");
     atclient_monitor_message_init(&message);
@@ -147,11 +156,25 @@ void main_loop() {
           break;
         }
 
+        // Managers are approved without a policy check; everyone else is
+        // referred to the policy service when one is configured
+        policy_checked = false;
         if (!is_manager_atsign(&params, message.notification->from)) {
-          atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN,
-                       "Rejecting request from unauthorized atSign: %s\n",
-                       message.notification->from == NULL ? "(none)" : message.notification->from);
-          break;
+          if (params.policy != NULL && message.notification->from != NULL) {
+            policy_auth_check(&worker, &monitor_ctx, &params, message.notification->from, &policy_decision);
+            if (!policy_decision.authorized) {
+              atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN,
+                           "Rejecting request from atSign not authorized by the policy service: %s\n",
+                           message.notification->from);
+              break;
+            }
+            policy_checked = true;
+          } else {
+            atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN,
+                         "Rejecting request from unauthorized atSign: %s\n",
+                         message.notification->from == NULL ? "(none)" : message.notification->from);
+            break;
+          }
         }
 
         char *key = message.notification->key;
@@ -204,11 +227,6 @@ void main_loop() {
           break;
         }
 
-        if (params.policy != NULL) {
-          // TODO: implement a separate permitopen check for npa checks
-          // DO NOT USE permitopen, use npa_permitopen
-        }
-
         switch (notification_key) {
         case NK_SSHPUBLICKEY:
           atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Executing handle_sshpublickey\n");
@@ -228,10 +246,19 @@ void main_loop() {
                          params.local_sshd_port);
             break;
           }
+          // Both the daemon's own permit-open list and the policy service's
+          // must allow the connection
+          if (policy_checked && !policy_permits_open(&policy_decision, "localhost", params.local_sshd_port)) {
+            atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN,
+                         "Ignoring request to localhost:%d - not in the policy service's permitOpen list\n",
+                         params.local_sshd_port);
+            break;
+          }
           handle_ssh_request(&worker, &params, &is_child_process, &message, signingkey);
           if (is_child_process) {
             atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Exiting child process\n");
             atclient_monitor_message_free(&message);
+            policy_decision_free(&policy_decision);
             return;
           }
           break;
@@ -239,10 +266,12 @@ void main_loop() {
           atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Executing handle_npt_request\n");
           // No permitopen here... since we need to parse the json first in order to check, it happens inside
           // handle_npt_request
-          handle_npt_request(&worker, &params, &is_child_process, &message, signingkey);
+          handle_npt_request(&worker, &params, &is_child_process, &message, signingkey,
+                             policy_checked ? &policy_decision : NULL);
           if (is_child_process) {
             atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Exiting child process\n");
             atclient_monitor_message_free(&message);
+            policy_decision_free(&policy_decision);
             return;
           }
           break;
@@ -264,5 +293,6 @@ void main_loop() {
     } // end of case ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION
     } // end of switch
     atclient_monitor_message_free(&message);
+    policy_decision_free(&policy_decision); // safe when nothing was allocated
   } // end of while loop
 }

--- a/packages/c/sshnpd/src/daemon.c
+++ b/packages/c/sshnpd/src/daemon.c
@@ -74,11 +74,6 @@ void main_loop() {
 
   atclient_monitor_message message;
 
-  permitopen_params permitopen;
-  permitopen.permitopen_len = params.permitopen_len;
-  permitopen.permitopen_hosts = params.permitopen_hosts;
-  permitopen.permitopen_ports = params.permitopen_ports;
-
   // The policy service's decision for the request currently being handled;
   // policy_checked is true only when the decision came from the policy
   // service (manager atsigns bypass it)
@@ -238,23 +233,10 @@ void main_loop() {
           break;
         case NK_SSH_REQUEST:
           atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Executing handle_ssh_request\n");
-          // permitopen happens first for ssh so we can avoid a bunch of unnecessary tasks
-          permitopen.requested_host = "localhost";
-          permitopen.requested_port = params.local_sshd_port;
-          if (!should_permitopen(&permitopen)) {
-            atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN, "Ignoring request to localhost:%d\n",
-                         params.local_sshd_port);
-            break;
-          }
-          // Both the daemon's own permit-open list and the policy service's
-          // must allow the connection
-          if (policy_checked && !policy_permits_open(&policy_decision, "localhost", params.local_sshd_port)) {
-            atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN,
-                         "Ignoring request to localhost:%d - not in the policy service's permitOpen list\n",
-                         params.local_sshd_port);
-            break;
-          }
-          handle_ssh_request(&worker, &params, &is_child_process, &message, signingkey);
+          // permit-open checks (daemon list and policy list) happen inside
+          // the handler, which can tell the client why a request was denied
+          handle_ssh_request(&worker, &params, &is_child_process, &message, signingkey,
+                             policy_checked ? &policy_decision : NULL);
           if (is_child_process) {
             atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Exiting child process\n");
             atclient_monitor_message_free(&message);

--- a/packages/c/sshnpd/src/daemon.c
+++ b/packages/c/sshnpd/src/daemon.c
@@ -175,8 +175,7 @@ void main_loop() {
             }
             policy_checked = true;
           } else {
-            atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN,
-                         "Rejecting request from unauthorized atSign: %s\n",
+            atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN, "Rejecting request from unauthorized atSign: %s\n",
                          message.notification->from == NULL ? "(none)" : message.notification->from);
             break;
           }

--- a/packages/c/sshnpd/src/daemon.c
+++ b/packages/c/sshnpd/src/daemon.c
@@ -151,6 +151,16 @@ void main_loop() {
           break;
         }
 
+        // Policy service traffic (config pushes replying to our heartbeats,
+        // rpc responses that missed their wait window) is not a session
+        // request - drop it before the auth gate, or the daemon would run an
+        // auth check asking the policy service about the policy service
+        if (params.policy != NULL && policy_is_policy_service_message(message.notification, &params)) {
+          atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Ignoring policy service message: %s\n",
+                       message.notification->key);
+          break;
+        }
+
         // Managers are approved without a policy check; everyone else is
         // referred to the policy service when one is configured
         policy_checked = false;

--- a/packages/c/sshnpd/src/handle_npt_request.c
+++ b/packages/c/sshnpd/src/handle_npt_request.c
@@ -11,6 +11,7 @@
 #include <atlogger/atlogger.h>
 #include <errno.h>
 #include <sshnpd/daemon.h>
+#include <sshnpd/handle_npt_request.h>
 #include <sshnpd/handle_ssh_request.h>
 #include <sshnpd/handler_commons.h>
 #include <sshnpd/run_srv_process.h>
@@ -23,7 +24,8 @@
 #define LOGGER_TAG "NPT_REQUEST"
 
 void handle_npt_request(atclient *atclient, sshnpd_params *params, bool *is_child_process,
-                        atclient_monitor_message *message, atchops_rsa_key_private_key signing_key) {
+                        atclient_monitor_message *message, atchops_rsa_key_private_key signing_key,
+                        const sshnpd_policy_decision *policy) {
   int res = 0;
 
   cJSON *envelope = extract_envelope_from_notification(message);
@@ -71,6 +73,17 @@ void handle_npt_request(atclient *atclient, sshnpd_params *params, bool *is_chil
   if (!should_permitopen(&permitopen)) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN, "Ignoring request to localhost:%d\n",
                  permitopen.requested_port);
+    cJSON_Delete(envelope);
+    return;
+  }
+
+  // Both the daemon's own permit-open list and the policy service's must
+  // allow the connection
+  if (policy != NULL &&
+      !policy_permits_open(policy, permitopen.requested_host, (uint16_t)permitopen.requested_port)) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN,
+                 "Ignoring request to %s:%d - not in the policy service's permitOpen list\n",
+                 permitopen.requested_host, permitopen.requested_port);
     cJSON_Delete(envelope);
     return;
   }

--- a/packages/c/sshnpd/src/handle_npt_request.c
+++ b/packages/c/sshnpd/src/handle_npt_request.c
@@ -88,11 +88,10 @@ void handle_npt_request(atclient *atclient, sshnpd_params *params, bool *is_chil
 
   // Both the daemon's own permit-open list and the policy service's must
   // allow the connection
-  if (policy != NULL &&
-      !policy_permits_open(policy, permitopen.requested_host, (uint16_t)permitopen.requested_port)) {
+  if (policy != NULL && !policy_permits_open(policy, permitopen.requested_host, (uint16_t)permitopen.requested_port)) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN,
-                 "Denying request to %s:%d - not in the policy service's permitOpen list\n",
-                 permitopen.requested_host, permitopen.requested_port);
+                 "Denying request to %s:%d - not in the policy service's permitOpen list\n", permitopen.requested_host,
+                 permitopen.requested_port);
     char po_list[256];
     format_string_list(policy->permit_open, policy->permit_open_len, po_list, sizeof(po_list));
     char error_message[512];

--- a/packages/c/sshnpd/src/handle_npt_request.c
+++ b/packages/c/sshnpd/src/handle_npt_request.c
@@ -70,9 +70,18 @@ void handle_npt_request(atclient *atclient, sshnpd_params *params, bool *is_chil
   permitopen.requested_host = cJSON_GetStringValue(requested_host);
   permitopen.requested_port = cJSON_GetNumberValue(requested_port);
 
+  char *session_id_for_errors = cJSON_GetStringValue(cJSON_GetObjectItem(payload, "sessionId"));
+
   if (!should_permitopen(&permitopen)) {
-    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN, "Ignoring request to localhost:%d\n",
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN, "Denying request to %s:%d\n", permitopen.requested_host,
                  permitopen.requested_port);
+    char po_list[256];
+    format_permitopen_list(params->permitopen_hosts, params->permitopen_ports, params->permitopen_len, po_list,
+                           sizeof(po_list));
+    char error_message[512];
+    snprintf(error_message, sizeof(error_message), "Connection to %s:%d denied based on daemon --permit-open %s",
+             permitopen.requested_host, permitopen.requested_port, po_list);
+    send_session_error(atclient, params, requesting_atsign, session_id_for_errors, error_message);
     cJSON_Delete(envelope);
     return;
   }
@@ -82,8 +91,14 @@ void handle_npt_request(atclient *atclient, sshnpd_params *params, bool *is_chil
   if (policy != NULL &&
       !policy_permits_open(policy, permitopen.requested_host, (uint16_t)permitopen.requested_port)) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN,
-                 "Ignoring request to %s:%d - not in the policy service's permitOpen list\n",
+                 "Denying request to %s:%d - not in the policy service's permitOpen list\n",
                  permitopen.requested_host, permitopen.requested_port);
+    char po_list[256];
+    format_string_list(policy->permit_open, policy->permit_open_len, po_list, sizeof(po_list));
+    char error_message[512];
+    snprintf(error_message, sizeof(error_message), "Connection to %s:%d denied based on POLICY --permit-open %s",
+             permitopen.requested_host, permitopen.requested_port, po_list);
+    send_session_error(atclient, params, requesting_atsign, session_id_for_errors, error_message);
     cJSON_Delete(envelope);
     return;
   }

--- a/packages/c/sshnpd/src/handle_ssh_request.c
+++ b/packages/c/sshnpd/src/handle_ssh_request.c
@@ -70,8 +70,7 @@ void handle_ssh_request(atclient *atclient, sshnpd_params *params, bool *is_chil
   permitopen.requested_port = params->local_sshd_port;
 
   if (!should_permitopen(&permitopen)) {
-    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN, "Denying request to localhost:%d\n",
-                 params->local_sshd_port);
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN, "Denying request to localhost:%d\n", params->local_sshd_port);
     char error_message[256];
     snprintf(error_message, sizeof(error_message), "Daemon does not permit connections to localhost:%d",
              params->local_sshd_port);

--- a/packages/c/sshnpd/src/handle_ssh_request.c
+++ b/packages/c/sshnpd/src/handle_ssh_request.c
@@ -12,6 +12,7 @@
 #include <sshnpd/daemon.h>
 #include <sshnpd/handle_ssh_request.h>
 #include <sshnpd/handler_commons.h>
+#include <sshnpd/permitopen.h>
 #include <sshnpd/run_srv_process.h>
 #include <srv/params.h>
 #include <stdlib.h>
@@ -23,7 +24,8 @@
 
 // TODO: refactor this to call the new common handlers
 void handle_ssh_request(atclient *atclient, sshnpd_params *params, bool *is_child_process,
-                        atclient_monitor_message *message, atchops_rsa_key_private_key signing_key) {
+                        atclient_monitor_message *message, atchops_rsa_key_private_key signing_key,
+                        const sshnpd_policy_decision *policy) {
   int res = 0;
 
   cJSON *envelope = extract_envelope_from_notification(message);
@@ -55,6 +57,40 @@ void handle_ssh_request(atclient *atclient, sshnpd_params *params, bool *is_chil
     return;
   }
   cJSON *payload = cJSON_GetObjectItem(envelope, "payload");
+
+  // ssh sessions always bridge to localhost:<local-sshd-port>; both the
+  // daemon's own permit-open list and (in policy mode) the policy service's
+  // permitOpen list must allow it, and the client is told why when they don't
+  char *session_id_for_errors = cJSON_GetStringValue(cJSON_GetObjectItem(payload, "sessionId"));
+  permitopen_params permitopen;
+  permitopen.permitopen_len = params->permitopen_len;
+  permitopen.permitopen_hosts = params->permitopen_hosts;
+  permitopen.permitopen_ports = params->permitopen_ports;
+  permitopen.requested_host = "localhost";
+  permitopen.requested_port = params->local_sshd_port;
+
+  if (!should_permitopen(&permitopen)) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN, "Denying request to localhost:%d\n",
+                 params->local_sshd_port);
+    char error_message[256];
+    snprintf(error_message, sizeof(error_message), "Daemon does not permit connections to localhost:%d",
+             params->local_sshd_port);
+    send_session_error(atclient, params, requesting_atsign, session_id_for_errors, error_message);
+    cJSON_Delete(envelope);
+    return;
+  }
+
+  if (policy != NULL && !policy_permits_open(policy, "localhost", params->local_sshd_port)) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN,
+                 "Denying request to localhost:%d - not in the policy service's permitOpen list\n",
+                 params->local_sshd_port);
+    char error_message[256];
+    snprintf(error_message, sizeof(error_message), "Client is not permitted connections to localhost:%d",
+             params->local_sshd_port);
+    send_session_error(atclient, params, requesting_atsign, session_id_for_errors, error_message);
+    cJSON_Delete(envelope);
+    return;
+  }
 
   bool authenticate_to_rvd = cJSON_IsTrue(cJSON_GetObjectItem(payload, "authenticateToRvd"));
   char *rvd_auth_string = NULL;

--- a/packages/c/sshnpd/src/handler_commons.c
+++ b/packages/c/sshnpd/src/handler_commons.c
@@ -37,11 +37,6 @@ bool is_manager_atsign(const sshnpd_params *params, const char *atsign) {
     return false;
   }
 
-  // TODO: policy authorization is unimplemented
-  if (params->policy != NULL) {
-    return false;
-  }
-
   if (params->manager_list == NULL || params->manager_list_len == 0) {
     return false;
   }

--- a/packages/c/sshnpd/src/handler_commons.c
+++ b/packages/c/sshnpd/src/handler_commons.c
@@ -17,6 +17,79 @@
 
 #define LOGGER_TAG "HANDLER_COMMONS"
 
+int send_session_error(atclient *atclient, sshnpd_params *params, char *requesting_atsign, const char *session_id,
+                       const char *message) {
+  if (session_id == NULL || requesting_atsign == NULL) {
+    return 1;
+  }
+
+  atclient_atkey atkey;
+  atclient_atkey_init(&atkey);
+
+  size_t keyname_size = strlen(session_id) + strlen(params->device) + 2;
+  char *keyname = malloc(keyname_size);
+  if (keyname == NULL) {
+    atclient_atkey_free(&atkey);
+    return 1;
+  }
+  snprintf(keyname, keyname_size, "%s.%s", session_id, params->device);
+  int res = atclient_atkey_create_shared_key(&atkey, keyname, params->atsign, requesting_atsign, SSHNP_NS);
+  free(keyname);
+  if (res != 0) {
+    atclient_atkey_free(&atkey);
+    return res;
+  }
+  atclient_atkey_metadata_set_is_public(&atkey.metadata, false);
+  atclient_atkey_metadata_set_is_encrypted(&atkey.metadata, true);
+  atclient_atkey_metadata_set_ttl(&atkey.metadata, 10000);
+
+  atclient_notify_params notify_params;
+  atclient_notify_params_init(&notify_params);
+  if ((res = atclient_notify_params_set_atkey(&notify_params, &atkey)) == 0 &&
+      (res = atclient_notify_params_set_operation(&notify_params, ATCLIENT_NOTIFY_OPERATION_UPDATE)) == 0 &&
+      (res = atclient_notify_params_set_value(&notify_params, message)) == 0) {
+    res = atclient_notify(atclient, &notify_params, NULL);
+  }
+  if (res != 0) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to send error message to %s\n", requesting_atsign);
+  }
+  atclient_notify_params_free(&notify_params);
+  atclient_atkey_free(&atkey);
+  return res;
+}
+
+void format_permitopen_list(char **hosts, const uint16_t *ports, size_t len, char *buf, size_t bufsize) {
+  size_t pos = 0;
+  pos += snprintf(buf + pos, bufsize - pos, "[");
+  for (size_t i = 0; i < len && pos < bufsize - 1; i++) {
+    if (ports[i] == 0) {
+      pos += snprintf(buf + pos, bufsize - pos, "%s%s:*", i > 0 ? ", " : "", hosts[i]);
+    } else {
+      pos += snprintf(buf + pos, bufsize - pos, "%s%s:%u", i > 0 ? ", " : "", hosts[i], (unsigned int)ports[i]);
+    }
+  }
+  if (pos < bufsize - 1) {
+    snprintf(buf + pos, bufsize - pos, "]");
+  } else {
+    buf[bufsize - 2] = ']';
+    buf[bufsize - 1] = '\0';
+  }
+}
+
+void format_string_list(char **items, size_t len, char *buf, size_t bufsize) {
+  size_t pos = 0;
+  pos += snprintf(buf + pos, bufsize - pos, "[");
+  for (size_t i = 0; i < len && pos < bufsize - 1; i++) {
+    pos += snprintf(buf + pos, bufsize - pos, "%s%s", i > 0 ? ", " : "", items[i]);
+  }
+  if (pos < bufsize - 1) {
+    snprintf(buf + pos, bufsize - pos, "]");
+  } else {
+    buf[bufsize - 2] = ']';
+    buf[bufsize - 1] = '\0';
+  }
+}
+
 char *public_signing_key_uri(const atclient_atkeys *atkeys, const char *atsign) {
   // 'primary' is the Dart at_client fallback when the atkeys file carries no
   // APKAM enrollment id

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -431,7 +431,7 @@ int main(int argc, char **argv) {
   }
 
   // 10. Start monitor
-  size_t regexlen = strlen(params.device) + strlen(SSHNP_NS) + 3;
+  size_t regexlen = 2 * strlen(params.device) + strlen(SSHNP_NS) + 64;
   regex = malloc(sizeof(char) * regexlen); // needs to be declared before any gotos
   if (regex == NULL) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to allocate memory for the monitor regex\n");
@@ -446,13 +446,20 @@ int main(int argc, char **argv) {
   }
 
   if (params.policy != NULL) {
-    // Policy rpc response keys ('<type>.<reqId>.auth_checks.__rpcs...') do
-    // not contain '<device>.sshnp@', so in policy mode the monitor must
-    // receive everything and filtering happens in the main loop
-    regex[0] = '\0';
+    // In policy mode the monitor must also receive the policy service's rpc
+    // responses ('<type>.<reqId>.auth_checks.__rpcs...') and config pushes
+    // ('config.<device>.devices.policy...'), whose keys don't contain
+    // '<device>.sshnp@'. The atServer monitor filter is a regex (the Dart
+    // daemon relies on alternation in its filters too), so subscribe to this
+    // device's requests plus the policy namespaces - notifications for other
+    // devices on this atsign are filtered out by the atServer, exactly as in
+    // the Dart daemon. The in-loop classifier remains as defense in depth.
+    snprintf(regex, regexlen, "\\.%s\\.%s@|auth_checks\\.__rpcs|%s\\.devices\\.policy", params.device, SSHNP_NS,
+             params.device);
   } else {
     snprintf(regex, regexlen, "%s.%s@", params.device, SSHNP_NS);
   }
+  atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Monitor filter: %s\n", regex);
   res = atclient_monitor_start(&monitor_ctx, regex);
   if (res != 0) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to start monitor\n");

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -454,7 +454,11 @@ int main(int argc, char **argv) {
     // device's requests plus the policy namespaces - notifications for other
     // devices on this atsign are filtered out by the atServer, exactly as in
     // the Dart daemon. The in-loop classifier remains as defense in depth.
-    snprintf(regex, regexlen, "\\.%s\\.%s@|auth_checks\\.__rpcs|%s\\.devices\\.policy", params.device, SSHNP_NS,
+    // Every alternative anchors the device name with '\.' on both sides so a
+    // device named 'iot' can never match keys for 'iot_device01' or 'my_iot'
+    // (validated against Dart RegExp semantics, which is what the atServer
+    // evaluates)
+    snprintf(regex, regexlen, "\\.%s\\.%s@|auth_checks\\.__rpcs|\\.%s\\.devices\\.policy", params.device, SSHNP_NS,
              params.device);
   } else {
     snprintf(regex, regexlen, "%s.%s@", params.device, SSHNP_NS);

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -439,8 +439,8 @@ int main(int argc, char **argv) {
   }
 
   // 10. Start monitor
-  size_t regexlen = 3 * strlen(params.device) + 2 * strlen(SSHNP_NS) +
-                    (params.policy != NULL ? strlen(params.policy) : 0) + 128;
+  size_t regexlen =
+      3 * strlen(params.device) + 2 * strlen(SSHNP_NS) + (params.policy != NULL ? strlen(params.policy) : 0) + 128;
   regex = malloc(sizeof(char) * regexlen); // needs to be declared before any gotos
   if (regex == NULL) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to allocate memory for the monitor regex\n");

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -431,7 +431,8 @@ int main(int argc, char **argv) {
   }
 
   // 10. Start monitor
-  size_t regexlen = 2 * strlen(params.device) + strlen(SSHNP_NS) + 64;
+  size_t regexlen = 3 * strlen(params.device) + 2 * strlen(SSHNP_NS) +
+                    (params.policy != NULL ? strlen(params.policy) : 0) + 128;
   regex = malloc(sizeof(char) * regexlen); // needs to be declared before any gotos
   if (regex == NULL) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to allocate memory for the monitor regex\n");
@@ -449,19 +450,23 @@ int main(int argc, char **argv) {
     // In policy mode the monitor must also receive the policy service's rpc
     // responses ('<type>.<reqId>.auth_checks.__rpcs...') and config pushes
     // ('config.<device>.devices.policy...'), whose keys don't contain
-    // '<device>.sshnp@'. The atServer monitor filter is a regex (the Dart
-    // daemon relies on alternation in its filters too), so subscribe to this
-    // device's requests plus the policy namespaces - notifications for other
-    // devices on this atsign are filtered out by the atServer, exactly as in
-    // the Dart daemon. The in-loop classifier remains as defense in depth.
-    // Every alternative anchors the device name with '\.' on both sides so a
-    // device named 'iot' can never match keys for 'iot_device01' or 'my_iot'
-    // (validated against Dart RegExp semantics, which is what the atServer
-    // evaluates)
-    snprintf(regex, regexlen, "\\.%s\\.%s@|auth_checks\\.__rpcs|\\.%s\\.devices\\.policy", params.device, SSHNP_NS,
-             params.device);
+    // '<device>.sshnp@'. The atServer monitor filter is a regex, so this is
+    // the union of the three filters the Dart daemon subscribes with
+    // (requests, AtRpc responses, policy config pushes with the sender
+    // pinned). The device name is anchored in every alternative so 'iot' can
+    // never match keys for 'iot_device01' or 'my_iot'; the rpc alternative
+    // deliberately tolerates a missing '.sshnp' suffix on response keys. All
+    // alternatives are validated against Dart RegExp semantics (which is
+    // what the atServer evaluates). The in-loop classifier and the exact
+    // device match in the dispatcher remain as defense in depth.
+    snprintf(regex, regexlen,
+             "(^%s|\\.%s)\\.%s@|(success|error|ack|nack)\\.\\d+\\.auth_checks\\.__rpcs|\\.%s\\.devices\\.policy\\.%s%s",
+             params.device, params.device, SSHNP_NS, params.device, SSHNP_NS, params.policy);
   } else {
-    snprintf(regex, regexlen, "%s.%s@", params.device, SSHNP_NS);
+    // Same request filter the Dart daemon uses; the previous
+    // '<device>.sshnp@' form was unanchored, so a daemon for 'device01' also
+    // received (and then discarded) traffic for 'iot_device01'
+    snprintf(regex, regexlen, "(^%s|\\.%s)\\.%s@", params.device, params.device, SSHNP_NS);
   }
   atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Monitor filter: %s\n", regex);
   res = atclient_monitor_start(&monitor_ctx, regex);

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -445,7 +445,14 @@ int main(int argc, char **argv) {
     return res;
   }
 
-  snprintf(regex, regexlen, "%s.%s@", params.device, SSHNP_NS);
+  if (params.policy != NULL) {
+    // Policy rpc response keys ('<type>.<reqId>.auth_checks.__rpcs...') do
+    // not contain '<device>.sshnp@', so in policy mode the monitor must
+    // receive everything and filtering happens in the main loop
+    regex[0] = '\0';
+  } else {
+    snprintf(regex, regexlen, "%s.%s@", params.device, SSHNP_NS);
+  }
   res = atclient_monitor_start(&monitor_ctx, regex);
   if (res != 0) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to start monitor\n");

--- a/packages/c/sshnpd/src/params.c
+++ b/packages/c/sshnpd/src/params.c
@@ -41,9 +41,9 @@ int parse_sshnpd_params(sshnpd_params *params, int argc, const char **argv) {
       OPT_STRING('m', "manager", &manager,
                  "atSign or list of atSigns (comma separated) that this device will accept requests from. At least one "
                  "of --manager and --policy-manager must be supplied."),
-      // OPT_STRING('p', "policy-manager", &params->policy,
-      //            "The atSign which this device will use to decide whether or not to accept request from some client "
-      //            "atSignAt least one of --manager and --policy-manager must be supplied."),
+      OPT_STRING('p', "policy-manager", &params->policy,
+                 "The atSign which this device will use to decide whether or not to accept requests from some client "
+                 "atSign. At least one of --manager and --policy-manager must be supplied."),
       OPT_STRING('d', "device", &params->device, "Device to use"),
       OPT_BOOLEAN('s', "sshpublickey", &params->sshpublickey, "Generate ssh public key"),
       OPT_BOOLEAN('h', "hide", &params->hide, "Hide device from device entry (still responds to pings)"),
@@ -78,19 +78,21 @@ int parse_sshnpd_params(sshnpd_params *params, int argc, const char **argv) {
     return 1;
   } else if (manager == NULL && params->policy == NULL) {
     argparse_usage(&argparse);
-    // TODO: enable this message when enabling policy
-    // printf("Invalid Argument(s) One of --manager or --policy-manager must be provided");
-    printf("Invalid Argument(s) --manager must be provided");
+    printf("Invalid Argument(s) One of --manager or --policy-manager must be provided");
     return 1;
   }
 
   if (permitopen == NULL) {
-    params->permitopen_str = malloc(sizeof(char) * (strlen(default_permitopen) + 1));
+    // With a policy manager and no explicit --permit-open, the policy
+    // service's permitOpen list is the effective ACL, so the daemon's own
+    // list defaults to allow-all rather than localhost only
+    const char *effective_default = params->policy != NULL ? "*:*" : default_permitopen;
+    params->permitopen_str = malloc(sizeof(char) * (strlen(effective_default) + 1));
     if (params->permitopen_str == NULL) {
       printf("Failed to allocate memory for default permitopen string\n");
       return 1;
     }
-    strcpy(params->permitopen_str, default_permitopen);
+    strcpy(params->permitopen_str, effective_default);
     permitopen = params->permitopen_str;
   }
   if ((parse_permitopen(permitopen, &params->permitopen_hosts, &params->permitopen_ports, &params->permitopen_len,

--- a/packages/c/sshnpd/src/params.c
+++ b/packages/c/sshnpd/src/params.c
@@ -53,7 +53,9 @@ int parse_sshnpd_params(sshnpd_params *params, int argc, const char **argv) {
                  "client. (defaults to \"localhost:22,localhost:3389\")"),
       OPT_STRING(0, "ssh-algorithm", &ssh_algorithm_input, "SSH algorithm to use"),
       OPT_STRING(0, "ephemeral-permission", &ephemeral_permissions, "(Kept for compatibility)"),
-      OPT_STRING(0, "root-domain", &params->root_domain, "Root domain to use. If a host but no port is specified (e.g. 'root.atsign.org'), the default port 64 will be appended (defaults to \"root.atsign.org:64\")"),
+      OPT_STRING(0, "root-domain", &params->root_domain,
+                 "Root domain to use. If a host but no port is specified (e.g. 'root.atsign.org'), the default port 64 "
+                 "will be appended (defaults to \"root.atsign.org:64\")"),
       OPT_INTEGER(0, "local-sshd-port", &params->local_sshd_port, "Local sshd port to use"),
       OPT_STRING(0, "storage-path", &params->storage_path, NULL),
 

--- a/packages/c/sshnpd/src/policy.c
+++ b/packages/c/sshnpd/src/policy.c
@@ -147,6 +147,14 @@ exit:
   return ret;
 }
 
+bool policy_is_policy_service_message(const atclient_atnotification *notification, const sshnpd_params *params) {
+  if (params->policy == NULL || notification->key == NULL || !atsign_equals(notification->from, params->policy)) {
+    return false;
+  }
+  return strstr(notification->key, POLICY_RPC_INFIX) != NULL ||
+         strstr(notification->key, ".devices.policy.") != NULL;
+}
+
 // Whether this notification is a response to our rpc request. The Dart AtRpc
 // server sends response keys of the form
 // '@daemon:<type>.<reqId>.auth_checks.__rpcs.sshnp@policy' - match on the
@@ -276,6 +284,12 @@ int policy_auth_check(atclient *worker, atclient *monitor, const sshnpd_params *
           atclient_monitor_message_free(&message);
           return 0; // definite decision (success / nack / error)
         }
+      } else if (atsign_equals(message.notification->from, params->policy)) {
+        // Config pushes and stale rpc responses from the policy service are
+        // routine while a check is in flight - not worth a warning
+        atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG,
+                     "Ignoring policy service message %s while waiting for the auth check response\n",
+                     message.notification->key);
       } else {
         atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN,
                      "Dropping notification %s received while waiting for the policy service\n",

--- a/packages/c/sshnpd/src/policy.c
+++ b/packages/c/sshnpd/src/policy.c
@@ -1,0 +1,334 @@
+#include "sshnpd/policy.h"
+#include "sshnpd/sshnpd.h"
+#include <atclient/atkey.h>
+#include <atclient/json.h>
+#include <atclient/notify.h>
+#include <atlogger/atlogger.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+#include <time.h>
+
+#define LOGGER_TAG "POLICY"
+
+// How long to wait for the policy service before denying; an ack from the
+// policy service resets the clock (it means the request was received and is
+// being worked on)
+#define POLICY_TIMEOUT_MS 10000
+
+// The rpc request notification expires if undelivered after this long
+#define POLICY_REQUEST_EXPIRY_MS 30000
+
+// How often the device heartbeat is sent to the policy service
+#define POLICY_HEARTBEAT_SECONDS 300
+
+// AtRpc namespaces: requests/responses travel as
+// <type>.<reqId>.auth_checks.__rpcs[.sshnp]@atsign
+#define POLICY_RPC_INFIX ".auth_checks.__rpcs"
+
+static int64_t now_millis(void) {
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  return (int64_t)tv.tv_sec * 1000 + tv.tv_usec / 1000;
+}
+
+// Compare two atsigns, tolerating a missing leading '@' on either side
+static bool atsign_equals(const char *a, const char *b) {
+  if (a == NULL || b == NULL) {
+    return false;
+  }
+  if (a[0] == '@') {
+    a++;
+  }
+  if (b[0] == '@') {
+    b++;
+  }
+  return strcmp(a, b) == 0;
+}
+
+void policy_decision_free(sshnpd_policy_decision *decision) {
+  for (size_t i = 0; i < decision->permit_open_len; i++) {
+    free(decision->permit_open[i]);
+  }
+  free(decision->permit_open);
+  memset(decision, 0, sizeof(*decision));
+}
+
+bool policy_permits_open(const sshnpd_policy_decision *decision, const char *host, uint16_t port) {
+  // An authorized client with an empty permitOpen list is a known client
+  // with no permitted services - deny
+  for (size_t i = 0; i < decision->permit_open_len; i++) {
+    const char *entry = decision->permit_open[i];
+    const char *colon = strrchr(entry, ':');
+    if (colon == NULL) {
+      continue; // malformed entry - skip, don't fail the whole list
+    }
+    size_t host_len = (size_t)(colon - entry);
+    const char *port_str = colon + 1;
+
+    bool host_matches = (host_len == 1 && entry[0] == '*') ||
+                        (strlen(host) == host_len && strncmp(entry, host, host_len) == 0);
+    uint16_t entry_port = (uint16_t)strtoul(port_str, NULL, 10);
+    bool port_matches = strcmp(port_str, "*") == 0 || entry_port == 0 || entry_port == port;
+
+    if (host_matches && port_matches) {
+      return true;
+    }
+  }
+  return false;
+}
+
+int policy_parse_response_value(const char *json, int64_t expected_req_id, sshnpd_policy_decision *decision,
+                                char *resp_type_out, size_t resp_type_size) {
+  cJSON *root = cJSON_Parse(json);
+  if (root == NULL) {
+    return 1;
+  }
+
+  int ret = 1;
+
+  // The reqId inside the value must match the one we sent - responses to
+  // other (stale) requests are not ours to act on
+  cJSON *req_id_json = cJSON_GetObjectItem(root, "reqId");
+  if (!cJSON_IsNumber(req_id_json) || (int64_t)cJSON_GetNumberValue(req_id_json) != expected_req_id) {
+    goto exit;
+  }
+
+  char *resp_type = cJSON_GetStringValue(cJSON_GetObjectItem(root, "respType"));
+  if (resp_type == NULL) {
+    goto exit;
+  }
+  snprintf(resp_type_out, resp_type_size, "%s", resp_type);
+
+  if (strcmp(resp_type, "success") == 0) {
+    cJSON *payload = cJSON_GetObjectItem(root, "payload");
+    decision->authorized = cJSON_IsTrue(cJSON_GetObjectItem(payload, "authorized"));
+
+    cJSON *permit_open = cJSON_GetObjectItem(payload, "permitOpen");
+    if (cJSON_IsArray(permit_open)) {
+      int len = cJSON_GetArraySize(permit_open);
+      if (len > 0) {
+        decision->permit_open = calloc(len, sizeof(char *));
+        if (decision->permit_open == NULL) {
+          decision->authorized = false;
+          goto exit;
+        }
+        for (int i = 0; i < len; i++) {
+          char *entry = cJSON_GetStringValue(cJSON_GetArrayItem(permit_open, i));
+          if (entry == NULL) {
+            continue;
+          }
+          decision->permit_open[decision->permit_open_len] = strdup(entry);
+          if (decision->permit_open[decision->permit_open_len] == NULL) {
+            policy_decision_free(decision);
+            goto exit;
+          }
+          decision->permit_open_len++;
+        }
+      }
+    }
+
+    char *policy_message = cJSON_GetStringValue(cJSON_GetObjectItem(payload, "message"));
+    if (policy_message != NULL) {
+      atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Policy message: %s\n", policy_message);
+    }
+  } else if (strcmp(resp_type, "ack") != 0) {
+    // nack / error / anything else: log why, decision stays deny
+    char *policy_message = cJSON_GetStringValue(cJSON_GetObjectItem(root, "message"));
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN, "Policy service replied %s: %s\n", resp_type,
+                 policy_message != NULL ? policy_message : "(no message)");
+  }
+
+  ret = 0;
+
+exit:
+  cJSON_Delete(root);
+  return ret;
+}
+
+// Whether this notification is a response to our rpc request. The Dart AtRpc
+// server sends response keys of the form
+// '@daemon:<type>.<reqId>.auth_checks.__rpcs.sshnp@policy' - match on the
+// rpcs infix and the reqId, and critically on the sender: only the
+// configured policy atsign may answer auth checks (the key pattern alone
+// binds the response to nothing).
+static bool is_policy_response(const atclient_atnotification *notification, const sshnpd_params *params,
+                               int64_t req_id) {
+  if (!atsign_equals(notification->from, params->policy)) {
+    return false;
+  }
+  if (strstr(notification->key, POLICY_RPC_INFIX) == NULL) {
+    return false;
+  }
+  char req_id_str[32];
+  snprintf(req_id_str, sizeof(req_id_str), ".%lld.", (long long)req_id);
+  return strstr(notification->key, req_id_str) != NULL;
+}
+
+static int send_auth_check_request(atclient *worker, const sshnpd_params *params, const char *client_atsign,
+                                   int64_t req_id) {
+  int ret = 1;
+
+  char keyname[96];
+  snprintf(keyname, sizeof(keyname), "request.%lld" POLICY_RPC_INFIX, (long long)req_id);
+
+  atclient_atkey key;
+  atclient_atkey_init(&key);
+  if (atclient_atkey_create_shared_key(&key, keyname, params->atsign, params->policy, SSHNP_NS) != 0) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to create rpc request atkey\n");
+    atclient_atkey_free(&key);
+    return 1;
+  }
+  atclient_atkey_metadata_set_is_public(&key.metadata, false);
+  atclient_atkey_metadata_set_is_encrypted(&key.metadata, true);
+
+  // NPAAuthCheckRequest
+  cJSON *payload = cJSON_CreateObject();
+  cJSON_AddItemToObject(payload, "daemonAtsign", cJSON_CreateString(params->atsign));
+  cJSON_AddItemToObject(payload, "daemonDeviceName", cJSON_CreateString(params->device));
+  // csshnpd has no --device-group option; '__none__' is the Dart default
+  cJSON_AddItemToObject(payload, "daemonDeviceGroupName", cJSON_CreateString("__none__"));
+  cJSON_AddItemToObject(payload, "clientAtsign", cJSON_CreateString(client_atsign));
+  char *payload_str = cJSON_PrintUnformatted(payload);
+  cJSON_Delete(payload);
+  if (payload_str == NULL) {
+    atclient_atkey_free(&key);
+    return 1;
+  }
+
+  // The reqId is written with snprintf rather than through cJSON so the
+  // 64 bit value can't pick up floating point formatting
+  size_t value_size = strlen(payload_str) + 64;
+  char *value = malloc(value_size);
+  if (value == NULL) {
+    free(payload_str);
+    atclient_atkey_free(&key);
+    return 1;
+  }
+  snprintf(value, value_size, "{\"reqId\":%lld,\"payload\":%s}", (long long)req_id, payload_str);
+  free(payload_str);
+
+  atclient_notify_params notify_params;
+  atclient_notify_params_init(&notify_params);
+  if (atclient_notify_params_set_atkey(&notify_params, &key) != 0 ||
+      atclient_notify_params_set_operation(&notify_params, ATCLIENT_NOTIFY_OPERATION_UPDATE) != 0 ||
+      atclient_notify_params_set_value(&notify_params, value) != 0 ||
+      atclient_notify_params_set_notification_expiry(&notify_params, POLICY_REQUEST_EXPIRY_MS) != 0) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to build rpc request notify params\n");
+    goto exit;
+  }
+
+  ret = atclient_notify(worker, &notify_params, NULL);
+  if (ret != 0) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to notify policy service %s: %d\n", params->policy,
+                 ret);
+  }
+
+exit:
+  atclient_notify_params_free(&notify_params);
+  free(value);
+  atclient_atkey_free(&key);
+  return ret;
+}
+
+int policy_auth_check(atclient *worker, atclient *monitor, const sshnpd_params *params, const char *client_atsign,
+                      sshnpd_policy_decision *decision) {
+  memset(decision, 0, sizeof(*decision));
+
+  int64_t req_id = 0;
+  {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    req_id = (int64_t)tv.tv_sec * 1000000 + tv.tv_usec;
+  }
+
+  if (send_auth_check_request(worker, params, client_atsign, req_id) != 0) {
+    return 1; // fail closed
+  }
+  atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Sent auth check for %s to policy service %s (reqId %lld)\n",
+               client_atsign, params->policy, (long long)req_id);
+
+  int64_t deadline = now_millis() + POLICY_TIMEOUT_MS;
+  while (now_millis() < deadline) {
+    atclient_monitor_message message;
+    atclient_monitor_message_init(&message);
+    int read_res = atclient_monitor_read(monitor, worker, &message, NULL);
+    if (read_res != 0) {
+      atclient_monitor_message_free(&message);
+      continue; // let the deadline decide; the main loop repairs the monitor
+    }
+
+    if (message.type == ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION &&
+        atclient_atnotification_is_key_initialized(message.notification) &&
+        atclient_atnotification_is_from_initialized(message.notification) &&
+        atclient_atnotification_is_decrypted_value_initialized(message.notification)) {
+      if (is_policy_response(message.notification, params, req_id)) {
+        char resp_type[16] = "";
+        if (policy_parse_response_value(message.notification->decrypted_value, req_id, decision, resp_type,
+                                        sizeof(resp_type)) == 0) {
+          if (strcmp(resp_type, "ack") == 0) {
+            // Request received and being worked on - restart the clock
+            deadline = now_millis() + POLICY_TIMEOUT_MS;
+            atclient_monitor_message_free(&message);
+            continue;
+          }
+          atclient_monitor_message_free(&message);
+          return 0; // definite decision (success / nack / error)
+        }
+      } else {
+        atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN,
+                     "Dropping notification %s received while waiting for the policy service\n",
+                     message.notification->key);
+      }
+    }
+    atclient_monitor_message_free(&message);
+  }
+
+  atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN, "Timed out waiting for policy service %s - denying %s\n",
+               params->policy, client_atsign);
+  policy_decision_free(decision);
+  return 0;
+}
+
+void policy_send_heartbeat(atclient *worker, const sshnpd_params *params, const char *ping_response) {
+  static time_t last_sent = 0;
+
+  if (params->policy == NULL || ping_response == NULL) {
+    return;
+  }
+  time_t now = time(NULL);
+  if (last_sent != 0 && now - last_sent < POLICY_HEARTBEAT_SECONDS) {
+    return;
+  }
+  last_sent = now;
+
+  char keyname[128];
+  snprintf(keyname, sizeof(keyname), "%s.devices.policy", params->device);
+
+  atclient_atkey key;
+  atclient_atkey_init(&key);
+  if (atclient_atkey_create_shared_key(&key, keyname, params->atsign, params->policy, SSHNP_NS) != 0) {
+    atclient_atkey_free(&key);
+    return;
+  }
+  atclient_atkey_metadata_set_is_public(&key.metadata, false);
+  atclient_atkey_metadata_set_is_encrypted(&key.metadata, true);
+
+  atclient_notify_params notify_params;
+  atclient_notify_params_init(&notify_params);
+  if (atclient_notify_params_set_atkey(&notify_params, &key) == 0 &&
+      atclient_notify_params_set_operation(&notify_params, ATCLIENT_NOTIFY_OPERATION_UPDATE) == 0 &&
+      atclient_notify_params_set_value(&notify_params, ping_response) == 0 &&
+      atclient_notify_params_set_notification_expiry(&notify_params, POLICY_HEARTBEAT_SECONDS * 1000) == 0) {
+    if (atclient_notify(worker, &notify_params, NULL) == 0) {
+      atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Sent device heartbeat to policy service %s\n",
+                   params->policy);
+    } else {
+      atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN, "Failed to send device heartbeat to policy service %s\n",
+                   params->policy);
+    }
+  }
+  atclient_notify_params_free(&notify_params);
+  atclient_atkey_free(&key);
+}

--- a/packages/c/sshnpd/src/policy.c
+++ b/packages/c/sshnpd/src/policy.c
@@ -67,8 +67,8 @@ bool policy_permits_open(const sshnpd_policy_decision *decision, const char *hos
     size_t host_len = (size_t)(colon - entry);
     const char *port_str = colon + 1;
 
-    bool host_matches = (host_len == 1 && entry[0] == '*') ||
-                        (strlen(host) == host_len && strncmp(entry, host, host_len) == 0);
+    bool host_matches =
+        (host_len == 1 && entry[0] == '*') || (strlen(host) == host_len && strncmp(entry, host, host_len) == 0);
     uint16_t entry_port = (uint16_t)strtoul(port_str, NULL, 10);
     bool port_matches = strcmp(port_str, "*") == 0 || entry_port == 0 || entry_port == port;
 
@@ -151,8 +151,7 @@ bool policy_is_policy_service_message(const atclient_atnotification *notificatio
   if (params->policy == NULL || notification->key == NULL || !atsign_equals(notification->from, params->policy)) {
     return false;
   }
-  return strstr(notification->key, POLICY_RPC_INFIX) != NULL ||
-         strstr(notification->key, ".devices.policy.") != NULL;
+  return strstr(notification->key, POLICY_RPC_INFIX) != NULL || strstr(notification->key, ".devices.policy.") != NULL;
 }
 
 // Whether this notification is a response to our rpc request. The Dart AtRpc

--- a/packages/c/sshnpd/tests/test_manager_auth.c
+++ b/packages/c/sshnpd/tests/test_manager_auth.c
@@ -200,9 +200,10 @@ int policy_manager_denies_everyone_test() {
   params.manager_list_len = 1;
   params.policy = "@policy";
 
-  // Policy authorization is unimplemented, so a policy daemon must authorize
-  // nobody -- including an atSign that a --manager list would have accepted.
-  if (is_manager_atsign(&params, "@alice")) {
+  // Managers are approved without a policy check even when a policy service
+  // is configured; anyone else is not a manager (the daemon then refers them
+  // to the policy service instead).
+  if (!is_manager_atsign(&params, "@alice")) {
     return 1;
   }
   if (is_manager_atsign(&params, "@eve")) {

--- a/packages/c/sshnpd/tests/test_policy.c
+++ b/packages/c/sshnpd/tests/test_policy.c
@@ -1,0 +1,118 @@
+// Tests for the policy service response parsing and permitOpen matching
+#include <sshnpd/policy.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int failures = 0;
+
+static void check(bool ok, const char *what) {
+  if (!ok) {
+    printf("FAIL: %s\n", what);
+    failures++;
+  } else {
+    printf("ok: %s\n", what);
+  }
+}
+
+static void test_parse_success(void) {
+  sshnpd_policy_decision decision;
+  memset(&decision, 0, sizeof(decision));
+  char resp_type[16] = "";
+
+  const char *json = "{\"reqId\":1756215032123456,\"respType\":\"success\","
+                     "\"payload\":{\"authorized\":true,\"message\":null,"
+                     "\"permitOpen\":[\"localhost:22\",\"*:3389\"]},\"message\":null}";
+  check(policy_parse_response_value(json, 1756215032123456LL, &decision, resp_type, sizeof(resp_type)) == 0,
+        "success response parses");
+  check(strcmp(resp_type, "success") == 0, "respType is success");
+  check(decision.authorized, "authorized is true");
+  check(decision.permit_open_len == 2, "two permitOpen entries");
+  check(decision.permit_open_len == 2 && strcmp(decision.permit_open[0], "localhost:22") == 0 &&
+            strcmp(decision.permit_open[1], "*:3389") == 0,
+        "permitOpen entries round trip");
+  policy_decision_free(&decision);
+  // double free must be safe
+  policy_decision_free(&decision);
+}
+
+static void test_parse_req_id_mismatch(void) {
+  sshnpd_policy_decision decision;
+  memset(&decision, 0, sizeof(decision));
+  char resp_type[16] = "";
+  const char *json = "{\"reqId\":42,\"respType\":\"success\","
+                     "\"payload\":{\"authorized\":true,\"permitOpen\":[\"*:*\"]}}";
+  check(policy_parse_response_value(json, 43, &decision, resp_type, sizeof(resp_type)) != 0,
+        "mismatched reqId is rejected");
+  check(!decision.authorized, "mismatched reqId does not authorize");
+  policy_decision_free(&decision);
+}
+
+static void test_parse_nack_and_garbage(void) {
+  sshnpd_policy_decision decision;
+  memset(&decision, 0, sizeof(decision));
+  char resp_type[16] = "";
+
+  const char *nack = "{\"reqId\":7,\"respType\":\"nack\",\"payload\":{},\"message\":\"no\"}";
+  check(policy_parse_response_value(nack, 7, &decision, resp_type, sizeof(resp_type)) == 0 && !decision.authorized &&
+            strcmp(resp_type, "nack") == 0,
+        "nack parses as deny");
+
+  check(policy_parse_response_value("not json at all", 7, &decision, resp_type, sizeof(resp_type)) != 0,
+        "garbage is rejected");
+  check(policy_parse_response_value("{\"respType\":\"success\"}", 7, &decision, resp_type, sizeof(resp_type)) != 0,
+        "missing reqId is rejected");
+
+  const char *ack = "{\"reqId\":7,\"respType\":\"ack\",\"payload\":{}}";
+  check(policy_parse_response_value(ack, 7, &decision, resp_type, sizeof(resp_type)) == 0 &&
+            strcmp(resp_type, "ack") == 0 && !decision.authorized,
+        "ack parses without authorizing");
+  policy_decision_free(&decision);
+}
+
+static void test_permits_open(void) {
+  sshnpd_policy_decision decision;
+  memset(&decision, 0, sizeof(decision));
+
+  check(!policy_permits_open(&decision, "localhost", 22), "empty list permits nothing");
+
+  char *entries[] = {"localhost:22", "*:3389", "webserver:*", "bad-entry-no-colon", "10.0.0.1:8080"};
+  decision.permit_open = calloc(5, sizeof(char *));
+  for (int i = 0; i < 5; i++) {
+    decision.permit_open[i] = strdup(entries[i]);
+  }
+  decision.permit_open_len = 5;
+  decision.authorized = true;
+
+  check(policy_permits_open(&decision, "localhost", 22), "exact host:port match");
+  check(!policy_permits_open(&decision, "localhost", 23), "port mismatch denied");
+  check(policy_permits_open(&decision, "anyhost", 3389), "wildcard host matches");
+  check(policy_permits_open(&decision, "webserver", 443), "wildcard port matches");
+  check(!policy_permits_open(&decision, "webserve", 443), "host prefix does not match");
+  check(!policy_permits_open(&decision, "webserverx", 443), "host with suffix does not match");
+  check(policy_permits_open(&decision, "10.0.0.1", 8080), "ip entry matches");
+  check(!policy_permits_open(&decision, "bad-entry-no-colon", 0), "malformed entry is skipped");
+
+  policy_decision_free(&decision);
+
+  // *:* permits everything
+  decision.permit_open = calloc(1, sizeof(char *));
+  decision.permit_open[0] = strdup("*:*");
+  decision.permit_open_len = 1;
+  check(policy_permits_open(&decision, "anything", 12345), "*:* permits everything");
+  policy_decision_free(&decision);
+}
+
+int main() {
+  test_parse_success();
+  test_parse_req_id_mismatch();
+  test_parse_nack_and_garbage();
+  test_permits_open();
+
+  if (failures > 0) {
+    printf("%d failures\n", failures);
+    return 1;
+  }
+  printf("all passed\n");
+  return 0;
+}

--- a/packages/c/sshnpd/tests/test_policy.c
+++ b/packages/c/sshnpd/tests/test_policy.c
@@ -103,11 +103,44 @@ static void test_permits_open(void) {
   policy_decision_free(&decision);
 }
 
+static void test_is_policy_service_message(void) {
+  sshnpd_params params;
+  memset(&params, 0, sizeof(params));
+  params.policy = "@wisefrog";
+
+  atclient_atnotification n;
+  memset(&n, 0, sizeof(n));
+
+  // Config push from the policy service in reply to a heartbeat
+  n.from = "@wisefrog";
+  n.key = "@ssh_1:config.mailbox.devices.policy.sshnp@wisefrog";
+  check(policy_is_policy_service_message(&n, &params), "config push from policy atsign is policy traffic");
+
+  // A late rpc response that missed its wait window
+  n.key = "@ssh_1:success.1787795933474969.auth_checks.__rpcs.sshnp@wisefrog";
+  check(policy_is_policy_service_message(&n, &params), "rpc response from policy atsign is policy traffic");
+
+  // The same key shapes from anyone else are NOT policy traffic
+  n.from = "@mallory";
+  check(!policy_is_policy_service_message(&n, &params), "rpc-shaped key from another atsign is not policy traffic");
+
+  // A genuine request from the policy atsign's key shape is not matched
+  n.from = "@wisefrog";
+  n.key = "@ssh_1:npt_request.mailbox.sshnp@wisefrog";
+  check(!policy_is_policy_service_message(&n, &params), "session request key is not policy traffic");
+
+  // No policy configured - nothing matches
+  params.policy = NULL;
+  n.key = "@ssh_1:config.mailbox.devices.policy.sshnp@wisefrog";
+  check(!policy_is_policy_service_message(&n, &params), "no policy configured means no policy traffic");
+}
+
 int main() {
   test_parse_success();
   test_parse_req_id_mismatch();
   test_parse_nack_and_garbage();
   test_permits_open();
+  test_is_policy_service_message();
 
   if (failures > 0) {
     printf("%d failures\n", failures);


### PR DESCRIPTION
> [!NOTE]
> **Ready for review.** Stacked on #2865 → #2864; merge in order — this PR’s diff is clean against #2865’s branch. Full CI runs once the bases merge and this retargets to trunk. End-to-end verification of the whole feature set is being run on the `cconstab/c-2831-integration` branch.

## What this does

Part 3 of 3 for #2831: enables `--policy-manager` / `-p` in csshnpd and implements the NPA auth-check RPC protocol, matching the Dart daemon and the Arduino daemon (used as the C reference).

## Protocol

- Request: notification `@policy:request.<reqId>.auth_checks.__rpcs.sshnp@daemon`, value `{"reqId":<epoch µs>,"payload":{"daemonAtsign","daemonDeviceName","daemonDeviceGroupName","clientAtsign"}}`, encrypted, 30s expiry. `reqId` is epoch-microseconds like Dart's `AtRpc` (a boot counter would collide with the policy server's 30s request mutex across daemon restarts — a real bug in the Arduino implementation this port avoids).
- Response: `ack` resets the 10s clock; `success` carries `{authorized, message, permitOpen[]}`; `nack`/`error`/timeout/garbage ⇒ **fail closed**. Only the configured policy atSign may answer — the sender is checked before the reqId, since the key pattern alone binds a response to nobody.

## Semantics (follows the Dart daemon where it and Arduino differ)

- At least one of `--manager` / `--policy-manager` required; **managers short-circuit** the policy check (Dart behavior; Arduino ignores the manager list in policy mode).
- Policy `permitOpen` is enforced **in addition to** the daemon's own `--permit-open` (Dart ANDs them; Arduino replaces). With `-p` and no explicit `--permit-open`, the daemon's own list defaults to `*:*` (Dart #1295), so policy is the effective ACL out of the box.
- Matching grammar: `host:port`, `*` wildcards, split on last colon, malformed entries skipped, `authorized:true` + empty `permitOpen` denies everything.
- Device heartbeat `<device>.devices.policy` (the ping response JSON) sent to the policy service at startup and every 5 minutes.
- In policy mode the monitor subscribes unfiltered — RPC response keys don't contain the `<device>.sshnp@` substring the normal filter uses.

## Design note: synchronous wait

csshnpd's main loop is single-threaded, so while an auth check is in flight the daemon reads the monitor looking for the RPC response and **drops unrelated notifications** it encounters (logged), like the Arduino daemon's single in-flight slot. The policy decision gates every notification type (ping, sshpublickey, ssh_request, npt_request), same as Dart's pre-dispatch `authCheck`. Denials are a silent drop + log, consistent with csshnpd's existing unauthorized handling. Not ported (yet): Dart's 15s per-client decision cache, `--device-group` (sends `__none__`), and the `config` push subscription for event logging (csshnpd has no event logging).

## Testing so far

- New `test_policy` unit test: response parsing (success/ack/nack, reqId mismatch, garbage, missing fields) and `permitOpen` matching (wildcards, malformed entries, empty-list-denies, `*:*`). `leaks --atExit`: 0 leaks.
- `test_manager_auth` updated: managers now short-circuit when a policy manager is configured (the old test asserted the unimplemented-policy stub that denied everyone).
- All 7 unit tests pass; CLI sanity: `-p @policy` accepted, permit-open defaults to `*:*`, arg validation intact.

## Remaining end-to-end verification (tracked on the `cconstab/c-2831-integration` branch)

- [ ] End-to-end against a real policy service (`npp_file` with a test policy YAML): manager short-circuit, authorized/denied clients, permitOpen narrowing, timeout fail-closed
- [ ] Confirm the RPC response key form from a real Dart policy service (code matches on the `.auth_checks.__rpcs` infix so both the `.sshnp`-suffixed and unsuffixed forms match)
- [ ] Verify heartbeat appears in the policy service's device view
- [ ] Consider a short per-client decision cache (Dart uses 15s) if ping+npt bursts double-hit the policy service
- [ ] OpenWRT target build/test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
