### PR TITLE
chore: Bump versions for c1.1.0 release

### DIFF
--- a/docs/installation/openwrt-installation-guide.md
+++ b/docs/installation/openwrt-installation-guide.md
@@ -41,10 +41,10 @@ Those command line snippets set some variables for the `RELEASE` number, `ARCH` 
 
 Packages are installed using `opkg install` for OpenWrt 24.10 and earlier releases that use `.ipk` type packages, or `apk add` for newer OpenWrt which uses `.apk` packages.
 
-For example, to install the c1.0.20 release:
+For example, to install the c1.1.0 release:
 
 ```
-RELEASE="1.0.20"
+RELEASE="1.1.0"
 ARCH=$(opkg print-architecture | grep ' 10$' | awk '{print $2}')
 PACKAGE="csshnpd_${RELEASE}-1_${ARCH}.ipk"
 wget -O ${PACKAGE} https://github.com/atsign-foundation/Atsign_OpenWrt_packages/releases/download/c${RELEASE}/${PACKAGE}

--- a/packages/c/cmake/CPackSetup.cmake
+++ b/packages/c/cmake/CPackSetup.cmake
@@ -1,7 +1,7 @@
 # package info
 set(CPACK_PACKAGE_NAME noports)
 set(CPACK_PACKAGE_DESCRIPTION "noports source tarballs")
-set(CPACK_PACKAGE_VERSION 1.0.20)
+set(CPACK_PACKAGE_VERSION 1.1.0)
 set(CPACK_PACKAGE_VENDOR_NAME atsign-foundation)
 
 # cmake configuration

--- a/packages/c/conanfile.py
+++ b/packages/c/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.files import get
 
 class at_cRecipe(ConanFile):
     name = "noports"
-    version = "1.0.20"
+    version = "1.1.0"
     package_type = "application"
 
     # Optional metadata

--- a/packages/c/graceful-shutdown-tool/CMakeLists.txt
+++ b/packages/c/graceful-shutdown-tool/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 cmake_policy(SET CMP0135 NEW)
-project(graceful-shutdown-tool VERSION 1.0.20 LANGUAGES C)
+project(graceful-shutdown-tool VERSION 1.1.0 LANGUAGES C)
 
 include(FetchContent)
 include(GNUInstallDirs)

--- a/packages/c/sshnpd/CHANGELOG.md
+++ b/packages/c/sshnpd/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 1.1.0
+
+- fix: validate --root-domain port with strtol instead of atoi
+- fix: don't log an error when the public signing key doesn't exist yet 
+- fix: bring the monitor filters to exact Dart daemon parity
+- fix: anchor the device name in the devices.policy monitor filter alternative
+- fix: filter the policy-mode monitor server side like the Dart daemon
+- fix: don't treat policy service traffic as session requests
+- feat: support 'proxy:' root domains in csshnpd
+- feat: tell clients why a session request was denied (Dart daemon parity)
+- feat: policy service (--policy-manager) support in csshnpd
+- feat: ESCR relay authentication in csshnpd and c srv (supportsRamEscr)
+- feat: adjustableTimeout support in csshnpd
+- fix: log a summary after sharing username keys with manager atSigns
+- fix: sshnpd C daemon manager list handling and exact -m authorization
+- fix: stop leaking buffer and socket fd when a side thread is cancelled
+- feat: Add twinned session key (twinKeys) support to C sshnpd and srv
+
 ## 1.0.20
 
 - fix: only manager Atsigns can establish sshnp connections with csshnpd


### PR DESCRIPTION
c1.1.0 release didn't have source tarball

**- What I did**

* Bumped version to c1.1.0
* Added changelog entries

**- How I did it**

Search for c1.0.20 and modify files

**- How to verify it**

Redo c1.1.0 release

**- Description for the changelog**

chore: Bump versions for c1.1.0 release
