### PR TITLE
feat: ephemeral tunnel key in csshnpd (PARKED - sshnp --no-et tunnel mode)

### DIFF
--- a/packages/c/sshnpd/CMakeLists.txt
+++ b/packages/c/sshnpd/CMakeLists.txt
@@ -13,6 +13,7 @@ set(
   ${CMAKE_CURRENT_LIST_DIR}/src/daemon.c
   ${CMAKE_CURRENT_LIST_DIR}/src/daemon_utils.c
   ${CMAKE_CURRENT_LIST_DIR}/src/device_info.c
+  ${CMAKE_CURRENT_LIST_DIR}/src/ephemeral_key.c
   ${CMAKE_CURRENT_LIST_DIR}/src/file_utils.c
   ${CMAKE_CURRENT_LIST_DIR}/src/handle_npt_request.c
   ${CMAKE_CURRENT_LIST_DIR}/src/handle_ping.c

--- a/packages/c/sshnpd/include/sshnpd/ephemeral_key.h
+++ b/packages/c/sshnpd/include/sshnpd/ephemeral_key.h
@@ -1,0 +1,71 @@
+#ifndef SSHNPD_EPHEMERAL_KEY_H
+#define SSHNPD_EPHEMERAL_KEY_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+// The ephemeral tunnel key flow (parity with the Dart daemon's
+// startDirectSsh): for each ssh_request session the daemon generates a
+// throwaway ssh keypair, authorizes the public key in authorized_keys with a
+// restrictive entry (forced command + PermitOpen to the local sshd only),
+// returns the private key to the client in the session response, and removes
+// the authorized_keys entry shortly afterwards. The client uses it to bring
+// up the initial tunnel ssh session, inside which --remote-sshd-port style
+// forwards are made by sshd itself.
+
+/**
+ * @brief Generate a throwaway ssh keypair for one session by running
+ * ssh-keygen (no shell involved; the session id is validated first).
+ *
+ * The key files are written under directory (created 0700 if needed), read
+ * into memory and unlinked before returning.
+ *
+ * @param directory directory for the transient key files, e.g. $HOME/.sshnp
+ * @param use_rsa true for rsa-4096, false for ed25519 (the default)
+ * @param session_id the session id (uuid); also used in the file name
+ * @param private_key_pem receives the malloc'd private key file contents
+ * @param public_key receives the malloc'd public key line
+ * @return int 0 on success
+ */
+int generate_ephemeral_ssh_keypair(const char *directory, bool use_rsa, const char *session_id,
+                                   char **private_key_pem, char **public_key);
+
+/**
+ * @brief Append the ephemeral public key to authorized_keys, restricted the
+ * same way the Dart daemon restricts it:
+ * `command="echo \"ssh session complete\";sleep 20",PermitOpen="localhost:<port>"[,extra] <key> sshnp_ephemeral_<sid>`
+ *
+ * @param authkeys_file the daemon's open authorized_keys stream
+ * @param authkeys_filename path of the authorized_keys file
+ * @param public_key the public key line from generate_ephemeral_ssh_keypair
+ * @param local_sshd_port the only host:port the tunnel session may open
+ * @param session_id the session id (uuid)
+ * @param extra_permissions extra authorized_keys options ('--ephemeral-permission'), may be NULL or ""
+ * @return int 0 on success
+ */
+int authorize_ephemeral_public_key(FILE *authkeys_file, char *authkeys_filename, const char *public_key,
+                                   uint16_t local_sshd_port, const char *session_id, const char *extra_permissions);
+
+/**
+ * @brief Remove this session's ephemeral key entry from authorized_keys.
+ * @return int 0 on success (including when no entry was present)
+ */
+int deauthorize_ephemeral_public_key(FILE *authkeys_file, const char *authkeys_filename, const char *session_id);
+
+/**
+ * @brief Queue this session's ephemeral key for removal from
+ * authorized_keys 15 seconds from now (long enough for the client to bring
+ * up the tunnel session). Processed by ephemeral_key_sweep_deauthorizations.
+ * If the queue is full the oldest queued key is removed immediately to make
+ * room, hence the file arguments.
+ */
+void ephemeral_key_schedule_deauthorize(FILE *authkeys_file, const char *authkeys_filename, const char *session_id);
+
+/**
+ * @brief Remove any queued ephemeral keys whose grace period has passed.
+ * Called from the daemon main loop; single threaded by design.
+ */
+void ephemeral_key_sweep_deauthorizations(FILE *authkeys_file, const char *authkeys_filename);
+
+#endif

--- a/packages/c/sshnpd/include/sshnpd/handler_commons.h
+++ b/packages/c/sshnpd/include/sshnpd/handler_commons.h
@@ -37,7 +37,10 @@ int setup_rvd_session_encryption(cJSON *payload, unsigned char **session_aes_key
 // The d2c key and iv may be NULL. When they are provided the response payload
 // uses the twinned key field names (aesKeyC2D/ivC2D/aesKeyD2C/ivD2C), matching
 // the Dart sshnpd; otherwise the legacy names (sessionAESKey/sessionIV).
-int send_success_payload(cJSON *payload, atclient *atclient, sshnpd_params *params, char *session_aes_key_c2d_base64,
+// ephemeral_private_key: the tunnel ssh private key generated for this
+// session (ssh_request flow), or NULL when the session has none (npt flow)
+int send_success_payload(cJSON *payload, atclient *atclient, sshnpd_params *params, char *ephemeral_private_key,
+                         char *session_aes_key_c2d_base64,
                          char *session_iv_c2d_base64, char *session_aes_key_d2c_base64, char *session_iv_d2c_base64,
                          atchops_rsa_key_private_key *signing_key, char *requesting_atsign);
 

--- a/packages/c/sshnpd/src/daemon.c
+++ b/packages/c/sshnpd/src/daemon.c
@@ -27,6 +27,7 @@
 #include <mbedtls/psa_util.h>
 #include <sshnpd/daemon.h>
 #include <sshnpd/file_utils.h>
+#include <sshnpd/ephemeral_key.h>
 #include <sshnpd/policy.h>
 #include <sshnpd/run_srv_process.h>
 #include <stdio.h>
@@ -92,6 +93,7 @@ void main_loop() {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Sending next device info\n");
     send_next_device_info(&worker, &params);
     policy_send_heartbeat(&worker, &params, ping_response);
+    ephemeral_key_sweep_deauthorizations(authkeys_file, authkeys_filename);
 
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Waiting for next monitor thread message\n");
     atclient_monitor_message_init(&message);

--- a/packages/c/sshnpd/src/ephemeral_key.c
+++ b/packages/c/sshnpd/src/ephemeral_key.c
@@ -1,0 +1,313 @@
+#include "sshnpd/ephemeral_key.h"
+#include "sshnpd/file_utils.h"
+#include <atlogger/atlogger.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#define LOGGER_TAG "EPHEMERAL KEY"
+
+// How long after the session response the ephemeral key stays authorized -
+// long enough for the client to bring up the tunnel ssh session (the Dart
+// daemon uses the same 15 second window)
+#define EPHEMERAL_DEAUTH_DELAY_SECONDS 15
+
+#define EPHEMERAL_DEAUTH_SLOTS 16
+
+#define EPHEMERAL_MARKER_PREFIX "sshnp_ephemeral_"
+
+// The session id ends up in a file name, in ssh-keygen argv and in an
+// authorized_keys line, so restrict it to the characters a uuid can contain
+static bool session_id_is_safe(const char *session_id) {
+  size_t len = strlen(session_id);
+  if (len == 0 || len > 40) {
+    return false;
+  }
+  for (size_t i = 0; i < len; i++) {
+    char c = session_id[i];
+    if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '-')) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static char *read_file_alloc(const char *path) {
+  FILE *f = fopen(path, "r");
+  if (f == NULL) {
+    return NULL;
+  }
+  if (fseek(f, 0, SEEK_END) != 0) {
+    fclose(f);
+    return NULL;
+  }
+  long size = ftell(f);
+  if (size < 0 || fseek(f, 0, SEEK_SET) != 0) {
+    fclose(f);
+    return NULL;
+  }
+  char *buf = malloc(size + 1);
+  if (buf == NULL) {
+    fclose(f);
+    return NULL;
+  }
+  size_t nread = fread(buf, 1, size, f);
+  fclose(f);
+  buf[nread] = '\0';
+  return buf;
+}
+
+int generate_ephemeral_ssh_keypair(const char *directory, bool use_rsa, const char *session_id,
+                                   char **private_key_pem, char **public_key) {
+  *private_key_pem = NULL;
+  *public_key = NULL;
+
+  if (!session_id_is_safe(session_id)) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Refusing to generate a key for an unsafe session id\n");
+    return 1;
+  }
+
+  if (mkdir(directory, 0700) != 0 && errno != EEXIST) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to create %s: %s\n", directory, strerror(errno));
+    return 1;
+  }
+
+  char key_path[512];
+  int written = snprintf(key_path, sizeof(key_path), "%s/ephemeral_%s", directory, session_id);
+  if (written < 0 || (size_t)written >= sizeof(key_path)) {
+    return 1;
+  }
+  char pub_path[520];
+  snprintf(pub_path, sizeof(pub_path), "%s.pub", key_path);
+
+  // Make sure a stale file from a crashed run can't make ssh-keygen prompt
+  unlink(key_path);
+  unlink(pub_path);
+
+  // Same ssh-keygen invocations as the Dart daemon's LocalSshKeyUtil
+  char *const argv_ed25519[] = {"ssh-keygen", "-t", "ed25519", "-a", "100", "-f", key_path, "-q", "-N", "", NULL};
+  char *const argv_rsa[] = {"ssh-keygen", "-t", "rsa", "-b", "4096", "-f", key_path, "-q", "-N", "", NULL};
+  char *const *keygen_argv = use_rsa ? argv_rsa : argv_ed25519;
+
+  pid_t pid = fork();
+  if (pid < 0) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to fork for ssh-keygen: %s\n", strerror(errno));
+    return 1;
+  }
+  if (pid == 0) {
+    execvp("ssh-keygen", keygen_argv);
+    _exit(127); // exec failed (e.g. ssh-keygen not installed)
+  }
+
+  int status = 0;
+  if (waitpid(pid, &status, 0) < 0 || !WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ssh-keygen failed (status %d)\n",
+                 WIFEXITED(status) ? WEXITSTATUS(status) : -1);
+    unlink(key_path);
+    unlink(pub_path);
+    return 1;
+  }
+
+  *private_key_pem = read_file_alloc(key_path);
+  *public_key = read_file_alloc(pub_path);
+
+  // The transient files are removed regardless; the private key only ever
+  // leaves this process inside the encrypted session response
+  unlink(key_path);
+  unlink(pub_path);
+
+  if (*private_key_pem == NULL || *public_key == NULL) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to read the generated key files\n");
+    free(*private_key_pem);
+    free(*public_key);
+    *private_key_pem = NULL;
+    *public_key = NULL;
+    return 1;
+  }
+  return 0;
+}
+
+int authorize_ephemeral_public_key(FILE *authkeys_file, char *authkeys_filename, const char *public_key,
+                                   uint16_t local_sshd_port, const char *session_id, const char *extra_permissions) {
+  if (!session_id_is_safe(session_id)) {
+    return 1;
+  }
+
+  if (extra_permissions == NULL) {
+    extra_permissions = "";
+  }
+  // Extra options join the comma separated option list (mirrors the Dart
+  // daemon's handling of --ephemeral-permissions)
+  const char *extra_sep = "";
+  if (extra_permissions[0] != '\0' && extra_permissions[0] != ',') {
+    extra_sep = ",";
+  }
+
+  char permissions[512];
+  int written = snprintf(permissions, sizeof(permissions),
+                         "command=\"echo \\\"ssh session complete\\\";sleep 20\",PermitOpen=\"localhost:%d\"%s%s",
+                         local_sshd_port, extra_sep, extra_permissions);
+  if (written < 0 || (size_t)written >= sizeof(permissions)) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "authorized_keys options line too long\n");
+    return 1;
+  }
+
+  // '<public key> sshnp_ephemeral_<session id>' - the marker makes the entry
+  // findable for removal
+  size_t key_size = strlen(public_key) + strlen(EPHEMERAL_MARKER_PREFIX) + strlen(session_id) + 3;
+  char *key = malloc(key_size);
+  if (key == NULL) {
+    return 1;
+  }
+  size_t pub_len = strlen(public_key);
+  while (pub_len > 0 && (public_key[pub_len - 1] == '\n' || public_key[pub_len - 1] == '\r' ||
+                         public_key[pub_len - 1] == ' ')) {
+    pub_len--;
+  }
+  snprintf(key, key_size, "%.*s %s%s\n", (int)pub_len, public_key, EPHEMERAL_MARKER_PREFIX, session_id);
+
+  authkeys_params akp;
+  akp.authkeys_file = authkeys_file;
+  akp.authkeys_filename = authkeys_filename;
+  akp.permissions = permissions;
+  akp.key = key;
+
+  int ret = authorize_ssh_public_key(&akp);
+  free(key);
+  return ret;
+}
+
+int deauthorize_ephemeral_public_key(FILE *authkeys_file, const char *authkeys_filename, const char *session_id) {
+  if (!session_id_is_safe(session_id)) {
+    return 1;
+  }
+
+  char marker[64];
+  int written = snprintf(marker, sizeof(marker), "%s%s", EPHEMERAL_MARKER_PREFIX, session_id);
+  if (written < 0 || (size_t)written >= sizeof(marker)) {
+    return 1;
+  }
+
+  int ret = 0;
+  flockfile(authkeys_file);
+
+  // Read the whole file, then rewrite it without this session's entry. The
+  // freopen pattern (also used by authorize_ssh_public_key) keeps the
+  // daemon's long lived FILE stream valid.
+  FILE *reopened = freopen(authkeys_filename, "r", authkeys_file);
+  if (reopened == NULL) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to reopen %s: %s\n", authkeys_filename,
+                 strerror(errno));
+    funlockfile(authkeys_file);
+    return 1;
+  }
+
+  char **lines = NULL;
+  size_t num_lines = 0;
+  bool found = false;
+
+  char *buf = NULL;
+  size_t bufsize = 0;
+  while (getline(&buf, &bufsize, authkeys_file) >= 0) {
+    if (strstr(buf, marker) != NULL) {
+      found = true;
+      continue; // drop this line
+    }
+    char **grown = realloc(lines, (num_lines + 1) * sizeof(char *));
+    if (grown == NULL) {
+      ret = 1;
+      goto exit;
+    }
+    lines = grown;
+    lines[num_lines] = strdup(buf);
+    if (lines[num_lines] == NULL) {
+      ret = 1;
+      goto exit;
+    }
+    num_lines++;
+  }
+
+  if (!found) {
+    // Nothing to remove; leave the file untouched
+    goto exit;
+  }
+
+  reopened = freopen(authkeys_filename, "w", authkeys_file);
+  if (reopened == NULL) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to rewrite %s: %s\n", authkeys_filename,
+                 strerror(errno));
+    ret = 1;
+    goto exit;
+  }
+  for (size_t i = 0; i < num_lines; i++) {
+    if (fputs(lines[i], authkeys_file) < 0) {
+      ret = 1;
+      break;
+    }
+  }
+  fflush(authkeys_file);
+  atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Removed ephemeral key for session %s\n", session_id);
+
+exit:
+  free(buf);
+  for (size_t i = 0; i < num_lines; i++) {
+    free(lines[i]);
+  }
+  free(lines);
+  funlockfile(authkeys_file);
+  return ret;
+}
+
+// Queue of sessions whose ephemeral keys are due for removal. The daemon
+// main loop is single threaded, so no locking is needed.
+static struct {
+  bool used;
+  time_t due;
+  char session_id[48];
+} deauth_queue[EPHEMERAL_DEAUTH_SLOTS];
+
+void ephemeral_key_schedule_deauthorize(FILE *authkeys_file, const char *authkeys_filename, const char *session_id) {
+  if (!session_id_is_safe(session_id)) {
+    return;
+  }
+  int slot = -1;
+  int oldest = 0;
+  for (int i = 0; i < EPHEMERAL_DEAUTH_SLOTS; i++) {
+    if (!deauth_queue[i].used) {
+      slot = i;
+      break;
+    }
+    if (deauth_queue[i].due < deauth_queue[oldest].due) {
+      oldest = i;
+    }
+  }
+  if (slot < 0) {
+    // Queue full (16 sessions inside one grace window) - revoke the oldest
+    // key now, most of its grace period has already passed
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN,
+                 "Deauthorize queue is full - removing the ephemeral key for session %s early\n",
+                 deauth_queue[oldest].session_id);
+    deauthorize_ephemeral_public_key(authkeys_file, authkeys_filename, deauth_queue[oldest].session_id);
+    slot = oldest;
+  }
+  deauth_queue[slot].used = true;
+  deauth_queue[slot].due = time(NULL) + EPHEMERAL_DEAUTH_DELAY_SECONDS;
+  snprintf(deauth_queue[slot].session_id, sizeof(deauth_queue[slot].session_id), "%s", session_id);
+}
+
+void ephemeral_key_sweep_deauthorizations(FILE *authkeys_file, const char *authkeys_filename) {
+  time_t now = time(NULL);
+  for (int i = 0; i < EPHEMERAL_DEAUTH_SLOTS; i++) {
+    if (deauth_queue[i].used && now >= deauth_queue[i].due) {
+      if (deauthorize_ephemeral_public_key(authkeys_file, authkeys_filename, deauth_queue[i].session_id) != 0) {
+        atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN, "Failed to remove ephemeral key for session %s\n",
+                     deauth_queue[i].session_id);
+      }
+      deauth_queue[i].used = false;
+    }
+  }
+}

