### PR TITLE
ci: add npe2e dockerfiles to depandabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
       - "/packages/dart/sshnoports/tools/"
       - "/tests/e2e_all/dockerfiles/"
       - "/tests/end2end_tests/image/"
+      - "/tests/npe2e/tools/dockerfiles/"
     schedule:
       interval: "daily"
     cooldown:

--- a/tests/npe2e/tools/dockerfiles/Dockerfile.c.branch
+++ b/tests/npe2e/tools/dockerfiles/Dockerfile.c.branch
@@ -24,7 +24,7 @@ RUN set -eux ; \
     cmake --build build ; \
     mv build/srv ${OUTPUT_DIR}/srv
 
-FROM atsigncompany/noports_e2e_all_base_runtime:latest@sha256:96af983d6e0fcd45e704709f70943cbdc9c2f2e249c6757c6b7000ec3d81c4f2 AS runtime
+FROM atsigncompany/noports_e2e_all_base_runtime:latest@sha256:1f83c03fa0267ab1d47875f9f83b10857ff57375046de97f2ad1369d39e49fc4 AS runtime
 
 ENV USER=atsign
 ENV HOMEDIR=/${USER}

--- a/tests/npe2e/tools/dockerfiles/Dockerfile.c.current
+++ b/tests/npe2e/tools/dockerfiles/Dockerfile.c.current
@@ -25,7 +25,7 @@ RUN set -eux ; \
     mv build/srv ${OUTPUT_DIR}/srv
 
 
-FROM atsigncompany/noports_e2e_all_base_runtime:latest@sha256:96af983d6e0fcd45e704709f70943cbdc9c2f2e249c6757c6b7000ec3d81c4f2 AS runtime
+FROM atsigncompany/noports_e2e_all_base_runtime:latest@sha256:1f83c03fa0267ab1d47875f9f83b10857ff57375046de97f2ad1369d39e49fc4 AS runtime
 
 ENV USER=atsign
 ENV HOMEDIR=/${USER}

--- a/tests/npe2e/tools/dockerfiles/Dockerfile.c.release
+++ b/tests/npe2e/tools/dockerfiles/Dockerfile.c.release
@@ -35,7 +35,7 @@ RUN set -eux ; \
     cmake --build build ; \
     mv build/srv ${OUTPUT_DIR}/srv ;
 
-FROM atsigncompany/noports_e2e_all_base_runtime:latest@sha256:96af983d6e0fcd45e704709f70943cbdc9c2f2e249c6757c6b7000ec3d81c4f2 AS runtime
+FROM atsigncompany/noports_e2e_all_base_runtime:latest@sha256:1f83c03fa0267ab1d47875f9f83b10857ff57375046de97f2ad1369d39e49fc4 AS runtime
 
 ENV USER=atsign
 ENV HOMEDIR=/${USER}

--- a/tests/npe2e/tools/dockerfiles/Dockerfile.dart.branch
+++ b/tests/npe2e/tools/dockerfiles/Dockerfile.dart.branch
@@ -26,7 +26,7 @@ RUN set -eux ; \
     dart compile exe ${PACKAGE_DIR}/bin/srvd.dart -o ${OUTPUT_DIR}/srvd ; \
     dart compile exe ${PACKAGE_DIR}/bin/npevents.dart -o ${OUTPUT_DIR}/npevents
 
-FROM atsigncompany/noports_e2e_all_base_runtime:latest@sha256:96af983d6e0fcd45e704709f70943cbdc9c2f2e249c6757c6b7000ec3d81c4f2 AS runtime
+FROM atsigncompany/noports_e2e_all_base_runtime:latest@sha256:1f83c03fa0267ab1d47875f9f83b10857ff57375046de97f2ad1369d39e49fc4 AS runtime
 
 ENV USER=atsign
 ENV HOMEDIR=/${USER}

--- a/tests/npe2e/tools/dockerfiles/Dockerfile.dart.current
+++ b/tests/npe2e/tools/dockerfiles/Dockerfile.dart.current
@@ -20,7 +20,7 @@ RUN set -eux ; \
     dart compile exe bin/srvd.dart -o ${OUTPUT_DIR}/srvd ; \
     dart compile exe bin/npevents.dart -o ${OUTPUT_DIR}/npevents
 
-FROM atsigncompany/noports_e2e_all_base_runtime:latest@sha256:96af983d6e0fcd45e704709f70943cbdc9c2f2e249c6757c6b7000ec3d81c4f2 AS runtime
+FROM atsigncompany/noports_e2e_all_base_runtime:latest@sha256:1f83c03fa0267ab1d47875f9f83b10857ff57375046de97f2ad1369d39e49fc4 AS runtime
 
 ENV USER=atsign
 ENV HOMEDIR=/${USER}

--- a/tests/npe2e/tools/dockerfiles/Dockerfile.dart.release
+++ b/tests/npe2e/tools/dockerfiles/Dockerfile.dart.release
@@ -29,7 +29,7 @@ RUN apt-get update && \
     cd sshnp && \
     mv -f at_activate install.sh np_admin npp npp_atserver npp_file npt srv srvd sshnp sshnpd npevents ${OUTPUT_DIR} || true
 
-FROM atsigncompany/noports_e2e_all_base_runtime:latest@sha256:96af983d6e0fcd45e704709f70943cbdc9c2f2e249c6757c6b7000ec3d81c4f2 AS runtime
+FROM atsigncompany/noports_e2e_all_base_runtime:latest@sha256:1f83c03fa0267ab1d47875f9f83b10857ff57375046de97f2ad1369d39e49fc4 AS runtime
 
 ENV USER=atsign
 ENV HOMEDIR=/${USER}


### PR DESCRIPTION
## What I did and why

- Last week, we found out that the new Dart versions no longer carry root certs, causing our base image to fall apart because it did not have root certs
- New images have been pushed which have the new `ca-certificates` package installed in the base image
- Adding the npe2e dockerfiles directory should keep those images up-to-date now as well
- Updated the hashes to `1f83c03fa0267ab1d47875f9f83b10857ff57375046de97f2ad1369d39e49fc4` which matches this [image on dockerhub](https://hub.docker.com/layers/atsigncompany/noports_e2e_all_base_runtime/sha256-1f83c03fa0267ab1d47875f9f83b10857ff57375046de97f2ad1369d39e49fc4.att/images/sha256-f9c1a9a089d4c513b1dfc29adfaf53902bd21fec53b76e1be94c93bb63218708)

**- Description for the changelog**
ci: add npe2e dockerfiles to depandabot.yml
