### PR TITLE
ci: build e2e C daemons with clang-19, drop apt-get from build stage

### DIFF
--- a/tests/e2e_all/dockerfiles/Dockerfile.c.branch
+++ b/tests/e2e_all/dockerfiles/Dockerfile.c.branch
@@ -8,19 +8,17 @@ ARG branch=trunk
 
 RUN set -eux ; \
     mkdir -p ${REPO_DIR} ${OUTPUT_DIR} ; \
-    apt-get update ; \
-    apt-get install -y git gcc ; \
     cd ${REPO_DIR} ; \
     git clone ${URL} . ; \
     git checkout ${branch} ; \
     cd ${REPO_DIR}/packages/c/sshnpd ; \
-    cmake -S . -B build -DCMAKE_C_COMPILER=gcc -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
+    cmake -S . -B build -DCMAKE_C_COMPILER=clang-19 -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
     cmake --build build ; \
     mv ./build/at_activate ${OUTPUT_DIR}/at_activate ; \
     mv ./build/sshnpd ${OUTPUT_DIR}/sshnpd ; \
     mv ./build/libsshnpd-lib.a ${OUTPUT_DIR}/libsshnpd-lib.a ; \
     cd ${REPO_DIR}/packages/c/srv ; \
-    cmake -S . -B build -DCMAKE_C_COMPILER=gcc -DATAUTH_BUILD_EXECUTABLES=OFF -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
+    cmake -S . -B build -DCMAKE_C_COMPILER=clang-19 -DATAUTH_BUILD_EXECUTABLES=OFF -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
     cmake --build build ; \
     mv build/srv ${OUTPUT_DIR}/srv
 

--- a/tests/e2e_all/dockerfiles/Dockerfile.c.current
+++ b/tests/e2e_all/dockerfiles/Dockerfile.c.current
@@ -9,18 +9,16 @@ COPY . ${REPO_DIR}
 
 RUN set -eux ; \
     mkdir -p ${REPO_DIR} ${OUTPUT_DIR} ; \
-    apt-get update ; \
-    apt-get install -y gcc ; \
     cd ${REPO_DIR}/packages/c/sshnpd ; \
     rm -rf build ; \
-    cmake -S . -B build -DCMAKE_C_COMPILER=gcc -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
+    cmake -S . -B build -DCMAKE_C_COMPILER=clang-19 -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
     cmake --build build ; \
     mv ./build/at_activate ${OUTPUT_DIR}/at_activate ; \
     mv ./build/sshnpd ${OUTPUT_DIR}/sshnpd ; \
     mv ./build/libsshnpd-lib.a ${OUTPUT_DIR}/libsshnpd-lib.a ; \
     cd ${REPO_DIR}/packages/c/srv ; \
     rm -rf build ; \
-    cmake -S . -B build -DCMAKE_C_COMPILER=gcc -DATAUTH_BUILD_EXECUTABLES=OFF -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
+    cmake -S . -B build -DCMAKE_C_COMPILER=clang-19 -DATAUTH_BUILD_EXECUTABLES=OFF -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
     cmake --build build ; \
     mv build/srv ${OUTPUT_DIR}/srv
 

--- a/tests/e2e_all/dockerfiles/Dockerfile.c.release
+++ b/tests/e2e_all/dockerfiles/Dockerfile.c.release
@@ -8,8 +8,6 @@ ENV OUTPUT_DIR=/output
 ARG release
 
 RUN set -eux ; \
-    apt-get update ; \
-    apt-get install -y wget dpkg curl gcc ; \
     mkdir -p ${BUILD_DIR} ${OUTPUT_DIR} ; \
     cd ${BUILD_DIR} ; \
     case "$(dpkg --print-architecture)" in \
@@ -25,13 +23,13 @@ RUN set -eux ; \
     tar -xvf ${TARGZNAME} ; \
     cd csshnpd-c${VERSION} ; \
     cd sshnpd ; \
