### PR TITLE
fix: install root CA certificates in published runtime container images

### DIFF
--- a/packages/dart/sshnoports/tools/Dockerfile
+++ b/packages/dart/sshnoports/tools/Dockerfile
@@ -28,7 +28,7 @@ COPY --from=buildimage /app/packages/dart/sshnoports/bundles/core/docker/.startu
 RUN \
   set -eux ; \
   apt-get update ; \
-  apt-get install -y adduser openssh-server sudo iputils-ping iproute2 ncat telnet net-tools nmap iperf3 traceroute vim ; \
+  apt-get install -y adduser ca-certificates openssh-server sudo iputils-ping iproute2 ncat telnet net-tools nmap iperf3 traceroute vim ; \
   addgroup --gid ${GROUP_ID} ${USER} ; \
   useradd --system --uid ${USER_ID} --gid ${GROUP_ID} --shell /bin/bash --home ${HOMEDIR} ${USER} ; \
   mkdir -p ${HOMEDIR}/.atsign/keys ; \

--- a/packages/dart/sshnoports/tools/Dockerfile.activate
+++ b/packages/dart/sshnoports/tools/Dockerfile.activate
@@ -28,7 +28,7 @@ WORKDIR ${HOMEDIR}
 RUN \
   set -eux ; \
   apt-get update ; \
-  apt-get install -y adduser sudo ; \
+  apt-get install -y adduser ca-certificates sudo ; \
   addgroup --gid ${GROUP_ID} ${USER} ; \
   useradd --system --uid ${USER_ID} --gid ${GROUP_ID} --shell /bin/bash --home ${HOMEDIR} ${USER} ; \
   mkdir -p ${HOMEDIR}/.atsign/keys ; \

--- a/packages/dart/sshnoports/tools/Dockerfile.npp
+++ b/packages/dart/sshnoports/tools/Dockerfile.npp
@@ -28,7 +28,7 @@ WORKDIR ${HOMEDIR}
 RUN \
   set -eux ; \
   apt-get update ; \
-  apt-get install -y adduser sudo ; \
+  apt-get install -y adduser ca-certificates sudo ; \
   addgroup --gid ${GROUP_ID} ${USER} ; \
   useradd --system --uid ${USER_ID} --gid ${GROUP_ID} --shell /bin/bash --home ${HOMEDIR} ${USER} ; \
   mkdir -p ${HOMEDIR}/.atsign/keys ; \

--- a/packages/dart/sshnoports/tools/Dockerfile.npt
+++ b/packages/dart/sshnoports/tools/Dockerfile.npt
@@ -28,7 +28,7 @@ WORKDIR ${HOMEDIR}
 RUN \
   set -eux ; \
   apt-get update ; \
-  apt-get install -y adduser sudo ; \
+  apt-get install -y adduser ca-certificates sudo ; \
   addgroup --gid ${GROUP_ID} ${USER} ; \
   useradd --system --uid ${USER_ID} --gid ${GROUP_ID} --shell /bin/bash --home ${HOMEDIR} ${USER} ; \
   mkdir -p ${HOMEDIR}/.atsign/keys ; \

--- a/packages/dart/sshnoports/tools/Dockerfile.srvd
+++ b/packages/dart/sshnoports/tools/Dockerfile.srvd
@@ -29,7 +29,7 @@ WORKDIR ${HOMEDIR}
 RUN \
   set -eux ; \
   apt-get update ; \
-  apt-get install -y adduser sudo ; \
+  apt-get install -y adduser ca-certificates sudo ; \
   addgroup --gid ${GROUP_ID} ${USER} ; \
   useradd --system --uid ${USER_ID} --gid ${GROUP_ID} --shell /bin/bash --home ${HOMEDIR} ${USER} ; \
   mkdir -p ${HOMEDIR}/.atsign/keys ; \

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnp
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnp
@@ -28,7 +28,7 @@ WORKDIR ${HOMEDIR}
 RUN \
   set -eux ; \
   apt-get update ; \
-  apt-get install -y adduser sudo ; \
+  apt-get install -y adduser ca-certificates sudo ; \
   addgroup --gid ${GROUP_ID} ${USER} ; \
   useradd --system --uid ${USER_ID} --gid ${GROUP_ID} --shell /bin/bash --home ${HOMEDIR} ${USER} ; \
   mkdir -p ${HOMEDIR}/.atsign/keys ; \