--- a/packages/c/sshnpd/src/handle_npt_request.c
+++ b/packages/c/sshnpd/src/handle_npt_request.c
@@ -261,7 +261,7 @@ void handle_npt_request(atclient *atclient, sshnpd_params *params, bool *is_chil
       goto cancel;
     }
 
-    res = send_success_payload(payload, atclient, params, session_aes_key_c2d_base64, session_iv_c2d_base64,
+    res = send_success_payload(payload, atclient, params, NULL, session_aes_key_c2d_base64, session_iv_c2d_base64,
                                session_aes_key_d2c_base64, session_iv_d2c_base64, &signing_key, requesting_atsign);
     if (res != 0) {
       atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR,

--- a/packages/c/sshnpd/src/handle_ssh_request.c
+++ b/packages/c/sshnpd/src/handle_ssh_request.c
@@ -10,6 +10,7 @@
 #include <atlogger/atlogger.h>
 #include <errno.h>
 #include <sshnpd/daemon.h>
+#include <sshnpd/ephemeral_key.h>
 #include <sshnpd/handle_ssh_request.h>
 #include <sshnpd/handler_commons.h>
 #include <sshnpd/run_srv_process.h>
@@ -221,8 +222,43 @@ void handle_ssh_request(atclient *atclient, sshnpd_params *params, bool *is_chil
       goto cancel;
     }
 
-    res = send_success_payload(payload, atclient, params, session_aes_key_c2d_base64, session_iv_c2d_base64,
-                               session_aes_key_d2c_base64, session_iv_d2c_base64, &signing_key, requesting_atsign);
+    // Generate and authorize the ephemeral tunnel key for this session, and
+    // return the private half to the client in the session response. The
+    // client needs it to bring up the initial tunnel ssh session when rvd
+    // traffic is not e2e encrypted (and for client-side port forwards such
+    // as sshnp --remote-sshd-port). Failure is not fatal: clients using
+    // encrypted rvd traffic connect with their own identity keys.
+    char *ephemeral_private_key = NULL;
+    char *ephemeral_public_key = NULL;
+    char *session_id_str = cJSON_GetStringValue(cJSON_GetObjectItem(payload, "sessionId"));
+    if (session_id_str != NULL) {
+      char keygen_dir[512];
+      snprintf(keygen_dir, sizeof(keygen_dir), "%s/.sshnp", home_dir);
+      res = generate_ephemeral_ssh_keypair(keygen_dir, params->ssh_algorithm == RSA, session_id_str,
+                                           &ephemeral_private_key, &ephemeral_public_key);
+      if (res == 0) {
+        res = authorize_ephemeral_public_key(authkeys_file, authkeys_filename, ephemeral_public_key,
+                                             params->local_sshd_port, session_id_str, params->ephemeral_permission);
+        if (res == 0) {
+          ephemeral_key_schedule_deauthorize(authkeys_file, authkeys_filename, session_id_str);
+        } else {
+          free(ephemeral_private_key);
+          ephemeral_private_key = NULL;
+        }
+      }
+      if (res != 0) {
+        atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN,
+                     "Could not set up an ephemeral tunnel key for this session - clients which need the initial "
+                     "tunnel ssh session will not be able to connect\n");
+        res = 0;
+      }
+    }
+
+    res = send_success_payload(payload, atclient, params, ephemeral_private_key, session_aes_key_c2d_base64,
+                               session_iv_c2d_base64, session_aes_key_d2c_base64, session_iv_d2c_base64, &signing_key,
+                               requesting_atsign);
+    free(ephemeral_private_key);
+    free(ephemeral_public_key);
     if (res != 0) {
       atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
                    "Failed to send success message to the requesting atsign: %s\n", requesting_atsign);

--- a/packages/c/sshnpd/src/handler_commons.c
+++ b/packages/c/sshnpd/src/handler_commons.c
@@ -532,8 +532,9 @@ int setup_rvd_session_encryption(cJSON *payload, unsigned char **session_aes_key
   return res;
 }
 
-int send_success_payload(cJSON *payload, atclient *atclient, sshnpd_params *params, char *session_aes_key_c2d_base64,
-                         char *session_iv_c2d_base64, char *session_aes_key_d2c_base64, char *session_iv_d2c_base64,
+int send_success_payload(cJSON *payload, atclient *atclient, sshnpd_params *params, char *ephemeral_private_key,
+                         char *session_aes_key_c2d_base64, char *session_iv_c2d_base64,
+                         char *session_aes_key_d2c_base64, char *session_iv_d2c_base64,
                          atchops_rsa_key_private_key *signing_key, char *requesting_atsign) {
   int res = 0;
   bool twin_keys = session_aes_key_d2c_base64 != NULL && session_iv_d2c_base64 != NULL;
@@ -542,6 +543,9 @@ int send_success_payload(cJSON *payload, atclient *atclient, sshnpd_params *para
   cJSON *final_res_payload = cJSON_CreateObject();
   cJSON_AddStringToObject(final_res_payload, "status", "connected");
   cJSON_AddItemReferenceToObject(final_res_payload, "sessionId", session_id);
+  if (ephemeral_private_key != NULL) {
+    cJSON_AddStringToObject(final_res_payload, "ephemeralPrivateKey", ephemeral_private_key);
+  }
   if (twin_keys) {
     cJSON_AddStringToObject(final_res_payload, "aesKeyC2D", (char *)session_aes_key_c2d_base64);
     cJSON_AddStringToObject(final_res_payload, "ivC2D", (char *)session_iv_c2d_base64);

--- a/packages/c/sshnpd/src/params.c
+++ b/packages/c/sshnpd/src/params.c
@@ -20,6 +20,7 @@ void apply_default_values_to_sshnpd_params(sshnpd_params *params) {
   params->hide = 0;
   params->verbose = 0;
   params->ssh_algorithm = ED25519;
+  params->ephemeral_permission = "";
   params->root_domain = "root.atsign.org";
   params->local_sshd_port = 22;
   params->storage_path = NULL;
@@ -52,7 +53,9 @@ int parse_sshnpd_params(sshnpd_params *params, int argc, const char **argv) {
                  "Comma separated-list of host:port to which the daemon will permit a connection from an authorized "
                  "client. (defaults to \"localhost:22,localhost:3389\")"),
       OPT_STRING(0, "ssh-algorithm", &ssh_algorithm_input, "SSH algorithm to use"),
-      OPT_STRING(0, "ephemeral-permission", &ephemeral_permissions, "(Kept for compatibility)"),
+      OPT_STRING(0, "ephemeral-permission", &ephemeral_permissions,
+                 "Additional authorized_keys options for the ephemeral tunnel key entries (comma separated, appended "
+                 "to the built-in restrictions)"),
       OPT_STRING(0, "root-domain", &params->root_domain, "Root domain to use. If a host but no port is specified (e.g. 'root.atsign.org'), the default port 64 will be appended (defaults to \"root.atsign.org:64\")"),
       OPT_INTEGER(0, "local-sshd-port", &params->local_sshd_port, "Local sshd port to use"),
       OPT_STRING(0, "storage-path", &params->storage_path, NULL),
@@ -109,6 +112,10 @@ int parse_sshnpd_params(sshnpd_params *params, int argc, const char **argv) {
     } else {
       printf("%s:%d\n", params->permitopen_hosts[i], params->permitopen_ports[i]);
     }
+  }
+
+  if (ephemeral_permissions != NULL) {
+    params->ephemeral_permission = ephemeral_permissions;
   }
 
   if (strlen(ssh_algorithm_input) != 0) {

--- a/packages/c/sshnpd/tests/test_ephemeral_key.c
+++ b/packages/c/sshnpd/tests/test_ephemeral_key.c
@@ -1,0 +1,120 @@
+// Tests for the ephemeral tunnel key flow: keypair generation (via
+// ssh-keygen), the restricted authorized_keys entry, and removal.
+#include <sshnpd/ephemeral_key.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static int failures = 0;
+
+static void check(bool ok, const char *what) {
+  if (!ok) {
+    printf("FAIL: %s\n", what);
+    failures++;
+  } else {
+    printf("ok: %s\n", what);
+  }
+}
+
+static char *read_all(const char *path) {
+  FILE *f = fopen(path, "r");
+  if (f == NULL) {
+    return NULL;
+  }
+  static char buf[8192];
+  size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+  buf[n] = '\0';
+  fclose(f);
+  return buf;
+}
+
+int main() {
+  // Everything works against a scratch directory and scratch
+  // authorized_keys file
+  char dir_template[] = "/tmp/test_ephemeral_key_XXXXXX";
+  char *dir = mkdtemp(dir_template);
+  if (dir == NULL) {
+    printf("FAIL: mkdtemp\n");
+    return 1;
+  }
+
+  char authkeys_path[512];
+  snprintf(authkeys_path, sizeof(authkeys_path), "%s/authorized_keys", dir);
+  FILE *authkeys = fopen(authkeys_path, "w+");
+  check(authkeys != NULL, "create scratch authorized_keys");
+  fputs("ssh-ed25519 AAAAexistingkey user@host\n", authkeys);
+  fflush(authkeys);
+
+  // Unsafe session ids must be rejected everywhere
+  char *priv = NULL, *pub = NULL;
+  check(generate_ephemeral_ssh_keypair(dir, false, "bad/../id", &priv, &pub) != 0, "keygen rejects path traversal");
+  check(generate_ephemeral_ssh_keypair(dir, false, "bad id;rm", &priv, &pub) != 0, "keygen rejects shell chars");
+  check(authorize_ephemeral_public_key(authkeys, authkeys_path, "ssh-ed25519 AAAA", 22, "bad$id", "") != 0,
+        "authorize rejects unsafe session id");
+
+  // If ssh-keygen isn't available, skip the generation-dependent tests
+  if (system("command -v ssh-keygen >/dev/null 2>&1") != 0) {
+    printf("ssh-keygen not found - skipping generation tests\n");
+    fclose(authkeys);
+    return failures > 0 ? 1 : 0;
+  }
+
+  const char *session_id = "9b6350cd-3ac6-4d47-9d43-a1d5bbcbe553";
+  check(generate_ephemeral_ssh_keypair(dir, false, session_id, &priv, &pub) == 0 && priv != NULL && pub != NULL,
+        "generate ed25519 keypair");
+  check(priv != NULL && strstr(priv, "OPENSSH PRIVATE KEY") != NULL, "private key looks like an openssh key");
+  check(pub != NULL && strncmp(pub, "ssh-ed25519 ", 12) == 0, "public key is ed25519");
+
+  // Transient key files must be gone
+  char key_path[600];
+  snprintf(key_path, sizeof(key_path), "%s/ephemeral_%s", dir, session_id);
+  check(access(key_path, F_OK) != 0, "private key file was removed");
+  snprintf(key_path, sizeof(key_path), "%s/ephemeral_%s.pub", dir, session_id);
+  check(access(key_path, F_OK) != 0, "public key file was removed");
+
+  // Authorize and inspect the entry
+  check(authorize_ephemeral_public_key(authkeys, authkeys_path, pub, 2222, session_id, "no-agent-forwarding") == 0,
+        "authorize ephemeral key");
+  char *content = read_all(authkeys_path);
+  check(content != NULL && strstr(content, "ssh-ed25519 AAAAexistingkey user@host") != NULL,
+        "pre-existing entry untouched");
+  check(content != NULL &&
+            strstr(content, "command=\"echo \\\"ssh session complete\\\";sleep 20\",PermitOpen=\"localhost:2222\""
+                            ",no-agent-forwarding ssh-ed25519 ") != NULL,
+        "entry has forced command, PermitOpen and extra permissions");
+  char marker[64];
+  snprintf(marker, sizeof(marker), "sshnp_ephemeral_%s", session_id);
+  check(content != NULL && strstr(content, marker) != NULL, "entry carries the session marker");
+
+  // Deauthorize removes exactly this entry
+  check(deauthorize_ephemeral_public_key(authkeys, authkeys_path, session_id) == 0, "deauthorize succeeds");
+  content = read_all(authkeys_path);
+  check(content != NULL && strstr(content, marker) == NULL, "entry removed");
+  check(content != NULL && strstr(content, "ssh-ed25519 AAAAexistingkey user@host") != NULL,
+        "other entries survive removal");
+
+  // Removing a session that has no entry is a no-op success
+  check(deauthorize_ephemeral_public_key(authkeys, authkeys_path, "00000000-0000-0000-0000-000000000000") == 0,
+        "deauthorize of unknown session is a no-op");
+
+  // The sweep path end to end: schedule with a full queue is exercised in
+  // real use; here just confirm an immediate-past due entry gets removed
+  check(authorize_ephemeral_public_key(authkeys, authkeys_path, pub, 22, session_id, NULL) == 0,
+        "re-authorize for sweep test");
+  ephemeral_key_schedule_deauthorize(authkeys, authkeys_path, session_id);
+  ephemeral_key_sweep_deauthorizations(authkeys, authkeys_path);
+  content = read_all(authkeys_path);
+  check(content != NULL && strstr(content, marker) != NULL, "sweep respects the grace period");
+
+  free(priv);
+  free(pub);
+  fclose(authkeys);
+
+  if (failures > 0) {
+    printf("%d failures\n", failures);
+    return 1;
+  }
+  printf("all passed\n");
+  return 0;
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Parked — we suggest ignoring this need for now.** The ephemeral tunnel key only matters for `sshnp --no-encrypt-rvd-traffic` (the pre-E2EE legacy tunnel mode). On a modern stack there is no reason to disable socket E2EE, and the two real-world needs it appeared to serve are already covered without it:
> - `sshnp` with default settings (E2EE on) works against csshnpd today — clients only demand `ephemeralPrivateKey` when `--no-et` is passed
> - a non-standard sshd port is served by daemon-side `--local-sshd-port`, or by `npt -rp <port>` (which is what NoPorts Desktop does)
>
> Meanwhile this is the largest security/maintenance surface of the csshnpd parity PRs: per-session `authorized_keys` rewrites, an `ssh-keygen` exec (often absent on dropbear-only OpenWRT images), and private keys in responses. Not worth it for a legacy client mode with no known users on C daemons.
>
> **The implementation is complete and unit-tested, and stays here in case the need arises** — if a real `--no-et`-against-csshnpd use case turns up, this can be rebased and taken to end-to-end testing. It has been dropped from the `cconstab/c-2831-integration` test branch. Suggested documentation stance: *csshnpd supports sshnp with encrypted relay traffic (the default); `--no-et` tunnel mode is unsupported.*

---

## What this does

Implements the **ephemeral tunnel key** flow in `ssh_request` handling, which is what "supporting `sshnp --remote-sshd-port 2222`" actually requires on the daemon side.

## Why this would be the fix for --remote-sshd-port

`--remote-sshd-port` never travels to the daemon — the `SshnpSessionRequest` payload carries no sshd port at all. Instead, the Dart client (both openssh and dartPure impls) reaches the alternate port by making an ssh port-forward (`-L …:localhost:2222` / `startForwarding`) **inside an initial tunnel ssh session to the daemon's sshd**, authenticated with an ephemeral key that the daemon generates, authorizes, and returns as `ephemeralPrivateKey` in the session response. csshnpd never returned that key, so tunnel-mode clients fail with `Expected an ephemeral private key from device daemon, but it was not set`.

Two behavioral notes (true against Dart daemons too, this is client-side design):
- The tunnel session (and therefore `--remote-sshd-port`) is only used when `encryptRvdTraffic == false` (`--no-et`). With e2ee on (the default), the user's ssh lands directly on the **daemon's** `--local-sshd-port` and the client's `--remote-sshd-port` is a no-op.
- The daemon's own srv always bridges to `--local-sshd-port`; csshnpd already supports that flag.

## Changes (ports Dart `startDirectSsh` exactly)

- **`ephemeral_key.c` (new)**:
  - keypair generation via the same ssh-keygen invocations as Dart's `LocalSshKeyUtil` (`-t ed25519 -a 100` default; `-t rsa -b 4096` with `--ssh-algorithm ssh-rsa`), via fork/exec (no shell), session id validated to uuid characters first; transient key files unlinked immediately after reading
  - authorized_keys entry byte-matching Dart: `command="echo \"ssh session complete\";sleep 20",PermitOpen="localhost:<port>"[,extra] <pubkey> sshnp_ephemeral_<sessionId>` — reuses the existing `authorize_ssh_public_key`
  - removal 15 seconds after the response (same grace as Dart's `Timer`), swept from the daemon main loop; queue-full evicts the oldest key immediately
- **`handle_ssh_request.c`** — generate + authorize + schedule removal, pass the private key into the response; non-fatal on failure
- **`handler_commons.c`** — `send_success_payload` gains the `ephemeralPrivateKey` field (NULL/omitted for npt)
- **`params.c`** — `--ephemeral-permission` was parsed but dropped; now wired through, matching the Dart daemon's `--ephemeral-permissions`

## Testing done

- New `test_ephemeral_key`: generation round-trip (skipped cleanly when ssh-keygen is absent), transient-file cleanup, unsafe-session-id rejection (path traversal, shell metacharacters), exact entry format incl. extra permissions, removal preserving other entries, no-op removal, and sweep grace-period behavior. `leaks --atExit`: 0 leaks.
- All 10 csshnpd unit tests pass; build clean.

## Would still need before merging (if ever revived)

- [ ] E2E: `sshnp --no-et` (openssh impl) against this daemon — tunnel session comes up with the ephemeral key, forced command + PermitOpen restrictions hold
- [ ] E2E: `sshnp --no-et --remote-sshd-port 2222` with a second sshd on 2222 — user session lands on 2222
- [ ] E2E: `sshnp --ssh-client dart` variant
- [ ] Verify the authorized_keys entry is removed ~15s after connect, and that a client connecting at second 14 stays connected
- [ ] OpenWRT: confirm ssh-keygen availability on the target image (dropbear-only images may need openssh-keygen; the daemon degrades gracefully without it) and dropbear's handling of the forced-command/PermitOpen entry syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)