### PR TITLE
feat: 'proxy:' root domain support in csshnpd (atServer connections via 443)

### DIFF
--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -12,7 +12,9 @@ if(NOT atsdk_FOUND)
     FetchContent_Declare(
       atsdk
       GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-      GIT_TAG 7b2d79e5e162286d4f45854f4d52fcb034c93534
+      # at_c trunk including PR #702: 'proxy:' root server support in
+      # at_activate and the connection CRLF fix required for reverse proxies
+      GIT_TAG f7303da5f3edf522a722a6ecabcae7b9a0db062a
     )
   endif()
   FetchContent_MakeAvailable(atsdk)

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -26,6 +26,7 @@
 #include <sshnpd/daemon.h>
 #include <sshnpd/file_utils.h>
 #include <sshnpd/run_srv_process.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -233,13 +234,15 @@ int main(int argc, char **argv) {
       }
       snprintf(root_host, root_host_size, "%.*s", (int)host_len, root_domain_str);
       const char *port_str = colon_pos + 1;
-      root_port = (uint16_t)atoi(port_str);
-      if (root_port == 0) {
+      char *port_end = NULL;
+      long port_val = strtol(port_str, &port_end, 10);
+      if (port_end == port_str || *port_end != '\0' || port_val < 1 || port_val > UINT16_MAX) {
         atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Root domain port is not a valid number: %s\n", port_str);
         atcommons_memlist_failure_free(&memlist);
         res = 1;
         return res;
       }
+      root_port = (uint16_t)port_val;
     } else {
       // no port specified, use the default port
       snprintf(root_host, root_host_size, "%s", root_domain_str);

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -201,20 +201,38 @@ int main(int argc, char **argv) {
   }
   memset(root_host, 0, sizeof(char) * root_host_size);
   uint16_t root_port = 0;
-  if (params.root_domain != NULL) {
+
+  // A 'proxy:' prefix on --root-domain (e.g. "proxy:proxy0001.atsign.org:443")
+  // means there is no atDirectory: every atServer connection goes to the given
+  // reverse proxy host and port instead. This matches the convention of the
+  // Dart at_lookup package, and lets a daemon run where only port 443 egress
+  // is allowed.
+  bool via_atserver_proxy = false;
+  const char *root_domain_str = params.root_domain;
+  if (root_domain_str != NULL && strncmp(root_domain_str, "proxy:", strlen("proxy:")) == 0) {
+    via_atserver_proxy = true;
+    root_domain_str += strlen("proxy:");
+    if (root_domain_str[0] == '\0') {
+      atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "No host given after 'proxy:' in --root-domain\n");
+      atcommons_memlist_failure_free(&memlist);
+      return 1;
+    }
+  }
+
+  if (root_domain_str != NULL) {
     // root_domain is something like 'root.atsign.wtf:64'
     // get the host and port and set them
-    char *colon_pos = strchr(params.root_domain, ':');
+    const char *colon_pos = strchr(root_domain_str, ':');
     if (colon_pos != NULL) {
-      size_t host_len = colon_pos - params.root_domain;
+      size_t host_len = colon_pos - root_domain_str;
       if (host_len >= host_name_max_length) {
         atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Root domain host name is too long (it is >= %lu\n", host_name_max_length);
         atcommons_memlist_failure_free(&memlist);
         res = 1;
         return res;
       }
-      snprintf(root_host, root_host_size, "%.*s", (int)host_len, params.root_domain);
-      char *port_str = colon_pos + 1;
+      snprintf(root_host, root_host_size, "%.*s", (int)host_len, root_domain_str);
+      const char *port_str = colon_pos + 1;
       root_port = (uint16_t)atoi(port_str);
       if (root_port == 0) {
         atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Root domain port is not a valid number: %s\n", port_str);
@@ -224,7 +242,7 @@ int main(int argc, char **argv) {
       }
     } else {
       // no port specified, use the default port
-      snprintf(root_host, root_host_size, "%s", params.root_domain);
+      snprintf(root_host, root_host_size, "%s", root_domain_str);
       root_port = DEFAULT_ROOT_PORT;
       atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Using root_host: \"%s\" and root_port: %d\n", root_host, root_port);
     }
@@ -232,6 +250,11 @@ int main(int argc, char **argv) {
     // use the default root domain
     snprintf(root_host, root_host_size, "%s", DEFAULT_ROOT_HOST);
     root_port = DEFAULT_ROOT_PORT;
+  }
+  if (via_atserver_proxy) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_INFO,
+                 "atServer connections will go via the reverse proxy %s:%d (no atDirectory lookups)\n", root_host,
+                 root_port);
   }
   atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Using root_host: \"%s\" and root_port: %d\n", root_host, root_port);
 
@@ -254,6 +277,11 @@ int main(int argc, char **argv) {
   }
   atclient_authenticate_options_set_atdirectory_host(&monitor_options, root_host);
   atclient_authenticate_options_set_atdirectory_port(&monitor_options, root_port);
