### PR TITLE
fix: forward backpressure through relay auth stream wrappers

### DIFF
--- a/apps/admin/admin_api/pubspec.lock
+++ b/apps/admin/admin_api/pubspec.lock
@@ -616,7 +616,7 @@ packages:
       path: "../../../packages/dart/noports_core"
       relative: true
     source: path
-    version: "6.14.0"
+    version: "6.14.1"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/noports_core/CHANGELOG.md
+++ b/packages/dart/noports_core/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 6.14.1
+
+- fix: the relay auth stream wrappers (the srv-side relay authenticator and
+  both srvd-side relay auth verifiers) now forward pause/resume from their
+  `StreamController` to the socket subscription, so backpressure applied by
+  the consumer of the wrapped stream reaches the socket and closes the TCP
+  window instead of buffering without bound in the wrapper
+
 # 6.14.0
 
 - fix: share event logging config once as cached key instead of on every

--- a/packages/dart/noports_core/lib/src/srv/relay_authenticators.dart
+++ b/packages/dart/noports_core/lib/src/srv/relay_authenticators.dart
@@ -136,12 +136,19 @@ class RelayAuthenticatorESCR implements RelayAuthenticator {
     Completer<(bool, Stream<Uint8List>?)> completer = Completer();
     bool receivedChallenge = false;
     bool authenticated = false;
-    StreamController<Uint8List> sc = StreamController();
+    // Forward pause/resume to the socket subscription: when the consumer of
+    // sc.stream applies backpressure it must reach the socket and close the
+    // TCP window, rather than buffering without bound in this controller.
+    late final StreamSubscription<Uint8List> subscription;
+    StreamController<Uint8List> sc = StreamController(
+      onPause: () => subscription.pause(),
+      onResume: () => subscription.resume(),
+    );
     List<int> buffer = [];
 
     Mutex listenMutex = Mutex();
 
-    socket.listen(
+    subscription = socket.listen(
       (Uint8List data) async {
         await listenMutex.acquire();
         try {

--- a/packages/dart/noports_core/lib/src/srvd/relay_auth_verifiers.dart
+++ b/packages/dart/noports_core/lib/src/srvd/relay_auth_verifiers.dart
@@ -324,7 +324,14 @@ class RelayAuthVerifierESCR implements RelayAuthVerifier {
   Future<(bool, Stream<Uint8List>?)> verifySocketAuth(Socket socket) async {
     Completer<(bool, Stream<Uint8List>?)> completer = Completer();
     bool authenticated = false;
-    StreamController<Uint8List> sc = StreamController();
+    // Forward pause/resume to the socket subscription: when the consumer of
+    // sc.stream applies backpressure it must reach the socket and close the
+    // TCP window, rather than buffering without bound in this controller.
+    late final StreamSubscription<Uint8List> subscription;
+    StreamController<Uint8List> sc = StreamController(
+      onPause: () => subscription.pause(),
+      onResume: () => subscription.resume(),
+    );
     logger.info('starting listen');
     List<int> buffer = [];
 
@@ -334,7 +341,7 @@ class RelayAuthVerifierESCR implements RelayAuthVerifier {
 
     Mutex listenMutex = Mutex();
 
-    socket.listen(
+    subscription = socket.listen(
       (Uint8List data) async {
         await listenMutex.acquire();
         try {
@@ -532,10 +539,17 @@ class RelayAuthVerifierLegacy implements RelayAuthVerifier {
   Future<(bool, Stream<Uint8List>?)> verifySocketAuth(Socket socket) async {
     Completer<(bool, Stream<Uint8List>?)> completer = Completer();
     bool authenticated = false;
-    StreamController<Uint8List> sc = StreamController();
+    // Forward pause/resume to the socket subscription: when the consumer of
+    // sc.stream applies backpressure it must reach the socket and close the
+    // TCP window, rather than buffering without bound in this controller.
+    late final StreamSubscription<Uint8List> subscription;
+    StreamController<Uint8List> sc = StreamController(
+      onPause: () => subscription.pause(),
+      onResume: () => subscription.resume(),
+    );
     logger.info('SignatureAuthVerifier for $tag: starting listen');
     List<int> buffer = [];
-    socket.listen(
+    subscription = socket.listen(
       (Uint8List data) {
         if (authenticated) {
           if (!sc.isClosed) {

--- a/packages/dart/noports_core/lib/src/version.dart
+++ b/packages/dart/noports_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '6.14.0';
+const packageVersion = '6.14.1';

--- a/packages/dart/noports_core/pubspec.yaml
+++ b/packages/dart/noports_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: noports_core
 description: Core library code for sshnoports
 homepage: https://docs.atsign.com/
 
-version: 6.14.0
+version: 6.14.1
 
 environment:
   sdk: ^3.8.0

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -712,10 +712,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.3"
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
@@ -808,10 +808,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.20"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -832,10 +832,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -906,7 +906,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.13.0"
+    version: "6.14.1"
   objective_c:
     dependency: transitive
     description:
@@ -1349,26 +1349,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.1"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.12"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.18"
+    version: "0.6.16"
   tray_manager:
     dependency: "direct main"
     description:
@@ -1493,10 +1493,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.2.0"
   version:
     dependency: transitive
     description:

--- a/packages/dart/npt_flutter/pubspec.lock
+++ b/packages/dart/npt_flutter/pubspec.lock
@@ -712,10 +712,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   io:
     dependency: transitive
     description:
@@ -808,10 +808,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -832,10 +832,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -906,7 +906,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.14.1"
+    version: "6.13.0"
   objective_c:
     dependency: transitive
     description:
@@ -1349,26 +1349,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.18"
   tray_manager:
     dependency: "direct main"
     description:
@@ -1493,10 +1493,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   version:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/CHANGELOG.md
+++ b/packages/dart/sshnoports/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- pyml disable md034-->
 
+## v5.16.1
+
+* fix: relay auth stream wrappers now propagate backpressure to the socket,
+  so a fast writer through an authenticated relay can no longer inflate
+  srv/srvd memory without bound (~1 GB per 10 s observed under iperf3)
+
 ## v5.16.0
 
 * fix: share event logging config once as cached key instead of on every

--- a/packages/dart/sshnoports/lib/src/version.dart
+++ b/packages/dart/sshnoports/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '5.16.0';
+const packageVersion = '5.16.1';

--- a/packages/dart/sshnoports/pubspec.lock
+++ b/packages/dart/sshnoports/pubspec.lock
@@ -607,7 +607,7 @@ packages:
       path: "../noports_core"
       relative: true
     source: path
-    version: "6.14.0"
+    version: "6.14.1"
   openssh_ed25519:
     dependency: transitive
     description:

--- a/packages/dart/sshnoports/pubspec.yaml
+++ b/packages/dart/sshnoports/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sshnoports
 publish_to: none
 
-version: 5.16.0
+version: 5.16.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Problem

The relay authenticator (`srv/relay_authenticators.dart`) and both relay auth verifiers (`srvd/relay_auth_verifiers.dart`) wrap the raw socket: they run their own `socket.listen(...)` and re-emit post-auth data into a `StreamController`, handing that controller's stream onward. The controllers were created without `onPause`/`onResume` wiring, so when the downstream consumer pauses its subscription, the raw socket keeps being read at full speed and the backlog accumulates in the controller without bound — the TCP window never closes and the far-end writer is never throttled.

This silently defeats any backpressure applied by the consumer. Observed with iperf3 through an authenticated relay (with socket_connector's backpressure fix, atsign-foundation/socket_connector#37, already in place): sender held a steady 2.01 Gbit/s while the receiver measured 1.12 Gbit/s — ~1 GB accumulated in srvd's heap in 10 seconds, inside the auth verifier's controller, exactly one layer above where socket_connector's pause stopped.

## Fix

Forward `onPause`/`onResume` from each wrapper's controller to the socket subscription, in all three places (srv-side authenticator, and both srvd-side verifiers: challenge/response and signature). Backpressure now propagates through the auth layer to the socket, and TCP throttles the sender.

With this fix plus socket_connector#37 on every hop, the same run converges: sender 1.88 Gbit/s vs receiver 1.84 Gbit/s (1.36/1.35 in reverse), RSS flat on srv, srvd and sshnpd throughout.

## Notes

- Independent of #2904; this bug predates it and this PR can land on its own. It only becomes *visible* at high throughput, which is why nobody hit it at the old cipher's rates.
- Analyzer output unchanged from trunk; all 380 noports_core tests pass.
- One further instance of the same pattern was found and deliberately left alone: `WrappedSSHSocket` (`srv_impl.dart:347`) pipes its encrypter with `encrypted.listen(underlyingSink.add)` — sshnp's in-process SSH path. A naive `addStream` fix would break its `flush()` (StateError while a sink is bound), so it deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
