### PR TITLE
fix: C daemon filter device Atsign from manager Atsign list

### DIFF
--- a/packages/c/sshnpd/src/main.c
+++ b/packages/c/sshnpd/src/main.c
@@ -84,6 +84,7 @@ int main(int argc, char **argv) {
 
   int res = 0;
   atlogger_set_logging_stream(stderr);
+  atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_INFO);
 
   // setup initial values for global variables
   is_child_process = false;

--- a/packages/c/sshnpd/src/params.c
+++ b/packages/c/sshnpd/src/params.c
@@ -211,6 +211,17 @@ int parse_sshnpd_params(sshnpd_params *params, int argc, const char **argv) {
       }
       params->manager_list[filtered_count++] = slot;
     }
+    if (filtered_count == 0) {
+      atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
+                   "Manager list is empty after filtering out device atSign\n");
+      free(norm_buf);
+      free(params->manager_list);
+      params->manager_list = NULL;
+      params->manager_list_len = 0;
+      free(params->permitopen_str);
+      params->permitopen_str = NULL;
+      return 1;
+    }
     params->manager_list_len = filtered_count;
     params->normalized_manager_buf = norm_buf;
   } else {

--- a/packages/c/sshnpd/src/params.c
+++ b/packages/c/sshnpd/src/params.c
@@ -1,3 +1,4 @@
+#include <atlogger/atlogger.h>
 #include <errno.h>
 #include <sshnpd/authorization.h>
 #include <sshnpd/params.h>
@@ -7,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define LOGGER_TAG "sshnpd - params"
 #define default_permitopen "localhost:22,localhost:3389"
 void apply_default_values_to_sshnpd_params(sshnpd_params *params) {
   params->key_file = NULL;
@@ -188,8 +190,13 @@ int parse_sshnpd_params(sshnpd_params *params, int argc, const char **argv) {
       free(params->permitopen_str);
       return 1;
     }
+    char normalized_device_atsign[SSHNPD_ATSIGN_BUFFER_LEN];
+    bool has_normalized_device_atsign =
+        (sshnpd_normalize_atsign(params->atsign, normalized_device_atsign, sizeof(normalized_device_atsign)) == 0);
+
+    size_t filtered_count = 0;
     for (size_t i = 0; i < params->manager_list_len; i++) {
-      char *slot = norm_buf + i * SSHNPD_ATSIGN_BUFFER_LEN;
+      char *slot = norm_buf + filtered_count * SSHNPD_ATSIGN_BUFFER_LEN;
       if (sshnpd_normalize_atsign(params->manager_list[i], slot, SSHNPD_ATSIGN_BUFFER_LEN) != 0) {
         printf("Invalid manager atSign: \"%s\"\n", params->manager_list[i]);
         free(norm_buf);
@@ -197,8 +204,14 @@ int parse_sshnpd_params(sshnpd_params *params, int argc, const char **argv) {
         free(params->permitopen_str);
         return 1;
       }
-      params->manager_list[i] = slot;
+      if (has_normalized_device_atsign && strcmp(slot, normalized_device_atsign) == 0) {
+        atlogger_log(LOGGER_TAG, ATLOGGER_LOGGING_LEVEL_WARN,
+                     "Device atSign \"%s\" included in --manager list; filtering out\n", slot);
+        continue;
+      }
+      params->manager_list[filtered_count++] = slot;
     }
+    params->manager_list_len = filtered_count;
     params->normalized_manager_buf = norm_buf;
   } else {
     params->manager_list_len = 0;

--- a/packages/c/sshnpd/tests/test_sshnpd_params.c
+++ b/packages/c/sshnpd/tests/test_sshnpd_params.c
@@ -1,3 +1,4 @@
+#include <atlogger/atlogger.h>
 #include "sshnpd/params.h"
 #include "sshnpd/permitopen.h"
 #include <stdio.h>
@@ -14,6 +15,7 @@ int device_lower_test();
 int manager_list_test();
 int manager_list_trailing_comma_test();
 int manager_list_filter_device_atsign_test();
+int manager_list_filter_device_atsign_error_logged_test();
 
 int main() {
   int ret = 0;
@@ -52,6 +54,10 @@ int main() {
   }
   if (manager_list_filter_device_atsign_test()) {
     printf("manager_list_filter_device_atsign_test failed\n");
+    ret++;
+  }
+  if (manager_list_filter_device_atsign_error_logged_test()) {
+    printf("manager_list_filter_device_atsign_error_logged_test failed\n");
     ret++;
   }
 
@@ -469,14 +475,17 @@ int manager_list_filter_device_atsign_test() {
   struct {
     const char *device_atsign;
     const char *manager_input;
+    int expected_ret;
     size_t expected_len;
     const char *expected[2];
   } cases[] = {
-      {"@device", "@alice,@device,@bob", 2, {"@alice", "@bob"}},
-      {"@device", "@device,@alice", 1, {"@alice", NULL}},
-      {"@device", "@alice,@device", 1, {"@alice", NULL}},
-      {"@device", "@Device,@alice", 1, {"@alice", NULL}},
-      {"@device", "@device", 0, {NULL, NULL}},
+      {"@device", "@alice,@device,@bob", 0, 2, {"@alice", "@bob"}},
+      {"@device", "@device,@alice", 0, 1, {"@alice", NULL}},
+      {"@device", "@alice,@device", 0, 1, {"@alice", NULL}},
+      {"@device", "@Device,@alice", 0, 1, {"@alice", NULL}},
+      {"@device", "@device", 1, 0, {NULL, NULL}},
+      {"@device", "@Device", 1, 0, {NULL, NULL}},
+      {"@device", "@device,@Device", 1, 0, {NULL, NULL}},
   };
 
   for (size_t c = 0; c < sizeof(cases) / sizeof(cases[0]); c++) {
@@ -495,7 +504,22 @@ int manager_list_filter_device_atsign_test() {
     };
 
     apply_default_values_to_sshnpd_params(params);
-    if (parse_sshnpd_params(params, 7, argv) != 0) {
+    int parse_ret = parse_sshnpd_params(params, 7, argv);
+    if (cases[c].expected_ret != 0) {
+      if (parse_ret == 0) {
+        printf("  input \"%s\": expected failure, but parse succeeded\n", cases[c].manager_input);
+        free(manager_str);
+        free(params);
+        return 1;
+      }
+      free(manager_str);
+      free(params);
+      continue;
+    }
+
+    if (parse_ret != 0) {
+      printf("  input \"%s\": expected parse success, but got %d\n", cases[c].manager_input, parse_ret);
+      free(manager_str);
       free(params);
       return 1;
     }
@@ -503,6 +527,7 @@ int manager_list_filter_device_atsign_test() {
     if (params->manager_list_len != cases[c].expected_len) {
       printf("  input \"%s\": expected len %zu, got %zu\n", cases[c].manager_input, cases[c].expected_len,
              params->manager_list_len);
+      free(manager_str);
       free(params);
       return 1;
     }
@@ -510,12 +535,68 @@ int manager_list_filter_device_atsign_test() {
       if (strcmp(params->manager_list[i], cases[c].expected[i]) != 0) {
         printf("  input \"%s\": expected [%zu] \"%s\", got \"%s\"\n", cases[c].manager_input, i, cases[c].expected[i],
                params->manager_list[i]);
+        free(manager_str);
         free(params);
         return 1;
       }
     }
 
+    free(manager_str);
     free(params);
+  }
+
+  return 0;
+}
+
+int manager_list_filter_device_atsign_error_logged_test() {
+  FILE *tmp = tmpfile();
+  if (tmp == NULL) {
+    return 1;
+  }
+  atlogger_set_logging_stream(tmp);
+  atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_INFO);
+
+  sshnpd_params *params = malloc(sizeof(sshnpd_params));
+  if (params == NULL) {
+    fclose(tmp);
+    return 1;
+  }
+
+  char *manager_str = strdup("@device");
+  if (manager_str == NULL) {
+    free(params);
+    fclose(tmp);
+    return 1;
+  }
+
+  const char *argv[] = {
+      "sshnpd", "-a", "@device", "-m", manager_str, "-d", "my_device",
+  };
+
+  apply_default_values_to_sshnpd_params(params);
+  int parse_ret = parse_sshnpd_params(params, 7, argv);
+
+  // Restore logger stream and level
+  atlogger_set_logging_stream(stdout);
+  atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_NONE);
+
+  free(manager_str);
+  free(params);
+
+  if (parse_ret == 0) {
+    fclose(tmp);
+    return 1;
+  }
+
+  rewind(tmp);
+  char log_buf[1024];
+  size_t bytes_read = fread(log_buf, 1, sizeof(log_buf) - 1, tmp);
+  log_buf[bytes_read] = '\0';
+  fclose(tmp);
+
+  if (strstr(log_buf, "ERROR") == NULL || strstr(log_buf, "Manager list is empty after filtering out device atSign") == NULL) {
+    printf("Expected ERROR log about empty manager list, got:\n%s\n", log_buf);
+    return 1;
   }
 
   return 0;

--- a/packages/c/sshnpd/tests/test_sshnpd_params.c
+++ b/packages/c/sshnpd/tests/test_sshnpd_params.c
@@ -13,6 +13,7 @@ int permit_open_parse_test();
 int device_lower_test();
 int manager_list_test();
 int manager_list_trailing_comma_test();
+int manager_list_filter_device_atsign_test();
 
 int main() {
   int ret = 0;
@@ -47,6 +48,10 @@ int main() {
   }
   if (manager_list_trailing_comma_test()) {
     printf("manager_list_trailing_comma_test failed\n");
+    ret++;
+  }
+  if (manager_list_filter_device_atsign_test()) {
+    printf("manager_list_filter_device_atsign_test failed\n");
     ret++;
   }
 
@@ -448,6 +453,62 @@ int manager_list_trailing_comma_test() {
     for (size_t i = 0; i < cases[c].expected_len; i++) {
       if (strcmp(params->manager_list[i], cases[c].expected[i]) != 0) {
         printf("  input \"%s\": expected [%zu] \"%s\", got \"%s\"\n", cases[c].input, i, cases[c].expected[i],
+               params->manager_list[i]);
+        free(params);
+        return 1;
+      }
+    }
+
+    free(params);
+  }
+
+  return 0;
+}
+
+int manager_list_filter_device_atsign_test() {
+  struct {
+    const char *device_atsign;
+    const char *manager_input;
+    size_t expected_len;
+    const char *expected[2];
+  } cases[] = {
+      {"@device", "@alice,@device,@bob", 2, {"@alice", "@bob"}},
+      {"@device", "@device,@alice", 1, {"@alice", NULL}},
+      {"@device", "@alice,@device", 1, {"@alice", NULL}},
+      {"@device", "@Device,@alice", 1, {"@alice", NULL}},
+      {"@device", "@device", 0, {NULL, NULL}},
+  };
+
+  for (size_t c = 0; c < sizeof(cases) / sizeof(cases[0]); c++) {
+    sshnpd_params *params = malloc(sizeof(sshnpd_params));
+    if (params == NULL) {
+      return 1;
+    }
+
+    char *manager_str = strdup(cases[c].manager_input);
+    if (manager_str == NULL) {
+      free(params);
+      return 1;
+    }
+    const char *argv[] = {
+        "sshnpd", "-a", cases[c].device_atsign, "-m", manager_str, "-d", "my_device",
+    };
+
+    apply_default_values_to_sshnpd_params(params);
+    if (parse_sshnpd_params(params, 7, argv) != 0) {
+      free(params);
+      return 1;
+    }
+
+    if (params->manager_list_len != cases[c].expected_len) {
+      printf("  input \"%s\": expected len %zu, got %zu\n", cases[c].manager_input, cases[c].expected_len,
+             params->manager_list_len);
+      free(params);
+      return 1;
+    }
+    for (size_t i = 0; i < cases[c].expected_len; i++) {
+      if (strcmp(params->manager_list[i], cases[c].expected[i]) != 0) {
+        printf("  input \"%s\": expected [%zu] \"%s\", got \"%s\"\n", cases[c].manager_input, i, cases[c].expected[i],
                params->manager_list[i]);
         free(params);
         return 1;


### PR DESCRIPTION
One part of fixing #2866 

**- What I did**

Filter device Atsign from manager Atsign list.

**- How I did it**

`agy` prompt:

```txt
if the device atsign is included in a list of the manager atsigns after the
-m flag then the daemon fails to start. draft a change set that filters the
device atsign from the list and warns in the logs
```

**- How to verify it**

Params tests have been expanded.

**- Description for the changelog**

fix: C daemon filter device Atsign from manager Atsign list
