### PR TITLE
feat(npt_flutter): re-add policy manager status light with version checking

### DIFF
--- a/packages/dart/npt_flutter/lib/features/policy/cubit/status_light/policy_status_light_cubit.dart
+++ b/packages/dart/npt_flutter/lib/features/policy/cubit/status_light/policy_status_light_cubit.dart
@@ -1,18 +1,27 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:at_client/at_client.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:npt_flutter/features/logging/models/logging_bloc.dart';
 import 'package:npt_flutter/features/policy/cubit/status_light/policy_status_light_state.dart';
+import 'package:version/version.dart';
 
 final class PolicyStatusLightCubit
     extends LoggingCubit<PolicyStatusLightState> {
   PolicyStatusLightCubit() : super(const PolicyStatusLightInitial());
 
+  static const String _minHeartbeatCoreVersion = '6.8.1';
+
   final AtSignLogger logger = AtSignLogger('PolicyStatusLightCubit');
 
-  /// Just reads the heartbeat key then emits state accordingly
+  bool _isLoading = false;
+
+  PolicyStatusLightLoaded? _cachedVersionCheckResult;
+
   Future<void> loadStatusLight() async {
+    if (_isLoading) return;
+    _isLoading = true;
     try {
       final AtClient atClient = AtClientManager.getInstance().atClient;
 
@@ -88,7 +97,6 @@ final class PolicyStatusLightCubit
       final DateTime heartbeatUtc = timestamp.toUtc();
       final Duration delta = nowUtc.difference(heartbeatUtc);
 
-      // e.g. if interval is 60 seconds, then heartbeat is fresh if last heartbeat was within the last 60 seconds
       bool isFresh = !delta.isNegative && delta <= interval;
 
       logger.info('Heartbeat check: nowUtc=$nowUtc, heartbeatUtc=$heartbeatUtc, delta=$delta, interval=$interval, isFresh=$isFresh');
@@ -96,11 +104,95 @@ final class PolicyStatusLightCubit
       final LightState lightState = isFresh ? LightState.green : LightState.red;
       final String message = _buildMessage(delta, heartbeatUtc);
 
+      _cachedVersionCheckResult = null;
       emit(PolicyStatusLightLoaded(lightState: lightState, message: message));
     } catch (error) {
-      final String msg = 'Failed to load policy heartbeat: $error';
-      emit(PolicyStatusLightLoaded(lightState: LightState.red, message: msg));
-      logger.severe(msg);
+      logger.severe('Failed to load policy heartbeat: $error');
+      if (_cachedVersionCheckResult != null) {
+        emit(_cachedVersionCheckResult!);
+      } else {
+        await _checkServerVersion(error.toString());
+      }
+    } finally {
+      _isLoading = false;
+    }
+  }
+
+  Future<void> _checkServerVersion(String originalError) async {
+    try {
+      final AtClient atClient = AtClientManager.getInstance().atClient;
+      final currentAtSign = atClient.getCurrentAtSign();
+      if (currentAtSign == null) {
+        const result = PolicyStatusLightLoaded(
+          lightState: LightState.red,
+          message: 'Unable to reach policy server',
+        );
+        _cachedVersionCheckResult = result;
+        emit(result);
+        return;
+      }
+
+      final rpc = AtRpcClient(
+        serverAtsign: currentAtSign,
+        atClient: atClient,
+        baseNameSpace: 'sshnp',
+        domainNameSpace: 'npp',
+      );
+
+      final Map<String, dynamic> response = await rpc
+          .call({'operation': 'ping'})
+          .timeout(const Duration(seconds: 10));
+
+      final String? coreVersionStr = response['coreVersion'] as String?;
+      if (coreVersionStr == null) {
+        const result = PolicyStatusLightLoaded(
+          lightState: LightState.red,
+          message: 'Policy server responded but did not report a version',
+        );
+        _cachedVersionCheckResult = result;
+        emit(result);
+        return;
+      }
+
+      try {
+        final Version serverVersion = Version.parse(coreVersionStr);
+        final Version minVersion = Version.parse(_minHeartbeatCoreVersion);
+
+        if (serverVersion < minVersion) {
+          final result = PolicyStatusLightLoaded(
+            lightState: LightState.yellow,
+            message:
+                'Policy server v$coreVersionStr does not support heartbeat (requires v$_minHeartbeatCoreVersion+)',
+          );
+          _cachedVersionCheckResult = result;
+          emit(result);
+          return;
+        }
+      } on FormatException {
+        final result = PolicyStatusLightLoaded(
+          lightState: LightState.yellow,
+          message:
+              'Policy server reported unrecognized version: $coreVersionStr',
+        );
+        _cachedVersionCheckResult = result;
+        emit(result);
+        return;
+      }
+
+      final result = PolicyStatusLightLoaded(
+        lightState: LightState.red,
+        message: 'Policy server is reachable but heartbeat unavailable: $originalError',
+      );
+      _cachedVersionCheckResult = result;
+      emit(result);
+    } catch (e) {
+      logger.severe('Version check failed: $e');
+      const result = PolicyStatusLightLoaded(
+        lightState: LightState.red,
+        message: 'Unable to reach policy server',
+      );
+      _cachedVersionCheckResult = result;
+      emit(result);
     }
   }
 
@@ -127,33 +219,40 @@ final class PolicyStatusLightCubit
       domainNameSpace: 'npp_atserver_heartbeat',
     );
 
