### PR TITLE
fix: uptake atchops_rsa_encrypt output-buffer bound (at_c#709)

### DIFF
--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -12,9 +12,11 @@ if(NOT atsdk_FOUND)
     FetchContent_Declare(
       atsdk
       GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-      # at_c v0.3.11: adds the enroll-via-proxy fix (at_c#705) on top of the
-      # 'proxy:' root server support and connection CRLF fix from v0.3.10
-      GIT_TAG 06dbc19ce2d1b682b7b51b3a2b5fb4dfdf1b3763
+      # PLACEHOLDER - update before merge: pinned to the at_c#709 PR branch
+      # head (atchops_rsa_encrypt output-buffer bound, breaking signature
+      # change). Replace with the at_c release SHA that contains #709 once it
+      # merges and is released.
+      GIT_TAG 05295c51791a17a8118361cd02d6b5e7ed6b845e
     )
   endif()
   FetchContent_MakeAvailable(atsdk)

--- a/packages/c/cmake/atsdk.cmake
+++ b/packages/c/cmake/atsdk.cmake
@@ -12,11 +12,9 @@ if(NOT atsdk_FOUND)
     FetchContent_Declare(
       atsdk
       GIT_REPOSITORY https://github.com/atsign-foundation/at_c.git
-      # PLACEHOLDER - update before merge: pinned to the at_c#709 PR branch
-      # head (atchops_rsa_encrypt output-buffer bound, breaking signature
-      # change). Replace with the at_c release SHA that contains #709 once it
-      # merges and is released.
-      GIT_TAG 05295c51791a17a8118361cd02d6b5e7ed6b845e
+      # at_c v0.4.0: atchops_rsa_encrypt output-buffer bound (at_c#709,
+      # breaking signature change) on top of the v0.3.11 proxy/enroll support
+      GIT_TAG 295c5d2b43264ac57432d4ceceee7955986d32de
     )
   endif()
   FetchContent_MakeAvailable(atsdk)

--- a/packages/c/sshnpd/src/handler_commons.c
+++ b/packages/c/sshnpd/src/handler_commons.c
@@ -510,7 +510,7 @@ int setup_rvd_session_encryption(cJSON *payload, unsigned char **session_aes_key
         return 1;
       }
 
-      res = atchops_rsa_encrypt(&ac, *session_aes_key, session_aes_key_len, session_aes_key_encrypted);
+      res = atchops_rsa_encrypt(&ac, *session_aes_key, session_aes_key_len, session_aes_key_encrypted, 256, NULL);
       if (res != 0) {
         atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to encrypt the session aes key\n");
         atchops_rsa_key_public_key_free(&ac);
@@ -560,7 +560,7 @@ int setup_rvd_session_encryption(cJSON *payload, unsigned char **session_aes_key
       }
       memset(session_iv_encrypted, 0, BYTES(256));
 
-      res = atchops_rsa_encrypt(&ac, *session_iv, session_iv_len, session_iv_encrypted);
+      res = atchops_rsa_encrypt(&ac, *session_iv, session_iv_len, session_iv_encrypted, 256, NULL);
       atchops_rsa_key_public_key_free(&ac);
       if (res != 0) {
         atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to encrypt the session iv\n");


### PR DESCRIPTION
Uptake PR for atsign-foundation/at_c#709 (fixes atsign-foundation/at_c#701 — `atchops_rsa_encrypt` gains a `ciphertext_size` bound and optional `ciphertext_len` out-param; breaking signature change).

## Changes
- Both call sites in `handler_commons.c` pass the new arguments. These encrypt the session AES key/IV to the **client-supplied** `clientEphemeralPK` — the exact hazard shape from the issue — so the SDK-level bound now backs the existing call-site modulus pre-check (kept as defense in depth for its clearer error).
- atsdk pin: **PLACEHOLDER** on the at_c#709 PR branch head (`05295c51`) so CI can prove the uptake compiles.

## Before undrafting
- [x] at_c#709 merged
- [x] at_c release cut containing it (breaking change → v0.4.0 candidate)
- [x] Bump the pin here to that release's tagged SHA and drop the PLACEHOLDER comment

Verified locally: fresh dev-preset configure fetches `05295c51` and sshnpd builds clean against the new signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)