-    cmake -S . -B build -DCMAKE_C_COMPILER=gcc -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
+    cmake -S . -B build -DCMAKE_C_COMPILER=clang-19 -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
     cmake --build build ; \
     mv ./build/at_activate ${OUTPUT_DIR}/at_activate ; \
     mv ./build/sshnpd ${OUTPUT_DIR}/sshnpd ; \
     mv ./build/libsshnpd-lib.a ${OUTPUT_DIR}/libsshnpd-lib.a ; \
     cd ../srv ; \
-    cmake -S . -B build -DCMAKE_C_COMPILER=gcc -DATAUTH_BUILD_EXECUTABLES=OFF -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
+    cmake -S . -B build -DCMAKE_C_COMPILER=clang-19 -DATAUTH_BUILD_EXECUTABLES=OFF -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
     cmake --build build ; \
     mv build/srv ${OUTPUT_DIR}/srv ;
 

--- a/tests/npe2e/tools/dockerfiles/Dockerfile.c.branch
+++ b/tests/npe2e/tools/dockerfiles/Dockerfile.c.branch
@@ -8,19 +8,17 @@ ARG branch=trunk
 
 RUN set -eux ; \
     mkdir -p ${REPO_DIR} ${OUTPUT_DIR} ; \
-    apt-get update ; \
-    apt-get install -y git gcc ; \
     cd ${REPO_DIR} ; \
     git clone ${URL} . ; \
     git checkout ${branch} ; \
     cd ${REPO_DIR}/packages/c/sshnpd ; \
-    cmake -S . -B build -DCMAKE_C_COMPILER=gcc -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
+    cmake -S . -B build -DCMAKE_C_COMPILER=clang-19 -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
     cmake --build build ; \
     mv ./build/at_activate ${OUTPUT_DIR}/at_activate ; \
     mv ./build/sshnpd ${OUTPUT_DIR}/sshnpd ; \
     mv ./build/libsshnpd-lib.a ${OUTPUT_DIR}/libsshnpd-lib.a ; \
     cd ${REPO_DIR}/packages/c/srv ; \
-    cmake -S . -B build -DCMAKE_C_COMPILER=gcc -DATAUTH_BUILD_EXECUTABLES=OFF -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
+    cmake -S . -B build -DCMAKE_C_COMPILER=clang-19 -DATAUTH_BUILD_EXECUTABLES=OFF -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
     cmake --build build ; \
     mv build/srv ${OUTPUT_DIR}/srv
 

--- a/tests/npe2e/tools/dockerfiles/Dockerfile.c.current
+++ b/tests/npe2e/tools/dockerfiles/Dockerfile.c.current
@@ -9,18 +9,16 @@ COPY . ${REPO_DIR}
 
 RUN set -eux ; \
     mkdir -p ${REPO_DIR} ${OUTPUT_DIR} ; \
-    apt-get update ; \
-    apt-get install -y gcc ; \
     cd ${REPO_DIR}/packages/c/sshnpd ; \
     rm -rf build ; \
-    cmake -S . -B build -DCMAKE_C_COMPILER=gcc -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
+    cmake -S . -B build -DCMAKE_C_COMPILER=clang-19 -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
     cmake --build build ; \
     mv ./build/at_activate ${OUTPUT_DIR}/at_activate ; \
     mv ./build/sshnpd ${OUTPUT_DIR}/sshnpd ; \
     mv ./build/libsshnpd-lib.a ${OUTPUT_DIR}/libsshnpd-lib.a ; \
     cd ${REPO_DIR}/packages/c/srv ; \
     rm -rf build ; \
-    cmake -S . -B build -DCMAKE_C_COMPILER=gcc -DATAUTH_BUILD_EXECUTABLES=OFF -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
+    cmake -S . -B build -DCMAKE_C_COMPILER=clang-19 -DATAUTH_BUILD_EXECUTABLES=OFF -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
     cmake --build build ; \
     mv build/srv ${OUTPUT_DIR}/srv
 