--- a/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
+++ b/packages/dart/sshnoports/tools/Dockerfile.sshnpd-slim
@@ -33,7 +33,7 @@ RUN \
   dart compile exe bin/sshnpd.dart -o ${BINARYDIR}/sshnpd ; \
   dart compile exe bin/srv.dart -o ${BINARYDIR}/srv ; \
   # create atsign account
-  apt-get update && apt-get install -y adduser autoconf curl gcc make ; \
+  apt-get update && apt-get install -y adduser autoconf ca-certificates curl gcc make ; \
   addgroup --gid $GROUP_ID atsign ; \
   useradd --system --uid $USER_ID --gid $GROUP_ID --shell /bin/bash \
   --home $HOMEDIR atsign ; \
@@ -56,6 +56,9 @@ COPY --from=buildimage /runtime/ /
 COPY --from=buildimage /etc/passwd /etc/passwd
 COPY --from=buildimage /etc/group /etc/group
 COPY --from=buildimage /etc/cacert /etc/cacert
+# Dart images no longer carry root certs in /runtime/, so copy them explicitly
+COPY --from=buildimage /etc/ssl/certs /etc/ssl/certs
+COPY --from=buildimage /usr/share/ca-certificates /usr/share/ca-certificates
 WORKDIR /usr/local/at
 COPY --from=buildimage  /usr/local/at/sshnpd /usr/local/at/
 COPY --from=buildimage  /usr/local/at/srv /usr/local/at/

--- a/tests/end2end_tests/image/Dockerfile
+++ b/tests/end2end_tests/image/Dockerfile
@@ -10,7 +10,7 @@ CMD sudo service ssh start
 
 RUN set -eux ; \
   apt-get update ; \
-  apt-get install -y openssh-server sudo vim nano iproute2 nmap tmux curl cron ; \
+  apt-get install -y ca-certificates openssh-server sudo vim nano iproute2 nmap tmux curl cron ; \
   groupadd --gid ${GROUP_ID} ${USER} ; \
   useradd --system --shell /bin/bash --home ${HOMEDIR} --uid ${USER_ID} --gid ${GROUP_ID} ${USER} ; \
   usermod -aG sudo ${USER} ; \

--- a/tests/npe2e/tools/dockerfiles/Dockerfile.base.runtime
+++ b/tests/npe2e/tools/dockerfiles/Dockerfile.base.runtime
@@ -8,7 +8,7 @@ ENV GROUP_ID=1024
 
 RUN set -eux ; \
     apt-get update ; \
-    apt-get install -y openssh-server sudo; \
+    apt-get install -y ca-certificates openssh-server sudo; \
     groupadd --gid ${GROUP_ID} ${USER} ; \
     useradd --system --shell /bin/bash --home ${HOMEDIR} --uid ${USER_ID} --gid ${GROUP_ID} ${USER} ; \
     usermod -aG sudo ${USER} ; \


### PR DESCRIPTION
## What I did and why

- Follow-up to #2907: new Dart versions no longer carry root certs, which is why the `noports_e2e_all_base_runtime` image was rebuilt with the `ca-certificates` package (and the e2e_all base runtime Dockerfile got it in 3e3a4332c).
- The production images built by `dockerhub_sshnpd.yml` (sshnpd, srvd, sshnp, npt, npp, at_activate, sshnpd-slim) have the same exposure: their `debian:stable-slim` runtime stages ship **zero** root certs (verified: `/etc/ssl/certs` is empty and `ca-certificates` is not installed in the pinned base), so the Dart binaries have nothing to validate atServer TLS connections against.
- This PR applies the same fix to those Dockerfiles:
  - install `ca-certificates` in every debian-slim runtime stage
  - for the scratch-based `Dockerfile.sshnpd-slim`, install `ca-certificates` in the build stage and explicitly `COPY /etc/ssl/certs` + `/usr/share/ca-certificates` into the final image — the currently pinned `dart:3.13.3` still provides certs via `/runtime/`, but newer Dart images drop them, so this protects the next dependabot dart bump
  - sync `tests/npe2e/tools/dockerfiles/Dockerfile.base.runtime` with the already-pushed base image (rebuilt with `ca-certificates` in #2907) so the file in git matches the published image
- Verified locally: built `Dockerfile.srvd` from this branch; the runtime image now has 301 certs in `/etc/ssl/certs` including `ca-certificates.crt`, and `srvd --help` runs.

**- Description for the changelog**
fix: install root CA certificates in published runtime container images

🤖 Generated with [Claude Code](https://claude.com/claude-code)