+  if (via_atserver_proxy) {
+    // Setting the atServer address directly bypasses the atDirectory lookup
+    atclient_authenticate_options_set_atserver_host(&monitor_options, root_host);
+    atclient_authenticate_options_set_atserver_port(&monitor_options, root_port);
+  }
 
   // 7.a.3 pkam auth the monitor client
   atclient_monitor_set_read_timeout(&monitor_ctx, MONITOR_READ_TIMEOUT_MS); // 5 seconds for timeout
@@ -281,7 +309,11 @@ int main(int argc, char **argv) {
   }
   atclient_authenticate_options_set_atdirectory_host(&worker_options, root_host);
   atclient_authenticate_options_set_atdirectory_port(&worker_options, root_port);
-
+  if (via_atserver_proxy) {
+    // Setting the atServer address directly bypasses the atDirectory lookup
+    atclient_authenticate_options_set_atserver_host(&worker_options, root_host);
+    atclient_authenticate_options_set_atserver_port(&worker_options, root_port);
+  }
 
   res = atclient_pkam_authenticate(&worker, params.atsign, &atkeys, &worker_options, NULL);
   if (res != 0 || !should_run) {

--- a/packages/c/sshnpd/src/params.c
+++ b/packages/c/sshnpd/src/params.c
@@ -53,7 +53,11 @@ int parse_sshnpd_params(sshnpd_params *params, int argc, const char **argv) {
                  "client. (defaults to \"localhost:22,localhost:3389\")"),
       OPT_STRING(0, "ssh-algorithm", &ssh_algorithm_input, "SSH algorithm to use"),
       OPT_STRING(0, "ephemeral-permission", &ephemeral_permissions, "(Kept for compatibility)"),
-      OPT_STRING(0, "root-domain", &params->root_domain, "Root domain to use. If a host but no port is specified (e.g. 'root.atsign.org'), the default port 64 will be appended (defaults to \"root.atsign.org:64\")"),
+      OPT_STRING(0, "root-domain", &params->root_domain,
+                 "Root domain to use. If a host but no port is specified (e.g. 'root.atsign.org'), the default port 64 "
+                 "will be appended (defaults to \"root.atsign.org:64\"). A 'proxy:' prefix (e.g. "
+                 "\"proxy:proxy0001.atsign.org:443\") skips the atDirectory and connects to every atServer via that "
+                 "reverse proxy instead"),
       OPT_INTEGER(0, "local-sshd-port", &params->local_sshd_port, "Local sshd port to use"),
       OPT_STRING(0, "storage-path", &params->storage_path, NULL),
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Ready for review**, but merge only after atsign-foundation/at_c#702 lands and `packages/c/cmake/atsdk.cmake` is bumped to an at_c trunk hash that contains it — the runtime proxy connection support lives in at_c, so merging this first would ship a `proxy:` option that cannot connect. The integration branch currently pins atsdk to the at_c PR branch for testing.

## What this does

Ports the Dart `at_lookup` `proxy:` root-domain convention to csshnpd. With

```
sshnpd ... --root-domain "proxy:proxy0001.atsign.org:443"
```

the daemon makes **no atDirectory lookups at all**: the address of every atServer is deemed to be the reverse proxy host and port, exactly as `SecondaryUrlFinder.findSecondaryUrl` does in Dart. This lets the daemon run on networks where only port 443 egress is allowed.

## How

Small change, because the C atclient already has the right hook: setting `atserver_host`/`atserver_port` on `atclient_authenticate_options` makes `atclient_pkam_authenticate` skip the atDirectory query entirely (`atclient.c` step 5). So:

- `main.c` root-domain parsing recognizes the `proxy:` prefix (port parsing follows `AtRootDomain.parse`: `proxy:host` → port 64, `proxy:host:port` → given port) and, in proxy mode, sets the atServer override on **both** the monitor and worker authenticate options
- the monitor/worker reconnect paths reuse the same option globals, so reconnections inherit the proxy address
- lookups of other atsigns' public keys (`verify_envelope_signature_from`, manager key caching) go through the daemon's own atServer connection via `plookup`, so no other code path touches the atDirectory — verified by grep, `atdirectory` is only referenced from the authenticate path
- `--root-domain` help text documents the new form

## Testing so far

- Build clean, all unit tests pass.
- Not yet run against a real proxy — needs the e2e checklist below.

## Remaining end-to-end verification (tracked on the `cconstab/c-2831-integration` branch)

- [ ] E2E: daemon starts and authenticates via a real reverse proxy on 443 (`proxy:proxy0001.atsign.org:443`); log shows `atServer connections will go via the reverse proxy ...` and no atDirectory contact
- [ ] Monitor reconnect (leave idle >40s, and force a network blip) still goes via the proxy
- [ ] Regression: plain `--root-domain root.atsign.org:64` and default behavior unchanged
- [ ] Combined with the #2831 stack (timeout/ESCR/policy) on the integration branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