--- a/tests/npe2e/tools/dockerfiles/Dockerfile.c.release
+++ b/tests/npe2e/tools/dockerfiles/Dockerfile.c.release
@@ -8,8 +8,6 @@ ENV OUTPUT_DIR=/output
 ARG release
 
 RUN set -eux ; \
-    apt-get update ; \
-    apt-get install -y wget dpkg curl gcc ; \
     mkdir -p ${BUILD_DIR} ${OUTPUT_DIR} ; \
     cd ${BUILD_DIR} ; \
     case "$(dpkg --print-architecture)" in \
@@ -25,13 +23,13 @@ RUN set -eux ; \
     tar -xvf ${TARGZNAME} ; \
     cd csshnpd-c${VERSION} ; \
     cd sshnpd ; \
-    cmake -S . -B build -DCMAKE_C_COMPILER=gcc -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
+    cmake -S . -B build -DCMAKE_C_COMPILER=clang-19 -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
     cmake --build build ; \
     mv ./build/at_activate ${OUTPUT_DIR}/at_activate ; \
     mv ./build/sshnpd ${OUTPUT_DIR}/sshnpd ; \
     mv ./build/libsshnpd-lib.a ${OUTPUT_DIR}/libsshnpd-lib.a ; \
     cd ../srv ; \
-    cmake -S . -B build -DCMAKE_C_COMPILER=gcc -DATAUTH_BUILD_EXECUTABLES=OFF -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
+    cmake -S . -B build -DCMAKE_C_COMPILER=clang-19 -DATAUTH_BUILD_EXECUTABLES=OFF -DBUILD_SHARED_LIBS=off -DCMAKE_C_FLAGS="-Wno-error -pthread" ; \
     cmake --build build ; \
     mv build/srv ${OUTPUT_DIR}/srv ;
 


### PR DESCRIPTION
## What I did and why

Trunk's `e2e_all` and `npe2e` jobs started failing on 2026-09-08 with what looks like a missing Docker Hub image (`pull access denied for atsigncompany/noports_e2e_all_c`). That image is built locally by the e2e scripts — the pull error is just Docker's fallback after the local build failed. The real failure (hidden by `docker build --quiet`) is in the build stage:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease
   is expired (invalid since 1d ...). Updates for this repository will not be applied.
```

`atsigncompany/cbuildimage` is deliberately based on Debian 11 bullseye (glibc 2.31 compatibility floor for release binaries). Bullseye LTS ended 2026-08-31 and the last bullseye-security Release file has now expired, so the `apt-get update ; apt-get install -y gcc` in the six `Dockerfile.c.*` files exits 100 — permanently. That matches the timeline: trunk e2e_all was green Sep 7 and broke Sep 8 with no relevant code change.

Fix: stop using apt entirely in these Dockerfiles.
- cbuildimage already ships `clang-19`, `git`, `wget` and `dpkg` — everything the apt lines were installing (`curl` was installed but never used).
- Build with `-DCMAKE_C_COMPILER=clang-19` instead of gcc, which is what the release pipeline (`packages/c/sshnpd/tools/Dockerfile.package`) already uses — so e2e now tests the compiler we actually ship with.

Verified locally: `docker build -f tests/e2e_all/dockerfiles/Dockerfile.c.current --target buildimage .` succeeds and produces working `sshnpd`, `srv`, `at_activate` binaries.

Companion to #2907, which fixes the separate stale-base_runtime/ca-certificates issue in the npe2e runtime stage — both are needed to get the e2e jobs green (different hunks, no conflict).

Follow-up worth considering: drop `--quiet` from the docker build in `tests/e2e_all/scripts/common/common_functions.include.sh` so the next infra failure isn't invisible.

**- Description for the changelog**
ci: build e2e C daemons with clang-19, drop apt-get from EOL bullseye build stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)