### PR TITLE
chore(c): bump C daemon to 1.1.0 for release

### DIFF
--- a/packages/c/CMakeLists.txt
+++ b/packages/c/CMakeLists.txt
@@ -14,7 +14,7 @@ set(ATSDK_USE_SHARED_LIBS ${NOPORTS_USE_SHARED_LIBS})
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(noports VERSION 1.0.20 LANGUAGES C)
+project(noports VERSION 1.1.0 LANGUAGES C)
 
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/CPackSetup.cmake")
 

--- a/packages/c/srv/CMakeLists.txt
+++ b/packages/c/srv/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
 
-project(srv VERSION 1.0.20 LANGUAGES C)
+project(srv VERSION 1.1.0 LANGUAGES C)
 
 # 1. Variables - you are free to edit anything in this step
 

--- a/packages/c/srv/include/srv/params.h
+++ b/packages/c/srv/include/srv/params.h
@@ -1,6 +1,6 @@
 #ifndef SRV_PARAMS_H
 #define SRV_PARAMS_H
-#define SRV_VERSION "0.1.0"
+#define SRV_VERSION "1.1.0"
 
 // Matches DefaultArgs.srvTimeoutInSeconds in the Dart noports_core package
 #define SRV_DEFAULT_TIMEOUT_SECONDS 30

--- a/packages/c/sshnpd/CMakeLists.txt
+++ b/packages/c/sshnpd/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(sshnpd VERSION 1.0.20 LANGUAGES C)
+project(sshnpd VERSION 1.1.0 LANGUAGES C)
 
 # 1. Variables - you are free to edit anything in this step
 

--- a/packages/c/sshnpd/include/sshnpd/version.h
+++ b/packages/c/sshnpd/include/sshnpd/version.h
@@ -1,4 +1,4 @@
 #ifndef SSHNPD_VERSION_H
 #define SSHNPD_VERSION_H
-#define SSHNPD_VERSION "1.0.20"
+#define SSHNPD_VERSION "1.1.0"
 #endif


### PR DESCRIPTION
Bumps the C daemon version **1.0.20 → 1.1.0** for the `c1.1.0` release (minor bump: the release carries behavioral changes and security hardening, not just patches).

Updates all version locations:
- `packages/c/CMakeLists.txt` — `project(noports VERSION …)`
- `packages/c/srv/CMakeLists.txt` — `project(srv VERSION …)`
- `packages/c/sshnpd/CMakeLists.txt` — `project(sshnpd VERSION …)`
- `packages/c/sshnpd/include/sshnpd/version.h` — `SSHNPD_VERSION`

### Notes
- First minor bump in the `c*` tag series (previous releases were all `c1.0.x` patches). No `1.1.x` tag existed.
- **Sequencing:** this only changes the version string. For `c1.1.0` to actually contain the security fixes, PR #2876 (M1–M8 + M11) should land on `trunk` before the release is cut/tagged.
- **`SRV_VERSION`** in `srv/include/srv/params.h` bumped `0.1.0 → 1.1.0` too. It had never been bumped since the C daemon was first added (`aadeec9fd`) while the CMake versions tracked the releases; srv ships in the same `c*` tag with no independent release, so it's now in step rather than a separate number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
