### PR TITLE
feat: C daemon + srv security hardening (M1–M8, M11)

### DIFF
--- a/packages/c/srv/src/srv.c
+++ b/packages/c/srv/src/srv.c
@@ -28,6 +28,14 @@ static pthread_mutex_t session_mutex = PTHREAD_MUTEX_INITIALIZER;
 static int active_sessions = 0;
 static time_t idle_since = 0;
 
+// Upper bound on concurrent socket-to-socket sessions per srv process. The
+// relay control channel is attacker-reachable and each connect: line spawns a
+// thread + two sockets, so without a cap a malicious relay can exhaust
+// threads/fds. 128 is well above any legitimate fan-out for one daemon.
+#ifndef SRV_MAX_SESSIONS
+#define SRV_MAX_SESSIONS 128
+#endif
+
 static void session_started(void) {
   pthread_mutex_lock(&session_mutex);
   active_sessions++;
@@ -250,6 +258,19 @@ int run_srv_daemon_side_multi(srv_params_t *params) {
                    new_session_aes_key_d2c_string != NULL ? "twinned keys" : "single key");
 
       if (strcmp(messagetype, "connect") == 0) {
+        // Reject before allocating anything if we are at the session cap. Only
+        // this control loop increments active_sessions, so reading it here and
+        // calling session_started() below is not a TOCTOU (the count can only
+        // fall in between, as worker threads finish).
+        pthread_mutex_lock(&session_mutex);
+        bool at_capacity = active_sessions >= SRV_MAX_SESSIONS;
+        pthread_mutex_unlock(&session_mutex);
+        if (at_capacity) {
+          atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_WARN, "Session cap (%d) reached - rejecting connect request\n",
+                       SRV_MAX_SESSIONS);
+          continue;
+        }
+
         chunked_transformer_t *new_socket_encrypter = NULL;
         chunked_transformer_t *new_socket_decrypter = NULL;
         atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG,

--- a/packages/c/srv/src/srv.c
+++ b/packages/c/srv/src/srv.c
@@ -192,7 +192,9 @@ int run_srv_daemon_side_multi(srv_params_t *params) {
       goto exit;
     }
 
-    res = mbedtls_net_recv_timeout(&control_side.socket, buffer, 4096, SRV_CONTROL_POLL_MS);
+    // Leave room for a NUL terminator: the relay bytes are attacker-controlled
+    // and buffer is consumed with strtok_r/"%s", which read until a NUL.
+    res = mbedtls_net_recv_timeout(&control_side.socket, buffer, 4095, SRV_CONTROL_POLL_MS);
     if (res == MBEDTLS_ERR_SSL_TIMEOUT) {
       continue;
     }
@@ -203,6 +205,7 @@ int run_srv_daemon_side_multi(srv_params_t *params) {
       goto exit;
     }
     len = res;
+    buffer[len] = '\0';
 
     if (control_side.transformer != NULL) {
       unsigned char *output = malloc(4096 * sizeof(unsigned char));
@@ -217,6 +220,7 @@ int run_srv_daemon_side_multi(srv_params_t *params) {
       }
       free(buffer);
       buffer = output;
+      buffer[len] = '\0';
     }
 
     char *messagetype = NULL, *new_session_aes_key_c2d_string = NULL, *new_session_aes_iv_c2d_string = NULL,

--- a/packages/c/sshnpd/include/sshnpd/run_srv_process.h
+++ b/packages/c/sshnpd/include/sshnpd/run_srv_process.h
@@ -8,11 +8,16 @@
 
 // Everything the srv needs to run ESCR (encrypted signed challenge response)
 // relay authentication for one session. All pointers are borrowed.
+//
+// signing_key_base64 is the daemon's PKAM private key in base64 (atkeys
+// pkam_private_key_base64). The srv is exec'd as a separate process and reads
+// it from REMOTE_AUTH_ESCR_SIGNING_PRIVKEY, matching the Dart daemon's
+// contract, so the parsed RSA struct is no longer passed across the boundary.
 typedef struct {
   const char *session_id;
-  const char *aes_key_base64;               // the session's relayAuthAesKey
-  const char *signing_key_uri;              // public:_apsk.<enrollmentId>.a.__e<atsign>
-  atchops_rsa_key_private_key *signing_key; // the daemon's PKAM private key
+  const char *aes_key_base64;      // the session's relayAuthAesKey
+  const char *signing_key_uri;     // public:_apsk.<enrollmentId>.a.__e<atsign>
+  const char *signing_key_base64;  // the daemon's PKAM private key, base64
 } sshnpd_escr_context;
 
 // The d2c key and iv may be NULL, in which case the session uses a single key

--- a/packages/c/sshnpd/src/file_utils.c
+++ b/packages/c/sshnpd/src/file_utils.c
@@ -12,20 +12,19 @@ int authorize_ssh_public_key(authkeys_params *params) {
   const char *tag = "AUTH SSH KEY";
   int ret = 0;
 
-  flockfile(params->authkeys_file); // should be safe to call freopen inside a lock, since the FILE stream is preserved
-                                    // in most implementations
-  params->authkeys_file = freopen(params->authkeys_filename, "a+", params->authkeys_file); // reopen file in append mode
-  if (params->authkeys_file == NULL) {
-    atlogger_log(tag, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to freopen authkeys file: %s\n", strerror(errno));
-    if (errno != 0) {
-      ret = errno;
-    } else {
-      ret = 1;
-    }
-    goto exit;
+  // Open a fresh handle per call instead of freopen'ing the shared persistent
+  // FILE*. freopen closes the original stream on failure, which left the
+  // daemon's global authkeys_file dangling (use-after-free on the next
+  // sshpublickey request) and fell through to funlockfile(NULL). This handler
+  // only runs on the single monitor thread, so no cross-call file lock is
+  // needed. The shared read-only handle stays owned by main's cleanup list.
+  FILE *file = fopen(params->authkeys_filename, "a+");
+  if (file == NULL) {
+    atlogger_log(tag, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to open authkeys file: %s\n", strerror(errno));
+    return errno != 0 ? errno : 1;
   }
 
-  ret = fseek(params->authkeys_file, 0, SEEK_SET);
+  ret = fseek(file, 0, SEEK_SET);
   if (ret != 0) {
     atlogger_log(tag, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to seek to the beginning of authkeys file: %s\n",
                  strerror(errno));
@@ -40,7 +39,7 @@ int authorize_ssh_public_key(authkeys_params *params) {
     goto exit;
   }
 
-  while (getline(&buf, &bufsize, params->authkeys_file) >= 0) {
+  while (getline(&buf, &bufsize, file) >= 0) {
     if (strstr(buf, params->key) != NULL) {
       // already exists in the file, moving on
       atlogger_log(tag, ATLOGGER_LOGGING_LEVEL_DEBUG, "Already found key in the file, did not add a second entry\n");
@@ -49,7 +48,7 @@ int authorize_ssh_public_key(authkeys_params *params) {
     }
   }
 
-  ret = fseek(params->authkeys_file, 0, SEEK_END); // on some platforms a+ opens to the end so seek to beginning first
+  ret = fseek(file, 0, SEEK_END); // on some platforms a+ opens to the end so seek to beginning first
   if (ret != 0) {
     atlogger_log(tag, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to seek to the end of authkeys file: %s\n",
                  strerror(errno));
@@ -62,27 +61,27 @@ int authorize_ssh_public_key(authkeys_params *params) {
   }
 
   if (strlen(params->permissions) > 0) {
-    ret = fprintf(params->authkeys_file, "%s %s%s", params->permissions, params->key, postfix);
+    ret = fprintf(file, "%s %s%s", params->permissions, params->key, postfix);
   } else {
-    ret = fprintf(params->authkeys_file, "%s%s", params->key, postfix);
+    ret = fprintf(file, "%s%s", params->key, postfix);
   }
 
   if (ret < 0) {
-    printf("%d\n", ret);
-    atlogger_log(tag, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to append key to authkeys file s: %s\n", strerror(errno));
+    atlogger_log(tag, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to append key to authkeys file: %s\n", strerror(errno));
     goto cleanup;
   }
 
-  ret = fflush(params->authkeys_file);
+  ret = fflush(file);
   if (ret != 0) {
     atlogger_log(tag, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to flush authkeys file: %s\n", strerror(errno));
     goto cleanup;
   }
+  ret = 0;
 
   atlogger_log(tag, ATLOGGER_LOGGING_LEVEL_DEBUG, "Successfully authorized the new public key\n");
 cleanup: { free(buf); }
 exit: {
-  funlockfile(params->authkeys_file);
+  fclose(file);
 
   return ret;
 }

--- a/packages/c/sshnpd/src/handle_npt_request.c
+++ b/packages/c/sshnpd/src/handle_npt_request.c
@@ -123,7 +123,7 @@ void handle_npt_request(atclient *atclient, sshnpd_params *params, bool *is_chil
         escr_context.session_id = session_id_str;
         escr_context.aes_key_base64 = relay_auth_aes_key;
         escr_context.signing_key_uri = escr_signing_key_uri;
-        escr_context.signing_key = &atkeys.pkam_private_key;
+        escr_context.signing_key_base64 = atkeys.pkam_private_key_base64;
         use_escr = true;
         atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Session will use escr relay auth\n");
       } else {

--- a/packages/c/sshnpd/src/handle_ssh_request.c
+++ b/packages/c/sshnpd/src/handle_ssh_request.c
@@ -112,7 +112,7 @@ void handle_ssh_request(atclient *atclient, sshnpd_params *params, bool *is_chil
         escr_context.session_id = session_id_str;
         escr_context.aes_key_base64 = relay_auth_aes_key;
         escr_context.signing_key_uri = escr_signing_key_uri;
-        escr_context.signing_key = &atkeys.pkam_private_key;
+        escr_context.signing_key_base64 = atkeys.pkam_private_key_base64;
         use_escr = true;
         atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Session will use escr relay auth\n");
       } else {

--- a/packages/c/sshnpd/src/handle_sshpublickey.c
+++ b/packages/c/sshnpd/src/handle_sshpublickey.c
@@ -56,7 +56,11 @@ void handle_sshpublickey(sshnpd_params *params, atclient_monitor_message *messag
   authkeys_params authkeys_params = {};
   authkeys_params.authkeys_file = authkeys_file;
   authkeys_params.authkeys_filename = authkeys_filename;
-  authkeys_params.permissions = "";
+  // Scope the pushed key to the local tunnel: an ssh session always reaches
+  // sshd via srv connecting to localhost, so it arrives from 127.0.0.1/::1.
+  // Without this the entry grants unrestricted login from anywhere and lingers
+  // in authorized_keys after the client's authorization is revoked.
+  authkeys_params.permissions = "from=\"127.0.0.1,::1\"";
   authkeys_params.key = ssh_key;
 
   // authorize public key

--- a/packages/c/sshnpd/src/handler_commons.c
+++ b/packages/c/sshnpd/src/handler_commons.c
@@ -246,14 +246,17 @@ int verify_envelope_signature(atchops_rsa_key_public_key *publickey, const unsig
 }
 
 cJSON *extract_envelope_from_notification(atclient_monitor_message *message) {
-  // Sanity check the notification
-  if (!atclient_atnotification_is_from_initialized(message->notification) && message->notification->from != NULL) {
+  // Sanity check the notification. The field must be initialized AND non-NULL;
+  // the guards previously used && (rejecting only the impossible
+  // uninitialized-but-non-NULL case), so a NULL from/decrypted_value fell
+  // through to strlen(NULL) below.
+  if (!atclient_atnotification_is_from_initialized(message->notification) || message->notification->from == NULL) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to initialize the from field of the notification\n");
     return NULL;
   }
 
-  if (!atclient_atnotification_is_decrypted_value_initialized(message->notification) &&
-      message->notification->decrypted_value != NULL) {
+  if (!atclient_atnotification_is_decrypted_value_initialized(message->notification) ||
+      message->notification->decrypted_value == NULL) {
     atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
                  "Failed to initialize the decrypted value of the notification\n");
     return NULL;

--- a/packages/c/sshnpd/src/handler_commons.c
+++ b/packages/c/sshnpd/src/handler_commons.c
@@ -140,6 +140,17 @@ int verify_envelope_signature_from(cJSON *envelope, char *requesting_atsign, atc
   cJSON *signing_algo = cJSON_GetObjectItem(envelope, "signingAlgo");
   cJSON *payload = cJSON_GetObjectItem(envelope, "payload");
 
+  // The envelope is attacker-controlled and has not been shape-validated yet
+  // (verify_envelope_contents runs after this). Reject anything missing the
+  // signed fields before we do the atServer public-key round-trip, otherwise
+  // the cJSON_GetStringValue/cJSON_PrintUnformatted results below are NULL and
+  // strlen/strcmp segfault the daemon.
+  if (!cJSON_IsString(signature) || !cJSON_IsString(hashing_algo) || !cJSON_IsString(signing_algo) || payload == NULL) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
+                 "Envelope missing signature/hashingAlgo/signingAlgo/payload - rejecting\n");
+    return 1;
+  }
+
   int res = 0;
   atclient_atkey atkey;
   atclient_atkey_init(&atkey);
@@ -186,6 +197,12 @@ int verify_envelope_signature_from(cJSON *envelope, char *requesting_atsign, atc
   }
 
   char *payloadstr = cJSON_PrintUnformatted(payload);
+  if (payloadstr == NULL) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to serialize envelope payload\n");
+    free(buffer);
+    atchops_rsa_key_public_key_free(&requesting_atsign_publickey);
+    return 1;
+  }
   res = verify_envelope_signature(&requesting_atsign_publickey, (const unsigned char *)payloadstr,
                                   (unsigned char *)buffer, hashing_algo_str, signing_algo_str);
 

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -27,6 +27,8 @@
 #include <sshnpd/file_utils.h>
 #include <sshnpd/handler_commons.h>
 #include <sshnpd/run_srv_process.h>
+#include <srv/params.h>
+#include <srv/srv.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -64,6 +66,22 @@ static void free_if_not_null(void *ptr) {
 }
 
 int main(int argc, char **argv) {
+  // srv worker mode: run_srv_process re-execs the daemon like this when the
+  // standalone srv binary is not found next to it. Secrets arrive in the
+  // environment; the rest is parsed from argv. This path runs the relay in a
+  // fresh process image (no daemon keys/atServer sockets) and never returns to
+  // daemon startup.
+  if (argc >= 2 && strcmp(argv[1], "--__srv-worker") == 0) {
+    atlogger_set_logging_stream(stderr);
+    srv_params_t srv_params;
+    apply_default_values_to_srv_params(&srv_params);
+    if (parse_srv_params(&srv_params, argc - 1, (const char **)(argv + 1), NULL) != 0) {
+      return 1;
+    }
+    atlogger_set_logging_level(INFO);
+    return run_srv(&srv_params);
+  }
+
   int res = 0;
   atlogger_set_logging_stream(stderr);
 

--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -44,12 +44,16 @@ static void exit_handler(int sig) {
   exit(1);
 }
 static void child_exit_handler(int sig) {
-  atlogger_log("child_exit_handler", ATLOGGER_LOGGING_LEVEL_WARN, "Received signal: %d\n", sig);
-  int status;
-  pid_t pid = waitpid(-1, &status, WNOHANG);
-  if (pid > 0 && WIFEXITED(status)) {
-    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "pid %d exited\n", pid);
+  (void)sig;
+  // SIGCHLD is not queued: several children exiting close together coalesce
+  // into a single delivery, so reap in a loop or zombies accumulate until PID
+  // exhaustion. Only async-signal-safe calls here - waitpid is safe, atlogger
+  // (stdio + locks) is not, so no logging. errno is saved/restored so a signal
+  // landing mid-syscall on the main thread doesn't clobber its errno.
+  int saved_errno = errno;
+  while (waitpid(-1, NULL, WNOHANG) > 0) {
   }
+  errno = saved_errno;
 }
 
 static void free_if_not_null(void *ptr) {

--- a/packages/c/sshnpd/src/params.c
+++ b/packages/c/sshnpd/src/params.c
@@ -204,6 +204,32 @@ int parse_sshnpd_params(sshnpd_params *params, int argc, const char **argv) {
     params->manager_list_len = 0;
   }
 
+  // Normalize the policy atSign the same way as managers. policy.c compares it
+  // case- and dot-sensitively against the canonical `from` the atServer
+  // delivers, so a non-canonical operator value (e.g. "@Policy", "@pol.icy")
+  // would make every policy response fail to match and silently deny all
+  // non-manager clients. That fails safe, but normalize it for parity so the
+  // configured policy service actually works.
+  if (params->policy != NULL) {
+    char *normalized_policy = malloc(SSHNPD_ATSIGN_BUFFER_LEN);
+    if (normalized_policy == NULL) {
+      printf("Failed to allocate memory for normalized policy atSign\n");
+      free(params->normalized_manager_buf);
+      free(params->manager_list);
+      free(params->permitopen_str);
+      return 1;
+    }
+    if (sshnpd_normalize_atsign(params->policy, normalized_policy, SSHNPD_ATSIGN_BUFFER_LEN) != 0) {
+      printf("Invalid policy-manager atSign: \"%s\"\n", params->policy);
+      free(normalized_policy);
+      free(params->normalized_manager_buf);
+      free(params->manager_list);
+      free(params->permitopen_str);
+      return 1;
+    }
+    params->policy = normalized_policy;
+  }
+
   // Repeat for permit-open
   // Convert devicename to lower case
   for (char *c = params->device; c[0] != '\0'; c++) {

--- a/packages/c/sshnpd/src/run_srv_process.c
+++ b/packages/c/sshnpd/src/run_srv_process.c
@@ -4,68 +4,153 @@
 #include <atclient/string_utils.h>
 #include <atlogger/atlogger.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
 #include <sshnpd/run_srv_process.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
 
 #define LOGGER_TAG "RUN SRV"
+
+// The relay is run by self-exec'ing this daemon in a hidden worker mode (see
+// SRV_WORKER_FLAG handling in main.c) rather than in-process, so it starts with
+// a fresh address space that holds none of the daemon's atSign private keys or
+// its authenticated atServer connections. We deliberately re-exec our own
+// already-trusted binary (which links srv-lib) instead of launching a separate
+// srv executable, so there is no external file to plant or replace. Secrets
+// travel via the environment and non-secrets via argv - the same contract the
+// standalone srv binary and the Dart daemon use.
+#define SRV_WORKER_FLAG "--__srv-worker"
+
+// Resolve the absolute path of the currently running executable into buf.
+static int resolve_own_exe(char *buf, size_t bufsize) {
+#ifdef __APPLE__
+  uint32_t size = (uint32_t)bufsize;
+  if (_NSGetExecutablePath(buf, &size) != 0) {
+    return -1;
+  }
+  return 0;
+#else
+  ssize_t n = readlink("/proc/self/exe", buf, bufsize - 1);
+  if (n < 0) {
+    return -1;
+  }
+  buf[n] = '\0';
+  return 0;
+#endif
+}
+
+// Close every descriptor above stderr so the exec'd srv cannot inherit the
+// daemon's open atServer TLS sockets (or any other fd). srv opens its own
+// sockets and only needs stdin/stdout/stderr.
+static void close_inherited_fds(void) {
+  long max_fd = sysconf(_SC_OPEN_MAX);
+  if (max_fd < 0 || max_fd > 65536) {
+    max_fd = 65536;
+  }
+  for (int fd = 3; fd < (int)max_fd; fd++) {
+    close(fd);
+  }
+}
 
 int run_srv_process(const char *srvd_host, uint16_t srvd_port, const char *requested_host, uint16_t requested_port,
                     bool authenticate_to_rvd, char *rvd_auth_string, const sshnpd_escr_context *escr,
                     bool encrypt_rvd_traffic, bool multi, int timeout_seconds, unsigned char *session_aes_key_c2d,
                     unsigned char *session_iv_c2d, unsigned char *session_aes_key_d2c, unsigned char *session_iv_d2c) {
 
-  int res = 0;
-  srv_params_t srv_params;
-  apply_default_values_to_srv_params(&srv_params);
+  const char *local_host = requested_host != NULL ? requested_host : "localhost";
+  uint16_t local_port = requested_port != 0 ? requested_port : 22;
+  int timeout = timeout_seconds > 0 ? timeout_seconds : SRV_DEFAULT_TIMEOUT_SECONDS;
 
-  srv_params.host = (char *)srvd_host;
-  srv_params.port = srvd_port;
+  char srvd_port_str[6], local_port_str[6], timeout_str[16];
+  snprintf(srvd_port_str, sizeof(srvd_port_str), "%u", srvd_port);
+  snprintf(local_port_str, sizeof(local_port_str), "%u", local_port);
+  snprintf(timeout_str, sizeof(timeout_str), "%d", timeout);
 
-  if (requested_host != NULL) {
-    srv_params.local_host = (char *)requested_host;
-  }
-  if (requested_port != 0) {
-    srv_params.local_port = requested_port;
-  }
-
+  // Secrets go through the environment, never argv (argv is world-visible via
+  // ps). These names are the contract parse_srv_params() reads.
   if (escr != NULL) {
-    // ESCR replaces the legacy auth string entirely; the daemon side is
-    // always side b of the session
-    srv_params.escr_auth = true;
-    srv_params.escr_is_side_a = false;
-    srv_params.escr_session_id = (char *)escr->session_id;
-    srv_params.escr_aes_key_base64 = (char *)escr->aes_key_base64;
-    srv_params.escr_signing_key_uri = (char *)escr->signing_key_uri;
-    srv_params.escr_signing_key = escr->signing_key;
-  } else {
-    srv_params.rv_auth = authenticate_to_rvd;
-    srv_params.rvd_auth_string = rvd_auth_string;
+    setenv("REMOTE_AUTH_ESCR_SESSION_ID", escr->session_id, 1);
+    setenv("REMOTE_AUTH_ESCR_AES_KEY", escr->aes_key_base64, 1);
+    setenv("REMOTE_AUTH_ESCR_PUB_KEY_URI", escr->signing_key_uri, 1);
+    setenv("REMOTE_AUTH_ESCR_SIGNING_PRIVKEY", escr->signing_key_base64, 1);
+    setenv("REMOTE_AUTH_ESCR_IS_SIDE_A", "false", 1);
+  } else if (authenticate_to_rvd && rvd_auth_string != NULL) {
+    setenv("RV_AUTH", rvd_auth_string, 1);
+  }
+  if (encrypt_rvd_traffic) {
+    setenv("RV_AES_C2D", (char *)session_aes_key_c2d, 1);
+    setenv("RV_IV_C2D", (char *)session_iv_c2d, 1);
+    if (session_aes_key_d2c != NULL && session_iv_d2c != NULL) {
+      setenv("RV_AES_D2C", (char *)session_aes_key_d2c, 1);
+      setenv("RV_IV_D2C", (char *)session_iv_d2c, 1);
+    }
   }
 
-  srv_params.rv_e2ee = encrypt_rvd_traffic;
-  srv_params.session_aes_key_c2d_string = (char *)session_aes_key_c2d;
-  srv_params.session_aes_iv_c2d_string = (char *)session_iv_c2d;
-  srv_params.session_aes_key_d2c_string = (char *)session_aes_key_d2c;
-  srv_params.session_aes_iv_d2c_string = (char *)session_iv_d2c;
-  srv_params.multi = multi;
-  srv_params.timeout = timeout_seconds > 0 ? timeout_seconds : SRV_DEFAULT_TIMEOUT_SECONDS;
+  // Build the srv argument list (non-secret). Index 0 is filled in per exec
+  // target below (srv binary name, or the daemon path + worker flag).
+  const char *srv_args[24];
+  int n = 0;
+  srv_args[n++] = "-h";
+  srv_args[n++] = srvd_host;
+  srv_args[n++] = "-p";
+  srv_args[n++] = srvd_port_str;
+  srv_args[n++] = "--local-port";
+  srv_args[n++] = local_port_str;
+  srv_args[n++] = "--local-host";
+  srv_args[n++] = local_host;
+  srv_args[n++] = "--timeout";
+  srv_args[n++] = timeout_str;
+  if (multi) {
+    srv_args[n++] = "--multi";
+  }
+  if (encrypt_rvd_traffic) {
+    srv_args[n++] = "--rv-e2ee";
+  }
+  // --rv-auth (legacy) and --relay-auth-mode escr are mutually exclusive in
+  // srv; pick exactly one, matching the auth env vars set above.
+  if (escr != NULL) {
+    srv_args[n++] = "--relay-auth-mode";
+    srv_args[n++] = "escr";
+  } else if (authenticate_to_rvd) {
+    srv_args[n++] = "--rv-auth";
+  }
+
+  char exe_path[PATH_MAX];
+  if (resolve_own_exe(exe_path, sizeof(exe_path)) != 0) {
+    atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to resolve daemon executable path: %s\n",
+                 strerror(errno));
+    return -1;
+  }
 
   atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Starting srv\n");
-  atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "relay: %s:%d\n", srvd_host, srvd_port);
-  atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "requested: %s:%d\n", requested_host, requested_port);
-  atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "rv_auth: %d\n", authenticate_to_rvd);
-  atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "rv_e2ee: %d\n", encrypt_rvd_traffic);
-  atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "multi: %d\n", multi);
-  atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "timeout: %d\n", srv_params.timeout);
+  atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "relay: %s:%s\n", srvd_host, srvd_port_str);
+  atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "requested: %s:%s\n", local_host, local_port_str);
   fflush(stdout);
 
-  atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_INFO);
-  res = run_srv(&srv_params);
+  close_inherited_fds();
 
-  atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "srv exited (with code %d): %s\n", res, strerror(errno));
-  fflush(stdout);
+  // Self-exec only: re-run this exact (already-trusted) binary in srv worker
+  // mode. There is deliberately no path to an external srv binary - that would
+  // add a plant/replace target in the install directory - and the daemon links
+  // srv-lib, so the worker path runs the same relay code in a fresh image with
+  // no inherited daemon keys or atServer sockets.
+  const char *argv[27];
+  int i = 0;
+  argv[i++] = exe_path;
+  argv[i++] = SRV_WORKER_FLAG;
+  for (int j = 0; j < n; j++) {
+    argv[i++] = srv_args[j];
+  }
+  argv[i] = NULL;
+  execv(exe_path, (char *const *)argv);
 
-  return res;
+  atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to self-exec srv worker (%s): %s\n", exe_path,
+               strerror(errno));
+  return -1;
 }


### PR DESCRIPTION
Security hardening for the C `sshnpd` daemon and `srv` relay, from a review of the C daemon + at_activate. One commit per finding (M1–M8).

## Findings fixed (this repo)
| ID | Severity | Summary |
|----|----------|---------|
| M1 | Medium | Reject malformed signed envelopes before deref — missing/mistyped `signature`/`hashingAlgo`/`signingAlgo`/`payload` crashed the parent daemon (remote authenticated DoS) |
| M2 | Low/Med | Inverted `&&`→`||` NULL guards in envelope extraction |
| M3 | Medium | NUL-terminate the 4096-byte relay control buffer (attacker-controlled over-read via strtok/`%s`) |
| M4 | Medium | Cap concurrent relay sessions (`SRV_MAX_SESSIONS=128`) — unbounded thread/fd creation from the control channel |
| M5 | Medium | Open `authorized_keys` per call instead of `freopen`+lock on a shared FILE* (fixed `funlockfile(NULL)` crash + dangling global UAF) |
| M6 | Medium | Reap all children in a `waitpid` loop; async-signal-safe SIGCHLD handler (zombie/PID-exhaustion) |
| M7 | Medium | Scope pushed ssh keys with `from="127.0.0.1,::1"` (were unrestricted + persisted past revocation) |
| M8 | Medium | Run the relay via **self-exec** (`--__srv-worker`) instead of an in-process fork, so it no longer shares an address space with the daemon's private keys / authenticated atServer sockets. Secrets via env, non-secrets via argv (matches the Dart/`srv` contract). Self-exec only — no external binary to plant/replace. |
| M11 | Low | Normalize the `--policy-manager` atSign like managers; a non-canonical value silently denied all non-manager clients (fails safe, but the policy service wouldn't work) |

## Testing
- Verified working over a real relay: **ssh + ESCR + twinned keys + encrypted** session.
- Author confirms the branch works in their environment. Reviewers/QA may still want to spot-check the **npt** path and the **legacy `RV_AUTH`** (non-ESCR) path, since M8 reroutes the launch for all session types.
- [x] Confirm M7's localhost restriction doesn't break any deployment that bridges sshd over a non-loopback local address.
- [x] Decide whether M4's session cap (128) is the right bound; a session recv-timeout was deliberately **not** added (would kill idle tunnels — needs a keepalive design).

## Not included (upstream)
- **M9/M10** (atauth enroll-response NULL-derefs / unchecked decrypt) live in the at_c SDK and need a separate upstream PR.
- The review's **High** items (world-readable `.atKeys`, CRAM/OTP in argv) are also at_c SDK.

Build: `sshnpd` + `srv` compile and link clean; self-exec worker dispatch smoke-tested.

## Follow-up (tracked separately)

- **#2877** — M8 passes the daemon's APKAM/PKAM **identity** key to `srv` (via env) so srv can answer the relay's ESCR challenge. This branch keeps that (net improvement over the old in-process fork, which inherited the daemon's *entire* address space), but the end state is to keep the identity key out of srv entirely (dedicated ESCR key / delegated ephemeral key / daemon-mediated signing). #2877 also captures a cross-protocol signing-oracle concern: ESCR and atServer PKAM auth sign with the same key + algorithm, and are kept safe only by message-format non-collision. Applies to both C and Dart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

