### PR TITLE
fix(npt_flutter): tooltip fixes and menu bar favouriting

### DIFF
--- a/packages/dart/npt_flutter/lib/features/profile/widgets/profile_device_name.dart
+++ b/packages/dart/npt_flutter/lib/features/profile/widgets/profile_device_name.dart
@@ -22,7 +22,7 @@ class ProfileDeviceName extends StatelessWidget {
         if (tuple == null) return gap0;
         var (deviceName, sshnpdAtsign) = tuple;
         return Tooltip(
-          verticalOffset: Sizes.p10n,
+          preferBelow: false,
           message: '$deviceName$sshnpdAtsign',
           child: Text(
             '$deviceName$sshnpdAtsign',

--- a/packages/dart/npt_flutter/lib/features/profile/widgets/profile_display_name.dart
+++ b/packages/dart/npt_flutter/lib/features/profile/widgets/profile_display_name.dart
@@ -21,7 +21,7 @@ class ProfileDisplayName extends StatelessWidget {
       builder: (BuildContext context, String? displayName) {
         if (displayName == null) return gap0;
         return Tooltip(
-          verticalOffset: Sizes.p10n,
+          preferBelow: false,
           message: displayName,
           child: Text(
             displayName,

--- a/packages/dart/npt_flutter/lib/features/profile/widgets/profile_service_view.dart
+++ b/packages/dart/npt_flutter/lib/features/profile/widgets/profile_service_view.dart
@@ -23,7 +23,7 @@ class ProfileServiceView extends StatelessWidget {
         if (triple == null) return gap0;
         var (localPort, remoteHost, remotePort) = triple;
         return Tooltip(
-          verticalOffset: Sizes.p10n,
+          preferBelow: false,
           message: '$localPort:$remoteHost:$remotePort',
           child: Text(
             '$localPort:$remoteHost:$remotePort',

--- a/packages/dart/npt_flutter/lib/features/profile/widgets/profile_status_indicator.dart
+++ b/packages/dart/npt_flutter/lib/features/profile/widgets/profile_status_indicator.dart
@@ -142,7 +142,7 @@ class StatusMessage extends StatelessWidget {
             : PhosphorIcon(icon, color: color, size: Sizes.p20);
 
     return Tooltip(
-      verticalOffset: Sizes.p10n,
+      preferBelow: false,
       message: tooltip,
       child: Row(
         mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
closes https://github.com/atsign-foundation/noports/issues/2912
closes https://github.com/atsign-foundation/noports/issues/2913

## What I did

- `preferBelow: true` for the tooltip hovers
- favouriting a connection now updates the menu bar

## How to verify it

### Re ticket 1

Tool tip now on top

<img width="255" height="94" alt="image" src="https://github.com/user-attachments/assets/dbcc8174-f367-4cb7-a489-db7b28fffd5c" />

### re ticket 2: 

I favourited 3 of my connections here

<img width="1030" height="416" alt="image" src="https://github.com/user-attachments/assets/d1789ad4-98ea-4bbb-ad87-27e6086450d6" />

<img width="173" height="167" alt="image" src="https://github.com/user-attachments/assets/3a78457f-9f3f-4a38-aec4-47dcee429185" />

**- Description for the changelog**
fix: tooltip fixes and menu bar favouriting