-    final Future<Map<String, dynamic>> rpcFuture = rpc.call({});
+    try {
+      final Map<String, dynamic> response = await rpc
+          .call({})
+          .timeout(const Duration(seconds: 10));
 
-    const int timeoutSeconds = 10;
-    rpcFuture.timeout(const Duration(seconds: timeoutSeconds), onTimeout: () {
-      emit(const PolicyStatusLightLoaded(lightState: LightState.clear, message: 'Heartbeat RPC call timed out after $timeoutSeconds seconds...'));
-      return {'success': false};
-    });
+      if (response['success'] != true) {
+        emit(
+          PolicyStatusLightLoaded(
+            lightState: LightState.red,
+            message:
+                'Failed to force heartbeat onto Policy Server: ${response.toString()}',
+          ),
+        );
+        return;
+      }
 
-    final Map<String, dynamic> response = await rpcFuture;
+      logger.info('Successfully sent RPC call to force heartbeat');
 
-    if (!response['success']) {
-      emit(
-        PolicyStatusLightLoaded(
-          lightState: LightState.red,
-          message:
-              'Failed to force heartbeat onto Policy Server: ${response.toString()}',
-        ),
-      );
-      return;
+      await Future.delayed(const Duration(milliseconds: 500));
+
+      emit(const PolicyStatusLightLoading());
+      _isLoading = false;
+      await loadStatusLight();
+    } on TimeoutException {
+      emit(const PolicyStatusLightLoaded(
+        lightState: LightState.clear,
+        message: 'Heartbeat RPC call timed out after 10 seconds',
+      ));
+    } catch (e) {
+      emit(PolicyStatusLightLoaded(
+        lightState: LightState.red,
+        message: 'Failed to force heartbeat: $e',
+      ));
     }
-
-    logger.info('Successfully sent RPC call to force heartbeat');
-
-    await Future.delayed(const Duration(milliseconds: 500));
-
-    emit(const PolicyStatusLightLoading());
-    await loadStatusLight();
   }
 
   String _buildMessage(Duration delta, DateTime heartbeatUtc) {

--- a/packages/dart/npt_flutter/lib/features/policy/cubit/status_light/policy_status_light_state.dart
+++ b/packages/dart/npt_flutter/lib/features/policy/cubit/status_light/policy_status_light_state.dart
@@ -1,9 +1,10 @@
 import 'package:npt_flutter/features/logging/models/loggable.dart';
 
 enum LightState {
-  green, // connected
-  red, // disconnected
-  clear, // unsure
+  green,
+  yellow,
+  red,
+  clear,
 }
 
 sealed class PolicyStatusLightState extends Loggable {

--- a/packages/dart/npt_flutter/lib/features/policy/widgets/sidebar/policy_status_light.dart
+++ b/packages/dart/npt_flutter/lib/features/policy/widgets/sidebar/policy_status_light.dart
@@ -36,10 +36,14 @@ class PolicyStatusLight extends StatelessWidget {
 
   _StatusIndicatorData _resolveStateData(PolicyStatusLightState state) {
     if (state is PolicyStatusLightLoaded) {
+      final Color color = switch (state.lightState) {
+        LightState.green => AppColor.successColor,
+        LightState.yellow => AppColor.warningColor,
+        LightState.red => AppColor.errorColor,
+        LightState.clear => AppColor.greyColor,
+      };
       return _StatusIndicatorData(
-        color: state.lightState == LightState.green
-            ? AppColor.successColor
-            : AppColor.errorColor,
+        color: color,
         tooltip: state.message ?? _defaultMessage(state.lightState),
       );
     }
@@ -53,8 +57,9 @@ class PolicyStatusLight extends StatelessWidget {
   String _defaultMessage(LightState lightState) {
     return switch (lightState) {
       LightState.green => 'Heartbeat healthy',
+      LightState.yellow => 'Server version outdated',
       LightState.red => 'Heartbeat unavailable',
-      LightState.clear => 'Heartbeat unknown'
+      LightState.clear => 'Heartbeat unknown',
     };
   }
 }

--- a/packages/dart/npt_flutter/lib/features/policy/widgets/sidebar/sidebar_header_widget.dart
+++ b/packages/dart/npt_flutter/lib/features/policy/widgets/sidebar/sidebar_header_widget.dart
@@ -6,6 +6,7 @@ import 'package:npt_flutter/styles/sizes.dart';
 
 import '../../cubit/policy_cubit.dart';
 import '../../cubit/status_light/policy_status_light_cubit.dart';
+import 'policy_status_light.dart';
 
 class SidebarHeaderWidget extends StatelessWidget {
   const SidebarHeaderWidget({super.key});
@@ -14,11 +15,9 @@ class SidebarHeaderWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final strings = AppLocalizations.of(context)!;
     return BlocProvider(
-      create: (_) => PolicyStatusLightCubit(),
+      create: (_) => PolicyStatusLightCubit()..loadStatusLight(),
       child: BlocBuilder<PolicyStatusLightCubit, PolicyStatusLightState>(
         builder: (context, state) {
-          final policyCubit = context.read<PolicyStatusLightCubit>();
-          policyCubit.loadStatusLight();
           return Padding(
             padding: const EdgeInsets.all(Sizes.p8),
             child: Row(
@@ -30,7 +29,7 @@ class SidebarHeaderWidget extends StatelessWidget {
                   ),
                 ),
                 const Spacer(),
-                // const PolicyStatusLight(),
+                const PolicyStatusLight(),
                 gapW12,
                 IconButton(
                   icon: const Icon(Icons.refresh),

--- a/packages/dart/npt_flutter/lib/styles/app_color.dart
+++ b/packages/dart/npt_flutter/lib/styles/app_color.dart
@@ -18,5 +18,6 @@ class AppColor {
   static const errorColorAlt = Color(0xFFFFEEEE);
   static const outlinePaddingColor = Color(0xFFEAEAEA);
   static const textFieldBorderColor = Color(0xFFD9D9D9);
+  static const warningColor = Color(0xFFE5A100);
   static const greyColor = Color(0xFFE2E2E2);
 }

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -1004,7 +1004,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.12.0"
+    version: "6.13.0"
   objective_c:
     dependency: transitive
     description:
@@ -1550,26 +1550,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   toml:
     dependency: "direct main"
     description:


### PR DESCRIPTION
closes https://github.com/atsign-foundation/operations/issues/239

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Re-enables the heartbeat status light in the policy manager sidebar that was removed in #2244. Adds server version detection so the light shows yellow when the deployed npp_atserver predates heartbeat support (< v6.8.1), with a tooltip explaining the minimum version required.

**- How I did it**

- Uncommented PolicyStatusLight in sidebar header, moved loadStatusLight() to BlocProvider create cascade
- Added LightState.yellow and AppColor.warningColor for outdated server state
- Added _checkServerVersion(): on heartbeat failure, pings server via manager RPC and compares coreVersion against minimum 6.8.1
- Fixed forceHeartbeat() race condition, added loading guard, cached version check result

**- How to verify it**

- Green: npp_atserver >= v6.8.1 running, heartbeat fresh
- Yellow: server reachable but version < v6.8.1 (simulate by setting _minHeartbeatCoreVersion to '99.0.0')
- Red: server unreachable or heartbeat stale
- Hover refreshes status, refresh button triggers force heartbeat

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Re-added policy manager status light with server version checking